### PR TITLE
feat: webhook endpoint to trigger agent from HTTP

### DIFF
--- a/backend/app/integrations/webhooks/router.py
+++ b/backend/app/integrations/webhooks/router.py
@@ -1,0 +1,88 @@
+import hmac
+import logging
+from uuid import uuid4
+
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException
+from langchain.messages import HumanMessage
+from pydantic import BaseModel, Field
+
+from app.agents.runtime import AgentRuntime, build_agent_deps
+from app.database import AsyncSessionLocal
+from app.mcp.client.exceptions import OAuthAuthorizationRequired
+from app.settings import app_settings
+from app.threads.models import ThreadDB
+from app.users.models import UserDB
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+
+class WebhookInvokeRequest(BaseModel):
+    agent_id: str
+    message: str = Field(max_length=10_000)
+    model_id: str | None = None
+
+
+async def _run_agent(thread: ThreadDB, message: str) -> None:
+    """Drain the agent stream in background, discarding output."""
+    async with AsyncSessionLocal() as db:
+        deps = build_agent_deps(thread, db)
+        try:
+            agent_runtime = await AgentRuntime.create(thread=thread, db=db, deps=deps)
+            # Use the slack adapter (yields plain Python dicts) instead of ai_sdk
+            # (yields SSE strings for browsers). We only need to drain the stream to
+            # trigger agent execution and catch errors — no output is forwarded.
+            async for ev in agent_runtime.stream(
+                messages=[HumanMessage(content=message)],
+                stream_adapter="slack",
+            ):
+                if ev.get("type") == "error":
+                    logger.error("Webhook agent error: %s", ev.get("content"))
+        except OAuthAuthorizationRequired as exc:
+            logger.error(
+                "Webhook: OAuth re-authorization required for thread %s — %s",
+                thread.id,
+                exc.url,
+            )
+        except Exception:
+            logger.exception("Webhook: unexpected error for thread %s", thread.id)
+
+
+@router.post("/invoke")
+async def webhook_invoke(
+    payload: WebhookInvokeRequest,
+    background_tasks: BackgroundTasks,
+    x_webhook_secret: str | None = Header(default=None),
+) -> dict:
+    if not app_settings.webhook_secret or not app_settings.webhook_user_id:
+        raise HTTPException(status_code=503, detail="Webhooks not configured")
+
+    if not x_webhook_secret or not hmac.compare_digest(x_webhook_secret, app_settings.webhook_secret):
+        raise HTTPException(status_code=401, detail="Invalid webhook secret")
+
+    async with AsyncSessionLocal() as db:
+        user = await db.get(UserDB, app_settings.webhook_user_id)
+        if not user:
+            raise HTTPException(status_code=503, detail="Webhook user not found")
+
+        from app.agents.models import AgentDB
+        agent = await db.get(AgentDB, payload.agent_id)
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+
+        thread = ThreadDB(
+            id=str(uuid4()),
+            agent_id=payload.agent_id,
+            user_id=app_settings.webhook_user_id,
+            model_id=payload.model_id or agent.model_id,
+            first_message_content=payload.message,
+        )
+        db.add(thread)
+        await db.commit()
+        await db.refresh(thread)
+        thread_id = thread.id
+
+    background_tasks.add_task(_run_agent, thread, payload.message)
+
+    return {"thread_id": thread_id, "agent_id": payload.agent_id}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.agents.router import router as agents_router
 from app.auth.router import router as auth_router
 from app.auth.settings import auth_settings
 from app.integrations.slack.router import router as slack_router
+from app.integrations.webhooks.router import router as webhooks_router
 from app.invites.router import router as invites_router
 from app.mcp.apps.router import router as mcp_apps_router
 from app.mcp.client.exceptions import OAuthAuthorizationRequired
@@ -109,5 +110,6 @@ app.include_router(users_router)
 app.include_router(invites_router)
 app.include_router(model_providers_router)
 app.include_router(slack_router)
+app.include_router(webhooks_router)
 
 app.mount("/", auxilia_mcp.streamable_http_app())

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -15,6 +15,8 @@ class AppSettings(BaseSettings):
     redis_db: int = 0
     backend_url: str = "http://localhost:8000"
     log_level: str = "INFO"
+    webhook_secret: str | None = None
+    webhook_user_id: str | None = None
 
     model_config: ConfigDict = ConfigDict(
         env_file=ROOT_ENV,


### PR DESCRIPTION
## Summary

- Add `POST /webhooks/invoke` — unauthenticated endpoint secured via `X-Webhook-Secret` header that creates a thread and runs an agent in background
- Add `WEBHOOK_SECRET` and `WEBHOOK_USER_ID` env vars in settings (webhooks are disabled if not set)
- User identity is fixed server-side via `WEBHOOK_USER_ID` — callers cannot impersonate other users

## Security

- Secret comparison uses `hmac.compare_digest` to prevent timing attacks
- `user_id` is not caller-controlled (fixed via env var)
- `message` capped at 10 000 characters
- Endpoint returns `503` if env vars are not configured, preventing silent misuse

## Test

Add to `.env`:

```
WEBHOOK_SECRET=your_secret_here
WEBHOOK_USER_ID=uuid-of-the-user
```

Invoke the endpoint:

```bash
curl -X POST http://localhost:8000/webhooks/invoke \
  -H "Content-Type: application/json" \
  -H "X-Webhook-Secret: $WEBHOOK_SECRET" \
  -d '{"agent_id": "<uuid>", "message": "Summarize my last emails"}'
```

Poll the result once the agent has finished:

```bash
curl http://localhost:8000/threads/<thread_id>
```
