### PR TITLE
Hide scrollbar and default new thread to last agent

### DIFF
--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -22,7 +22,7 @@ export default async function ProtectedLayout({
 					<SidebarTrigger className="cursor-pointer" />
 					<ChatHeader />
 				</div>
-				<div className="flex flex-1 flex-col gap-4 lg:px-8 px-4 py-4 pt-0 min-h-0 overflow-y-auto">
+				<div className="flex flex-1 flex-col gap-4 lg:px-8 px-4 py-4 pt-0 min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 					{children}
 				</div>
 			</main>

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -128,7 +128,10 @@ export function AppSidebar() {
 							<button
 								onClick={() => {
 									if (agents.length > 0) {
-										router.push(`/agents/${agents[0].id}/chat`);
+										const lastAgent = threads[0]
+											? agents.find((a) => a.id === threads[0].agentId)
+											: undefined;
+										router.push(`/agents/${(lastAgent ?? agents[0]).id}/chat`);
 									}
 								}}
 								disabled={agents.length === 0}


### PR DESCRIPTION
## Summary
- Hide the scrollbar on the main content area to prevent layout shift when switching between pages with different content heights
- "New thread" now defaults to the agent from the most recent thread, instead of always picking the first agent. Falls back to `agents[0]` if no threads exist or the agent was deleted.

## Test plan
- [x] Switch between Agents/Users/MCP Servers tabs — no horizontal layout shift from scrollbar appearing/disappearing
- [x] Create threads with different agents, click "New thread" — should default to the last used agent
- [ ] Delete the last used agent, click "New thread" — should fall back to the first available agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the main content scrollbar to stop layout shifts between pages. Also makes “New thread” default to the agent from the most recent thread, falling back to the first agent if no threads exist or the last agent was deleted.

<sup>Written for commit 587d1fc4fdb1d79663841c50073ab57eca65c01b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

