### PR TITLE
Fix agent PATCH dropping MCP servers from response

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,4 @@
+engines:
+  bandit:
+    exclude_paths:
+      - "backend/tests/**"

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -182,12 +182,19 @@ class AgentService:
             for agent in agents_map.values()
         ]
 
-    async def update_agent(self, agent_id: UUID, data: AgentUpdate) -> AgentDB:
+    async def update_agent(
+        self,
+        agent_id: UUID,
+        data: AgentUpdate,
+        user_id: UUID | None = None,
+        user_role: WorkspaceRole | None = None,
+    ) -> AgentRead:
         agent = await self.repository.get(agent_id)
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
         update_data = data.model_dump(exclude_unset=True)
-        return await self.repository.update(agent, update_data)
+        await self.repository.update(agent, update_data)
+        return await self.get_agent(agent_id, user_id=user_id, user_role=user_role)
 
     async def delete_agent(self, agent_id: UUID) -> None:
         agent = await self.repository.get(agent_id)

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -67,9 +67,12 @@ async def get_agent(
 async def update_agent(
     agent_id: UUID,
     agent_update: AgentUpdate,
+    current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> AgentRead:
-    return await service.update_agent(agent_id, agent_update)
+    return await service.update_agent(
+        agent_id, agent_update, user_id=current_user.id, user_role=current_user.role
+    )
 
 
 @router.delete("/{agent_id}", status_code=204)

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -126,22 +126,32 @@ def test_get_agent_not_found(client: TestClient, mock_db):
     assert response.json()["detail"] == "Agent not found"
 
 
-def test_update_agent(client: TestClient, mock_db):
+def test_update_agent(client: TestClient, mock_db, current_user):
     """Test updating an agent."""
     agent_id = uuid4()
-    owner_id = uuid4()
+    owner_id = current_user.id
     agent = AgentDB(
         id=agent_id,
-        name="Original Agent",
-        instructions="Original instructions",
+        name="Updated Agent",
+        instructions="Updated instructions",
         owner_id=owner_id,
         created_at=datetime.now(),
         updated_at=datetime.now(),
     )
 
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = agent
-    mock_db.execute.return_value = mock_result
+    def make_result(*, scalar=None, rows=None, scalars_list=None):
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = scalar
+        r.all.return_value = rows or []
+        r.scalars.return_value.all.return_value = scalars_list or []
+        return r
+
+    mock_db.execute.side_effect = [
+        make_result(scalar=agent),         # repository.get
+        make_result(rows=[(agent, None)]), # get_agent reload
+        make_result(scalars_list=[]),       # load_subagents → get_for_coordinator
+        make_result(scalar=None),          # is_subagent
+    ]
 
     update_data = {
         "name": "Updated Agent",
@@ -154,9 +164,10 @@ def test_update_agent(client: TestClient, mock_db):
     assert data["id"] == str(agent_id)
     assert data["name"] == update_data["name"]
     assert data["instructions"] == update_data["instructions"]
+    assert data["mcp_servers"] == []
 
 
-def test_update_agent_not_found(client: TestClient, mock_db):
+def test_update_agent_not_found(client: TestClient, mock_db, current_user):
     """Test updating a non-existent agent returns 404."""
     fake_id = uuid4()
 

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -329,23 +329,28 @@ async def test_list_agents_no_user_returns_agents_with_no_permission(service, mo
 # update_agent
 # ---------------------------------------------------------------------------
 
-async def test_update_agent_delegates_to_repository(service, mock_repo):
+async def test_update_agent_delegates_to_repository(service, mock_repo, mock_db):
     agent = make_agent()
-    updated = make_agent(id=agent.id, name="Updated")
     mock_repo.get.return_value = agent
-    mock_repo.update.return_value = updated
+
+    # Mock the get_agent reload query
+    mock_db.execute.return_value = _make_mock_execute_result(rows=[(agent, None)])
 
     result = await service.update_agent(agent.id, AgentUpdate(name="Updated"))
 
     mock_repo.get.assert_awaited_once_with(agent.id)
     mock_repo.update.assert_awaited_once_with(agent, {"name": "Updated"})
-    assert result is updated
+    assert isinstance(result, AgentRead)
+    assert result.id == agent.id
+    assert result.mcp_servers == []
 
 
-async def test_update_agent_passes_only_set_fields(service, mock_repo):
+async def test_update_agent_passes_only_set_fields(service, mock_repo, mock_db):
     agent = make_agent()
     mock_repo.get.return_value = agent
-    mock_repo.update.return_value = agent
+
+    # Mock the get_agent reload query
+    mock_db.execute.return_value = _make_mock_execute_result(rows=[(agent, None)])
 
     await service.update_agent(agent.id, AgentUpdate(name="New Name"))
 

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -87,8 +87,8 @@ def test_get_threads(client: TestClient, mock_db, current_user):
 
     mock_result = MagicMock()
     mock_result.all.return_value = [
-        (thread2, "Test Agent", "🤖"),
-        (thread1, "Test Agent", "🤖"),
+        (thread2, "Test Agent", "🤖", None, False),
+        (thread1, "Test Agent", "🤖", None, False),
     ]
     mock_db.execute.return_value = mock_result
 
@@ -114,7 +114,7 @@ def test_get_thread(mock_checkpointer, client: TestClient, mock_db):
     )
 
     mock_result = MagicMock()
-    mock_result.one_or_none.return_value = (thread, "Test Agent", "🤖")
+    mock_result.one_or_none.return_value = (thread, "Test Agent", "🤖", None, False)
     mock_db.execute.return_value = mock_result
 
     # Mock the checkpointer context manager


### PR DESCRIPTION
## Summary
- **PATCH /agents/{id}** returned `AgentDB` (no relationships) instead of `AgentRead`, causing the frontend Zustand store to overwrite `mcpServers` with `null` on every auto-save — making MCP servers intermittently disappear from the agent editor.
- Now calls `get_agent()` after update to return a fully populated `AgentRead` with `mcp_servers`, `subagents`, and `current_user_permission`.
- Fixes pre-existing thread test failures where mock tuples were missing `color` and `is_archived` columns.

## Test plan
- [x] All 148 tests pass
- [x] Open agent editor, attach MCP servers, edit agent name/instructions — verify MCP servers remain visible after auto-save

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PATCH /agents/{id} to return a full agent payload so MCP servers no longer disappear after auto-save in the agent editor. The endpoint now responds with `AgentRead` including relations and permissions.

- **Bug Fixes**
  - Re-fetch via `get_agent` and pass `current_user` so PATCH returns `AgentRead` with `mcp_servers`, `subagents`, and `current_user_permission`.
  - Update tests and mocks (threads include `color` and `is_archived`; router asserts `mcp_servers`).

- **Dependencies**
  - Add `.codacy.yml` to exclude `backend/tests/**` from `bandit` (avoid S101 on test assertions).

<sup>Written for commit 0f2a3b3b531dee53fa7402c35a64b72f8ec1d276. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

