### PR TITLE
Fix MCP app widget instability and sandbox handshake race

### DIFF
--- a/web/public/sandbox.html
+++ b/web/public/sandbox.html
@@ -11,32 +11,106 @@
 				padding: 0;
 				width: 100%;
 				height: 100%;
+				overflow: hidden;
+				background: transparent;
+			}
+
+			#mcp-app-frame {
+				width: 100%;
+				height: 100%;
+				border: 0;
+				background: transparent;
 			}
 		</style>
 	</head>
 	<body>
+		<iframe
+			id="mcp-app-frame"
+			title="MCP App"
+			sandbox="allow-scripts allow-same-origin allow-forms"
+		></iframe>
 		<script>
-			window.addEventListener("message", (event) => {
-				const data = event.data;
-				if (!data || typeof data !== "object") return;
+			(() => {
+				const SANDBOX_PROXY_READY = "ui/notifications/sandbox-proxy-ready";
+				const SANDBOX_RESOURCE_READY =
+					"ui/notifications/sandbox-resource-ready";
 
-				if (data.method === "ui/notifications/sandbox-resource-ready") {
-					const html = data.params && data.params.html;
-					if (typeof html === "string") {
-						document.open();
-						document.write(html);
-						document.close();
-					}
+				const frame = document.getElementById("mcp-app-frame");
+				if (!(frame instanceof HTMLIFrameElement)) {
+					return;
 				}
-			});
 
-			window.parent.postMessage(
-				{
-					method: "ui/notifications/sandbox-proxy-ready",
+				const postToParent = (data) => {
+					window.parent.postMessage(data, "*");
+				};
+
+				const postToApp = (data) => {
+					if (!frame.contentWindow) {
+						return;
+					}
+					frame.contentWindow.postMessage(data, "*");
+				};
+
+				const loadResource = (params) => {
+					if (
+						!params ||
+						typeof params !== "object" ||
+						typeof params.html !== "string"
+					) {
+						return;
+					}
+
+					const sandboxPermissions =
+						typeof params.sandbox === "string" && params.sandbox.trim()
+							? params.sandbox
+							: "allow-scripts allow-same-origin allow-forms";
+					frame.setAttribute("sandbox", sandboxPermissions);
+					frame.srcdoc = params.html;
+				};
+
+				// @mcp-ui/client has a 10s hardcoded timeout waiting for
+				// SANDBOX_PROXY_READY and no retry. One-shot posts race against
+				// the library attaching its listener (React strict-mode
+				// double-mount, dev HMR, slow boot). Re-announce every 100ms
+				// until the parent responds with SANDBOX_RESOURCE_READY, then
+				// stop. Safety cap at 15s keeps us from posting forever.
+				const readyMessage = {
+					jsonrpc: "2.0",
+					method: SANDBOX_PROXY_READY,
 					params: {},
-				},
-				"*",
-			);
+				};
+				const postReady = () => postToParent(readyMessage);
+
+				postReady();
+				const readyInterval = setInterval(postReady, 100);
+				const readyTimeout = setTimeout(
+					() => clearInterval(readyInterval),
+					15000,
+				);
+
+				window.addEventListener("message", (event) => {
+					if (event.source === window.parent) {
+						const message = event.data;
+						if (!message || typeof message !== "object") {
+							return;
+						}
+
+						if (message.method === SANDBOX_RESOURCE_READY) {
+							clearInterval(readyInterval);
+							clearTimeout(readyTimeout);
+							loadResource(message.params);
+							return;
+						}
+
+						postToApp(message);
+						return;
+					}
+
+					if (event.source === frame.contentWindow) {
+						postToParent(event.data);
+					}
+				});
+			})();
 		</script>
 	</body>
 </html>

--- a/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
@@ -101,22 +101,15 @@ export const McpAppWidget = ({
 
 	const serverId = appToolInfo.serverId;
 
-	// Parents typically rebuild `input` / `output` / `structuredContent` on every
-	// render (e.g. page.tsx runs JSON.parse on each pass via getToolOutputContent),
-	// so ref-based memo keys invalidate every tick. Use string keys derived from
-	// the content so the memoized objects stay stable across no-op re-renders —
-	// otherwise AppRenderer re-syncs the sandboxed iframe on every tick and
-	// floods the console with "Ignoring message from unknown source" and the
-	// widget keeps re-measuring.
-	const inputKey = input ? stableKey(input) : "";
+	// toCallToolResult(...) allocates a fresh wrapper, and page.tsx rebuilds
+	// `output` / `structuredContent` on every render (JSON.parse runs per pass
+	// in getToolOutputContent). AppRenderer tracks toolResult by reference
+	// identity, so without this memo it would re-sync the sandboxed iframe on
+	// every tick — flooding the console with "Ignoring message from unknown
+	// source" and keeping the widget re-measuring. Key by a content hash so
+	// upstream ref-churn can't invalidate us.
 	const outputKey = output === undefined ? "" : stableKey(output);
 	const structuredKey = structuredContent ? stableKey(structuredContent) : "";
-
-	const toolInput = useMemo(
-		() => input,
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[inputKey],
-	);
 
 	const toolResult = useMemo(
 		() => toCallToolResult(output, errorText, structuredContent),
@@ -190,7 +183,7 @@ export const McpAppWidget = ({
 				toolResourceUri={appToolInfo.resourceUri}
 				sandbox={sandboxConfig}
 				hostContext={hostContext}
-				toolInput={toolInput}
+				toolInput={input}
 				toolResult={toolResult}
 				onReadResource={onReadResource}
 				onCallTool={onCallTool}

--- a/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { AppRenderer } from "@mcp-ui/client";
 import { api } from "@/lib/api/client";
 import { cn } from "@/lib/utils";
@@ -46,6 +46,18 @@ const hasStructuredContent = (
 	"structuredContent" in output &&
 	isRecord(output.structuredContent);
 
+// Content hash used to keep useMemo stable across parent re-renders that
+// rebuild the same value into a fresh reference.
+const stableKey = (value: unknown): string => {
+	if (value === null || value === undefined) return "";
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+};
+
 const toCallToolResult = (
 	output: unknown,
 	errorText: string | undefined,
@@ -87,6 +99,74 @@ export const McpAppWidget = ({
 		[],
 	);
 
+	const serverId = appToolInfo.serverId;
+
+	// Parents typically rebuild `input` / `output` / `structuredContent` on every
+	// render (e.g. page.tsx runs JSON.parse on each pass via getToolOutputContent),
+	// so ref-based memo keys invalidate every tick. Use string keys derived from
+	// the content so the memoized objects stay stable across no-op re-renders —
+	// otherwise AppRenderer re-syncs the sandboxed iframe on every tick and
+	// floods the console with "Ignoring message from unknown source" and the
+	// widget keeps re-measuring.
+	const inputKey = input ? stableKey(input) : "";
+	const outputKey = output === undefined ? "" : stableKey(output);
+	const structuredKey = structuredContent ? stableKey(structuredContent) : "";
+
+	const toolInput = useMemo(
+		() => input,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[inputKey],
+	);
+
+	const toolResult = useMemo(
+		() => toCallToolResult(output, errorText, structuredContent),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[outputKey, errorText, structuredKey],
+	);
+
+	const onReadResource = useCallback(
+		async ({ uri }: { uri: string }) => {
+			const response = await api.post(
+				`/mcp-servers/${serverId}/app/read-resource`,
+				{ uri },
+			);
+			return response.data;
+		},
+		[serverId],
+	);
+
+	const onCallTool = useCallback(
+		async ({
+			name,
+			arguments: args,
+		}: {
+			name: string;
+			arguments?: Record<string, unknown> | null;
+		}) => {
+			const response = await api.post(
+				`/mcp-servers/${serverId}/app/call-tool`,
+				{ toolName: name, arguments: args ?? null },
+			);
+
+			const data = response.data;
+
+			if (data.content) {
+				data.content = data.content.map((block: Record<string, unknown>) => {
+					const cleaned = { ...block };
+					if (cleaned.annotations === null) delete cleaned.annotations;
+					if (cleaned.Meta === null) delete cleaned.Meta;
+					if (cleaned._meta === null) delete cleaned._meta;
+					return cleaned;
+				});
+			}
+			if (data._meta === null) delete data._meta;
+			if (data.Meta === null) delete data.Meta;
+
+			return data;
+		},
+		[serverId],
+	);
+
 	if (typeof window === "undefined") {
 		return null;
 	}
@@ -94,7 +174,14 @@ export const McpAppWidget = ({
 	return (
 		<div
 			className={cn(
-				"mt-2 w-full min-w-0 overflow-hidden [&_iframe]:w-full! [&_iframe]:max-w-full!",
+				"mt-2 w-full min-w-0 overflow-hidden",
+				// AppRenderer has no autoResize option and writes iframe.style.height
+				// directly in response to `onsizechange`. When the app's body uses
+				// `height: 100%`, that resize reflows content, which re-measures and
+				// posts again — an unbounded growth loop. Cap the iframe height with
+				// !important so the library's inline style can't actually grow the
+				// element; the handshake settles after one frame.
+				"[&_iframe]:w-full! [&_iframe]:max-w-full! [&_iframe]:max-h-[70vh]!",
 				className,
 			)}
 		>
@@ -103,42 +190,10 @@ export const McpAppWidget = ({
 				toolResourceUri={appToolInfo.resourceUri}
 				sandbox={sandboxConfig}
 				hostContext={hostContext}
-				toolInput={input}
-				toolResult={toCallToolResult(output, errorText, structuredContent)}
-				onReadResource={async ({ uri }) => {
-					const response = await api.post(
-						`/mcp-servers/${appToolInfo.serverId}/app/read-resource`,
-						{ uri },
-					);
-					return response.data;
-				}}
-				onCallTool={async ({ name, arguments: args }) => {
-					const response = await api.post(
-						`/mcp-servers/${appToolInfo.serverId}/app/call-tool`,
-						{
-							toolName: name,
-							arguments: args ?? null,
-						},
-					);
-
-					const data = response.data;
-
-					if (data.content) {
-						data.content = data.content.map(
-							(block: Record<string, unknown>) => {
-								const cleaned = { ...block };
-								if (cleaned.annotations === null) delete cleaned.annotations;
-								if (cleaned.Meta === null) delete cleaned.Meta;
-								if (cleaned._meta === null) delete cleaned._meta;
-								return cleaned;
-							},
-						);
-					}
-					if (data._meta === null) delete data._meta;
-					if (data.Meta === null) delete data.Meta;
-
-					return data;
-				}}
+				toolInput={toolInput}
+				toolResult={toolResult}
+				onReadResource={onReadResource}
+				onCallTool={onCallTool}
 			/>
 		</div>
 	);

--- a/web/src/hooks/use-mcp-host-context.ts
+++ b/web/src/hooks/use-mcp-host-context.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import type { McpUiHostContext, McpUiStyles } from "@modelcontextprotocol/ext-apps";
 
 /**
@@ -95,14 +95,19 @@ export function useMcpHostContext(): McpUiHostContext {
 		() => "light" as const,
 	);
 
-	const variables = resolveStyleVariables();
-
-	return {
-		theme,
-		styles: {
-			variables: variables as McpUiStyles,
-		},
-		platform: "web",
-		deviceCapabilities: { touch: false, hover: true },
-	};
+	// Memoize by theme — style variables only change with the theme class flip.
+	// Without this, every parent re-render produces a new hostContext object,
+	// which makes AppRenderer re-sync to the sandboxed iframe on every tick and
+	// floods the console with "Ignoring message from unknown source" warnings.
+	return useMemo<McpUiHostContext>(
+		() => ({
+			theme,
+			styles: {
+				variables: resolveStyleVariables() as McpUiStyles,
+			},
+			platform: "web",
+			deviceCapabilities: { touch: false, hover: true },
+		}),
+		[theme],
+	);
 }


### PR DESCRIPTION
## Summary

Three independent bugs that combined to make MCP app widgets unstable — console flood during streaming, widget growing unbounded, and a 10s timeout on boot. Each is a host-side workaround for a `@mcp-ui/client` limitation; there is no upstream release that addresses any of them (v7.0.0 is a JSDoc-only bump).

- **`use-mcp-host-context.ts`**: memoize the returned `hostContext` by theme. It was a fresh object literal on every render, so `AppRenderer`'s identity-based effect fired every tick and re-synced the iframe.
- **`mcp-app-widget.tsx`**: stabilize every prop fed to `AppRenderer` by content hash (`stableKey`) — `toolInput`, `toolResult`, `onReadResource`, `onCallTool`. Also cap the iframe with `max-h-[70vh]!` to break the library's `onsizechange` → `iframe.style.height = evt.height` → reflow → re-measure feedback loop (no `autoResize` opt-out exists).
- **`sandbox.html`**: restore the canonical two-tier proxy (nested `srcdoc` iframe with bidirectional message relay), add JSON-RPC 2.0 envelope on the ready message, and re-announce readiness every 100ms until the parent responds — defeats the 10s hardcoded timeout + no-retry race under React dev strict-mode / HMR / slow boots. Pattern matches MCPJam Inspector's reference sandbox proxy.

## Test plan

- [ ] Open a chat that invokes an MCP app widget (e.g. the BigQuery / football card example). Reload.
  - [ ] No "Timed out waiting for sandbox proxy iframe to be ready" error
  - [ ] Widget renders at a stable height and does not grow
- [ ] Stream a long response with the widget visible in the thread.
  - [ ] DevTools console does not flood with "Ignoring message from unknown source" proportional to tokens streamed (residual entries from browser extensions like React DevTools are expected and unrelated)
- [ ] Hard-refresh 5+ times rapidly (simulates boot races).
  - [ ] Widget connects every time — no timeout errors
- [ ] Interact with a widget that calls back (approve, submit, etc.). Confirm `onCallTool` still fires and results return.
- [ ] Toggle dark/light theme with the widget open.
  - [ ] Widget picks up the theme (one re-sync, not a loop)

## Upstream follow-ups worth filing against `@mcp-ui/client`

1. Configurable or retry-capable `sandbox-proxy-ready` timeout.
2. `autoResize: false` / `maxHeight` option on `AppRenderer`.
3. Internal deep-compare (or documented stability contract) for `hostContext` / `toolInput` / `toolResult`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes MCP app widgets to remove the 10s sandbox timeout, stop console spam during streaming, and prevent unbounded iframe growth. Done by memoizing host context, stabilizing `toolResult`, and restoring a resilient sandbox proxy.

- **Bug Fixes**
  - `use-mcp-host-context.ts`: Memoize `hostContext` by theme so `@mcp-ui/client`’s `AppRenderer` doesn’t re-sync on every render.
  - `mcp-app-widget.tsx`: Use content-hash keys to keep `toolResult` stable; pass `toolInput` through; memoize callbacks; cap iframe height with `max-h-[70vh]!` to break the resize loop.
  - `sandbox.html`: Reinstate two-tier proxy with `srcdoc` iframe, JSON-RPC ready envelope, and 100ms re-announce until resource loads (15s cap) to defeat the handshake race.

<sup>Written for commit c557844d891ca39fb58ddf3995d53eb2aa40a2e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

