### PR TITLE
Refresh docs and add MCP servers screenshots

### DIFF
--- a/docs/content/_meta.js
+++ b/docs/content/_meta.js
@@ -8,6 +8,7 @@ export default {
   'mcp-servers': 'MCP Servers',
   agents: 'Agents',
   tools: 'Tools',
+  sandbox: 'Sandbox',
   '----': {
     type: 'separator'
   },

--- a/docs/content/agents/_meta.js
+++ b/docs/content/agents/_meta.js
@@ -1,4 +1,6 @@
 export default {
   index: 'Overview',
-  configuration: 'Configuration'
+  configuration: 'Configuration',
+  permissions: 'Permissions',
+  subagents: 'Subagents'
 }

--- a/docs/content/agents/configuration.mdx
+++ b/docs/content/agents/configuration.mdx
@@ -1,59 +1,68 @@
 # Agent Configuration
 
-This page covers the details of configuring an agent in **auxilia**.
+Every field on an agent can be edited at any time. Changes take effect on the next message — existing threads are not recomputed.
 
-## System Prompt (Instructions)
+## Instructions (system prompt)
 
-The instructions field is the system prompt sent to the LLM on every message. It defines the agent's personality, behavior, and constraints.
+The instructions field is the system prompt prepended to every conversation. It defines the agent's role, tone, and constraints.
 
-Tips for writing effective instructions:
+Tips for effective instructions:
 
-- Be specific about the agent's role and domain
-- List what the agent should and shouldn't do
-- Mention which tools to prefer for specific tasks
-- Include formatting preferences for responses
+- Be specific about the agent's domain and the audience
+- Tell it which tools (and MCP servers) to prefer for which tasks
+- List formatting rules, e.g. "always cite the HubSpot contact ID"
+- Say what to do when a tool fails or data is missing — otherwise the LLM will guess
 
-**Example:**
+Example:
 
+```text
+You are a CRM assistant for the sales team. Use the HubSpot MCP tools to look up
+contacts, deals, and companies.
+
+When reporting on a contact, always include: email, company, deal stage, and the
+last-activity date. Format monetary values with currency symbols. If a record
+cannot be found, say so plainly rather than guessing.
 ```
-You are a CRM assistant for the sales team. Use the HubSpot tools to look up
-contacts, deals, and company information.
 
-When asked about a contact, always include their email, company, and deal stage.
-Format monetary values with currency symbols. If you can't find a record,
-say so clearly rather than guessing.
-```
+## Avatar
 
-## Emoji Avatar
+Agents have a two-part avatar:
 
-Each agent has an emoji avatar displayed in the agent list and chat header. Click the emoji in the agent editor to open the picker.
+- **Emoji** — picked via the emoji picker in the agent editor
+- **Color** — a hex color used as the badge background in the sidebar and chat header
 
-## MCP Server Bindings
+## Description
 
-After creating an agent, bind MCP servers to give it access to tools:
+A short description shown on the agent card in the **Agents** list. Keep it to one sentence — users pick agents by skimming this.
 
-1. Click **Add MCP Server** in the agent configuration
-2. Select a server from the workspace's registered servers
-3. The server's tools will appear with their default status
+## MCP server bindings
 
-Each binding tracks:
+After the agent exists, bind one or more workspace MCP servers from the agent's configuration page:
 
-- **Enabled tools** — which tools from this server are available
-- **Tool statuses** — per-tool permission level (see [Tool Settings](/docs/tools/settings))
+1. Click **Add MCP Server**
+2. Pick a server from the workspace catalog
+3. **auxilia** fetches the server's tools and adds them to the binding
 
-## Editing an Agent
+Each binding carries:
 
-All agent properties can be modified at any time:
+- **Tools** — the list discovered at bind time, each one with a status (`always allow`, `needs approval`, `disabled`). See [Tool Settings](/docs/tools/settings).
+- **Sync tools** — re-fetches the tool list from the MCP server. Use this when the server publishes new tools or changes descriptions.
 
-- Changes to **instructions** take effect on the next message
-- Changes to **MCP server bindings** take effect on the next message
-- Changes to **tool settings** take effect on the next message
-- Existing chat threads are not affected by historical changes — they use the current configuration
+## Code execution (sandbox)
 
-## Deleting an Agent
+Toggle **Code execution** on the agent page to give the agent a Linux sandbox with shell, file, and search tools. See [Sandbox](/docs/sandbox) for the full toolset and security model.
 
-Deleting an agent removes:
+## Subagents
 
-- The agent configuration
+Admins can attach **subagents** — specialized agents that the coordinator agent can call as tools. See [Subagents](/docs/agents/subagents).
+
+## Archiving and deleting
+
+Agents can be **archived** (hidden from the default list but preserved with their threads) or **deleted** outright. Deleting an agent removes:
+
+- The agent config
 - All MCP server bindings for that agent
-- All chat threads associated with the agent
+- All subagent links to or from it
+- All threads and checkpoints associated with it
+
+Archived agents remain queryable; deleted agents don't.

--- a/docs/content/agents/index.mdx
+++ b/docs/content/agents/index.mdx
@@ -1,54 +1,67 @@
 # Agents
 
-Agents are the core of **auxilia**. An agent is an AI assistant configured with a system prompt (instructions), an emoji avatar, and a set of MCP server bindings that determine which tools it can use.
+Agents are the core of **auxilia**. An agent is an AI assistant defined by:
 
-## How Agents Work
+- A **name**, **emoji**, and **color** (the avatar shown in the sidebar and chat)
+- **Instructions** — the system prompt sent on every message
+- A set of **MCP server bindings** — which tools the agent can reach
+- Optional **subagents** — specialized agents this agent can dispatch work to
+- A **sandbox** flag — whether the agent has access to a Linux code-execution environment
+
+## How agents run
 
 When a user sends a message to an agent, **auxilia**:
 
-1. Loads the agent configuration (instructions, model, MCP servers)
-2. Connects to all bound MCP servers and discovers available tools
-3. Filters tools based on each tool's status (always allow / needs approval / disabled)
-4. Sends the message to the LLM with the system prompt and available tools
-5. Streams the response back, executing tool calls as needed
+1. Loads the agent configuration from Postgres
+2. Opens an MCP session to every bound server (reusing cached OAuth tokens per user)
+3. Discovers each server's tools and filters them by the agent's [tool settings](/docs/tools/settings)
+4. If the **sandbox** is enabled, adds the `create_sandbox` / `connect_sandbox` tools and the standard file-ops toolset
+5. If subagents are configured, wraps them as tools the coordinator can call
+6. Sends the conversation to the LLM via LangGraph with the resolved toolset
+7. Streams tokens back to the UI (or Slack) and executes tool calls as they appear
+8. Persists state as a LangGraph checkpoint in Postgres so the thread can be resumed
 
-## Creating an Agent
+The underlying runtime is LangGraph's `create_agent` (or `create_deep_agent` when the sandbox is on), with middleware for HITL interrupts, tool errors, and optional subagent dispatch.
 
-1. Navigate to the **Agents** page
+## Creating an agent
+
+1. Navigate to **Agents** in the sidebar
 2. Click **Create Agent**
-3. Fill in the agent details:
-   - **Name** — a descriptive name for the agent
-   - **Emoji** — an avatar emoji shown in the agent list and chat
-   - **Instructions** — the system prompt that defines the agent's behavior
+3. Fill in:
+   - **Name** — what users see in the agent list
+   - **Emoji** and **color** — the avatar
+   - **Description** — short summary shown on the agent card
+   - **Instructions** — the system prompt
+4. Save, then open the agent's configuration page to bind MCP servers
 
-## Agent-MCP Server Bindings
+Only users with the **editor** or **admin** role can create agents. The creator becomes the **owner** of the agent.
 
-Each agent can be connected to multiple MCP servers. When you bind an MCP server to an agent, all of that server's tools become available (subject to [tool settings](/docs/tools/settings)).
+## Threads
 
-To add MCP servers to an agent:
+Conversations with an agent are organized into **threads**. Each thread:
 
-1. Open the agent's configuration page
-2. Click **Add MCP Server**
-3. Select from the workspace's registered MCP servers
-4. Configure tool permissions for each server
+- Is tied to one agent and one user
+- Persists its message history via LangGraph Postgres checkpoints
+- Remembers the model selected for that thread (not switchable)
+- Is independent from other threads — each one has its own memory
 
-## Chat Threads
+You can regenerate the last assistant message in a thread; **auxilia** rewinds the LangGraph checkpoint and re-streams.
 
-Conversations with agents are organized into **threads**. Each thread:
+## Available models
 
-- Is tied to a specific agent and user
-- Has its own conversation history (persisted via LangGraph checkpoints)
-- Can use a specific LLM model (selectable per thread)
-- Is independent from other threads with the same agent
+You can pick a different LLM per thread. Only models whose API key is configured in the environment appear in the selector.
 
-## Supported Models
+| Provider  | Models                                                     |
+| --------- | ---------------------------------------------------------- |
+| Anthropic | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6` |
+| OpenAI    | `gpt-4o-mini`                                              |
+| Google    | `gemini-3-flash-preview`, `gemini-3-pro-preview`           |
+| DeepSeek  | `deepseek-chat`, `deepseek-reasoner`                       |
 
-You can select a different LLM model for each thread. Available models depend on which API keys are configured:
+## Where to go next
 
-| Provider  | Models                                   |
-| --------- | ---------------------------------------- |
-| Anthropic | Claude Haiku, Claude Sonnet, Claude Opus |
-| OpenAI    | GPT-4o mini                              |
-| Google    | Gemini 3 Flash, Gemini 3 Pro             |
-| DeepSeek  | DeepSeek Chat, DeepSeek Reasoner         |
-| LiteLLM   | Any custom model via LiteLLM proxy       |
+- **[Configuration](/docs/agents/configuration)** — editing instructions, avatar, MCP bindings
+- **[Permissions](/docs/agents/permissions)** — sharing agents across the workspace
+- **[Subagents](/docs/agents/subagents)** — dispatching work to specialized agents
+- **[Sandbox](/docs/sandbox)** — enabling code execution
+- **[Tool Settings](/docs/tools/settings)** — approval rules per tool

--- a/docs/content/agents/permissions.mdx
+++ b/docs/content/agents/permissions.mdx
@@ -1,0 +1,54 @@
+# Agent Permissions
+
+Agents are not automatically visible to everyone in the workspace. Access is governed by the user's **workspace role** and by explicit **per-agent grants**.
+
+## Workspace roles
+
+| Role     | Can create agents | Can see unshared agents | Can manage MCP servers, invites, PATs |
+| -------- | ----------------- | ----------------------- | ------------------------------------- |
+| `admin`  | yes               | yes (all agents)        | yes                                   |
+| `editor` | yes               | only own + explicitly shared | no                                |
+| `member` | no                | only explicitly shared  | no                                    |
+
+## Per-agent permission levels
+
+On top of the workspace role, each agent can grant users one of three levels:
+
+| Level    | What it allows                                                   |
+| -------- | ---------------------------------------------------------------- |
+| `user`   | Chat with the agent                                              |
+| `editor` | Chat + edit the agent's configuration and MCP bindings           |
+| `admin`  | Chat + edit + manage permissions for the agent                   |
+
+A fourth virtual level, `owner`, is derived from `AgentDB.owner_id` — the user who created the agent. Owners have full control and cannot be removed.
+
+## How **auxilia** resolves the effective level
+
+For each `(agent, user)` pair, the backend returns the first match from:
+
+1. **Owner** (`agent.owner_id == user.id`) → `owner`
+2. **Workspace admin** (`user.role == "admin"`) → `admin`
+3. **Explicit grant** in the agent permissions table → `user` / `editor` / `admin`
+4. Otherwise → `None`
+
+If the effective level is `None`, the agent doesn't appear in the user's agent list and they cannot open a thread on it.
+
+## Managing permissions
+
+From an agent's configuration page, admins (workspace admins, agent owners, or users with `admin` on the agent) can:
+
+- Grant new users one of the three levels
+- Change an existing user's level
+- Revoke a grant
+
+Admins of the workspace always see every agent — even unshared ones — so they can audit, share, or archive them.
+
+## Invites and new users
+
+Only workspace admins can invite new users. From **Settings → Users**:
+
+1. Click **Invite user**
+2. Enter the email address and pick a role (`admin`, `editor`, or `member`)
+3. **auxilia** returns a one-time invite URL — share it with the person you're inviting
+
+The first account created on a fresh install automatically becomes an `admin`.

--- a/docs/content/agents/subagents.mdx
+++ b/docs/content/agents/subagents.mdx
@@ -1,0 +1,55 @@
+# Subagents
+
+A **subagent** is an agent exposed as a tool to another agent. The caller — the **coordinator** — decides when to hand off a question to the subagent, receives the subagent's answer as a tool result, and uses it in its own response.
+
+This lets you build specialized agents (one great at SQL, one great at Slack-drafting, one great at investigation) and have a single entry-point agent dispatch work across them without the user having to pick the right tool.
+
+## How it works
+
+When a coordinator has subagents attached, **auxilia** builds it as a [deep agent](https://github.com/langchain-ai/deepagents) and wraps each subagent as a tool:
+
+```
+┌──────────────────┐
+│  Coordinator     │  ask_sql("top 10 customers by MRR")
+│   (LLM + tools)  │ ─────────────────────────────────────┐
+└──────────────────┘                                       │
+         │                                                 ▼
+         │                                      ┌──────────────────┐
+         │                                      │  SQL subagent    │
+         │                                      │   (LLM + tools)  │
+         │                                      └──────────────────┘
+         │                                                 │
+         │          result                                 │
+         │◀────────────────────────────────────────────────┘
+         ▼
+    final message
+```
+
+Subagents run in their own LangGraph invocation; their tool calls, approvals, and messages are rolled up into the coordinator's stream.
+
+## Constraints
+
+**auxilia** enforces two structural rules at bind time:
+
+- An agent that has subagents cannot itself be used as a subagent
+- An agent that is already a subagent cannot have subagents
+
+In other words, the subagent graph is one level deep — no nested coordinators. This keeps reasoning and HITL flows predictable.
+
+## Managing subagents
+
+Only workspace **admins** can add or remove subagent links. From an agent's configuration page:
+
+1. Open the **Subagents** section
+2. Click **Add subagent** and pick an agent from the workspace
+3. **auxilia** creates the coordinator → subagent binding
+
+Removing a subagent unlinks it; both agents continue to exist.
+
+## Picking good subagents
+
+Subagents shine when each one has a narrow, well-described purpose. The coordinator picks between subagents the same way an LLM picks between tools — based on names and descriptions — so:
+
+- Give each subagent a **clear description** (it becomes the tool description)
+- Make their instructions **specific** so they stay on task
+- Bind each subagent to the **minimum set of MCP servers** it needs

--- a/docs/content/deployment/cloud-run.mdx
+++ b/docs/content/deployment/cloud-run.mdx
@@ -6,11 +6,9 @@ This guide walks through deploying **auxilia** on Google Cloud Run with Cloud SQ
 
 - A Google Cloud project with billing enabled
 - [gcloud CLI](https://cloud.google.com/sdk/docs/install) installed and authenticated
-- Docker installed locally
+- Docker installed locally (or use Cloud Build as shown below)
 
-## 1. Set Up Cloud SQL
-
-Create a PostgreSQL instance:
+## 1. Set up Cloud SQL
 
 ```bash
 gcloud sql instances create auxilia-db \
@@ -26,7 +24,7 @@ gcloud sql users set-password postgres \
   --password=YOUR_DB_PASSWORD
 ```
 
-## 2. Set Up Memorystore (Redis)
+## 2. Set up Memorystore (Redis)
 
 ```bash
 gcloud redis instances create auxilia-redis \
@@ -35,25 +33,22 @@ gcloud redis instances create auxilia-redis \
   --redis-version=redis_7_0
 ```
 
-Note the IP address from the output — you'll need it for `REDIS_HOST`.
+Note the IP address from the output — you'll use it for `REDIS_HOST`.
 
-## 3. Build and Push Images
+## 3. Build and push images
 
 ```bash
-# Set your project
 export PROJECT_ID=your-project-id
 export REGION=us-central1
 
-# Build and push backend
 gcloud builds submit backend/ \
   --tag ${REGION}-docker.pkg.dev/${PROJECT_ID}/auxilia/backend
 
-# Build and push web
 gcloud builds submit web/ \
   --tag ${REGION}-docker.pkg.dev/${PROJECT_ID}/auxilia/web
 ```
 
-## 4. Deploy Backend
+## 4. Deploy the backend
 
 ```bash
 gcloud run deploy auxilia-backend \
@@ -64,16 +59,18 @@ gcloud run deploy auxilia-backend \
   --set-env-vars "DATABASE_URL=postgresql+psycopg://postgres:YOUR_DB_PASSWORD@/auxilia?host=/cloudsql/${PROJECT_ID}:${REGION}:auxilia-db" \
   --set-env-vars "REDIS_HOST=REDIS_IP" \
   --set-env-vars "REDIS_PORT=6379" \
-  --set-env-vars "JWT_SECRET_KEY=your-secret-key" \
+  --set-env-vars "JWT_SECRET_KEY=your-jwt-secret" \
+  --set-env-vars "SALT=your-encryption-salt" \
   --set-env-vars "COOKIE_SECURE=true" \
   --set-env-vars "FRONTEND_URL=https://auxilia-web-HASH.run.app" \
-  --set-env-vars "MCP_API_KEY_ENCRYPTION_SALT=your-encryption-salt" \
-  --set-env-vars "OPENAI_API_KEY=sk-..." \
+  --set-env-vars "ANTHROPIC_API_KEY=sk-ant-..." \
   --add-cloudsql-instances ${PROJECT_ID}:${REGION}:auxilia-db \
-  --vpc-connector your-vpc-connector
+  --vpc-connector auxilia-connector
 ```
 
-## 5. Deploy Web
+Migrations (`alembic upgrade head`) run automatically when the container starts.
+
+## 5. Deploy the web
 
 ```bash
 gcloud run deploy auxilia-web \
@@ -84,9 +81,9 @@ gcloud run deploy auxilia-web \
   --set-env-vars "BACKEND_URL=https://auxilia-backend-HASH.run.app"
 ```
 
-## 6. Configure VPC Connector
+## 6. VPC connector
 
-Both Cloud Run services need to access Memorystore through a VPC connector:
+Both services need network access to Memorystore through a VPC connector:
 
 ```bash
 gcloud compute networks vpc-access connectors create auxilia-connector \
@@ -94,9 +91,9 @@ gcloud compute networks vpc-access connectors create auxilia-connector \
   --range 10.8.0.0/28
 ```
 
-Update both Cloud Run services to use `--vpc-connector auxilia-connector`.
+Attach `--vpc-connector auxilia-connector` to both services.
 
-## Custom Domain
+## 7. Custom domain
 
 Map a custom domain to the web service:
 
@@ -107,4 +104,10 @@ gcloud run domain-mappings create \
   --region ${REGION}
 ```
 
-Update `FRONTEND_URL` on the backend service to match.
+Update `FRONTEND_URL` on the backend to the new domain.
+
+## Notes on Cloud Run sizing
+
+- The backend keeps a persistent OAuth token cache in Redis, so you can scale instances to zero safely
+- LangGraph checkpoints live in Postgres, not in process memory, so scaling up horizontally is fine
+- Remember that Cloud Run request timeout caps streaming responses — use at least `--timeout=3600` if you expect long agent runs

--- a/docs/content/deployment/index.mdx
+++ b/docs/content/deployment/index.mdx
@@ -1,33 +1,51 @@
 # Deployment
 
-**auxilia** can be deployed on any platform that supports Docker containers. The stack consists of three services:
+**auxilia** can be deployed on anything that runs Docker containers. The stack consists of three services (plus an optional sandbox runtime):
 
 - **Backend** (FastAPI) — Python 3.12+
 - **Web** (Next.js) — Node.js 20+
 - **Database** — PostgreSQL 17 + Redis 7
+- **Sandbox** (optional) — [OpenSandbox](https://github.com/langchain-ai/opensandbox) for code execution
 
-## Docker Images
-
-The project provides Dockerfiles for both services:
+The repository ships with:
 
 ```
-backend/Dockerfile    # FastAPI backend
-web/Dockerfile        # Next.js frontend
+backend/Dockerfile       # FastAPI backend
+web/Dockerfile           # Next.js frontend
+docker-compose.yml       # production compose file
+docker-compose.dev.yml   # postgres + redis for local dev
 ```
 
-## Environment Variables
+## Minimum environment
 
-All configuration is done through environment variables. See the [Get Started](/docs/get-started) guide for the full list.
+| Variable                 | Required | Notes                                                        |
+| ------------------------ | -------- | ------------------------------------------------------------ |
+| `DATABASE_URL`           | yes      | `postgresql+psycopg://...` connection string                 |
+| `REDIS_HOST` / `REDIS_PORT` | yes   | Reachable from the backend (OAuth tokens are stored here)    |
+| `JWT_SECRET_KEY`         | yes      | 32+ random characters                                        |
+| `SALT`                   | yes      | Salt for AES-GCM encryption of stored MCP API keys           |
+| `FRONTEND_URL`           | yes      | Public URL of the web app (used as OAuth redirect base)      |
+| `BACKEND_URL`            | yes (web) | Internal URL the Next.js proxy uses to reach the backend    |
+| `COOKIE_SECURE`          | recommended | `true` in production (requires HTTPS)                     |
+| One LLM key              | yes      | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `DEEPSEEK_API_KEY` |
 
-Key production considerations:
+Optional:
 
-| Variable                     | Production Value                                      |
-| ---------------------------- | ----------------------------------------------------- |
-| `JWT_SECRET_KEY`             | A strong random string (32+ characters)               |
-| `COOKIE_SECURE`              | `true` (requires HTTPS)                               |
-| `FRONTEND_URL`               | Your public URL (e.g. `https://auxilia.example.com`)  |
-| `MCP_API_KEY_ENCRYPTION_SALT` | A secret string used to derive the encryption key for stored API keys |
+- Google OAuth: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `AUTH_GOOGLE_EXCLUSIVE`
+- Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`
+- Slack: `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`
+- Sandbox: `OPEN_SANDBOX_DOMAIN`, `OPEN_SANDBOX_API_KEY`, `OPEN_SANDBOX_USE_SERVER_PROXY`
 
-## Deployment Guides
+See the [Get Started](/docs/get-started) guide and [`.env.example`](https://github.com/keurcien/auxilia/blob/main/.env.example) for the full list.
 
-- [Google Cloud Run](/docs/deployment/cloud-run) — Deploy **auxilia** as serverless containers on GCP
+## Migrations
+
+Alembic migrations run automatically at backend startup (`alembic upgrade head` is invoked by the entrypoint). No extra step is needed on deploy — just restart the backend when pulling a new image.
+
+## Reverse proxy / HTTPS
+
+The web container listens on port 3000 and proxies `/api/backend/*` to the backend on port 8000. Put a TLS-terminating reverse proxy in front (Cloud Run, Nginx, Caddy, Cloudflare, …) and set `COOKIE_SECURE=true`, `FRONTEND_URL=https://your-domain`.
+
+## Deployment guides
+
+- **[Google Cloud Run](/docs/deployment/cloud-run)** — deploy on serverless containers with Cloud SQL and Memorystore

--- a/docs/content/get-started.mdx
+++ b/docs/content/get-started.mdx
@@ -5,59 +5,123 @@ This guide walks you through running **auxilia** locally with Docker Compose.
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
-- At least one LLM API key (OpenAI, Anthropic, Google, or DeepSeek)
+- At least one LLM API key (Anthropic, OpenAI, Google, or DeepSeek)
 
-## Clone the Repository
+## 1. Clone the repository
 
 ```bash
 git clone https://github.com/keurcien/auxilia.git
 cd auxilia
 ```
 
-## Configure Environment
+## 2. Configure environment
 
-Copy the example environment file and fill in your API keys:
+Copy the example environment file:
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` with your configuration:
+The minimum configuration you need is a database URL, a JWT secret, an MCP encryption salt, and at least one LLM API key:
 
 ```env
-# Required: at least one LLM provider
-OPENAI_API_KEY=sk-...
+# Database
+DATABASE_URL=postgresql+psycopg://auxilia:auxilia@localhost:5432/auxilia
+
+# Redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# At least one LLM provider
 ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
 GOOGLE_API_KEY=...
 DEEPSEEK_API_KEY=...
+
+# Auth
+JWT_SECRET_KEY=change-me-in-production
+COOKIE_SECURE=false
+FRONTEND_URL=http://localhost:3000
+
+# MCP API-key encryption
+SALT=changeme
+
+# Backend URL — used by the Next.js proxy (server-side only)
+BACKEND_URL=http://localhost:8000
 ```
 
-## Start the Stack
+Optional:
 
-For development with hot-reloading:
+```env
+# Google OAuth sign-in
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback
+
+# Code-execution sandbox (see /docs/sandbox)
+OPEN_SANDBOX_DOMAIN=localhost:8083
+OPEN_SANDBOX_API_KEY=your-key
+OPEN_SANDBOX_USE_SERVER_PROXY=true
+
+# Langfuse observability (see /docs/integrations/langfuse)
+LANGFUSE_PUBLIC_KEY=pk-...
+LANGFUSE_SECRET_KEY=sk-...
+LANGFUSE_BASE_URL=https://cloud.langfuse.com
+
+# Slack integration (see /docs/integrations/slack)
+SLACK_SIGNING_SECRET=
+SLACK_BOT_TOKEN=xoxb-...
+```
+
+## 3. Start the stack
+
+The fastest way to get everything running with hot reload:
 
 ```bash
 make dev
 ```
 
-Or using Docker Compose directly:
+This starts PostgreSQL, Redis, the FastAPI backend (with Alembic migrations) and the Next.js frontend in parallel.
+
+Equivalent individual commands:
 
 ```bash
-docker compose -f docker-compose.dev.yml up
+make dev-stack       # docker compose -f docker-compose.dev.yml up (postgres, redis)
+make dev-backend     # alembic upgrade head + uvicorn with reload
+make dev-frontend    # next dev
 ```
 
-For production:
+For production (Docker Compose):
 
 ```bash
-docker compose up -d
+make build           # or: docker compose build
+make up              # docker compose up -d
 ```
 
-## Access the App
+## 4. Create the first admin account
 
-Open [http://localhost:3000](http://localhost:3000) in your browser. Create an account with email and password to get started.
+Open [http://localhost:3000](http://localhost:3000). The first account you create becomes the workspace **admin**. After that, new accounts require an invite from an admin.
 
-## Next Steps
+## 5. Add an MCP server
 
-1. **[Add MCP Servers](/docs/mcp-servers)** — Register remote MCP servers for your workspace
-2. **[Create an Agent](/docs/agents/configuration)** — Set up your first AI assistant
-3. **[Configure Tools](/docs/tools/settings)** — Control which tools your agents can use
+Navigate to **MCP Servers** in the sidebar and either:
+
+- Click **Install** on one of the official servers (Notion, Linear, GitHub, HubSpot, BigQuery, …), or
+- Click **Add MCP Server** to register any remote MCP server by URL.
+
+See [MCP Servers](/docs/mcp-servers) for the full registration flow and auth options.
+
+## 6. Create an agent
+
+1. Go to **Agents** → **Create Agent**
+2. Set a name, emoji, and color
+3. Write a system prompt (instructions)
+4. Bind one or more MCP servers
+5. Open a chat and send a message
+
+## Next steps
+
+- **[Agents](/docs/agents)** — full configuration, permissions, subagents
+- **[Tool Settings](/docs/tools/settings)** — approval rules per tool
+- **[Sandbox](/docs/sandbox)** — enable code execution for an agent
+- **[Deployment](/docs/deployment)** — move from local to production

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,25 +1,34 @@
 # auxilia
 
-**auxilia** is an open-source web MCP client for hosting MCP-powered AI assistants. Built for enterprise deployment, it lets teams share AI agents backed by remote [Model Context Protocol](https://modelcontextprotocol.io/) servers.
+**auxilia** is an open-source web MCP client for teams. It lets you host AI assistants backed by remote [Model Context Protocol](https://modelcontextprotocol.io/) servers, share them across your organization, and keep every integration — tools, credentials, observability — under your own infrastructure.
 
-## Why auxilia?
+## Why auxilia
 
 Most MCP clients today are desktop apps tied to a single user. **auxilia** is different:
 
-- **Web-based** — accessible from any browser, no desktop app required
-- **Multi-user** — share agents across teams and organization members
-- **Remote MCP only** — designed for production server-to-server MCP connections, not local stdio processes
-- **Self-hosted** — deploy on your own infrastructure
+- **Web-based** — accessible from any browser, no desktop app to install
+- **Multi-user** — workspace admins register MCP servers once; every teammate can bind them to agents
+- **Remote MCP only** — designed for server-to-server MCP connections over Streamable HTTP, not local stdio processes
+- **Self-hosted** — runs on your own infrastructure, keeps credentials and conversation data in your database
+- **MCP-native** — everything the LLM sees (tools, skills, resources) flows through MCP, so the core stays small
+
+## What you can build
+
+- A CRM agent that queries HubSpot and drafts Slack replies
+- A data analyst that runs BigQuery, produces charts in a sandbox, and posts results to a thread
+- An on-call assistant that reads Sentry issues, searches Linear, and opens pull requests via GitHub
+- A workspace-wide coordinator agent that dispatches work to specialized subagents
 
 ## Architecture
 
-**auxilia** is composed of three services:
+**auxilia** is composed of three services plus an optional sandbox runtime:
 
-| Service      | Technology          | Purpose                        |
-| ------------ | ------------------- | ------------------------------ |
-| **Backend**  | FastAPI + LangGraph | Agent runtime, MCP client, API |
-| **Web**      | Next.js + React     | User interface                 |
-| **Database** | PostgreSQL + Redis  | Persistence and token storage  |
+| Service      | Technology                    | Purpose                                       |
+| ------------ | ----------------------------- | --------------------------------------------- |
+| **Backend**  | FastAPI + LangGraph           | Agent runtime, MCP client, auth, API          |
+| **Web**      | Next.js 16 + React 19         | User interface and backend proxy              |
+| **Database** | PostgreSQL 17 + Redis 7       | Persistence, checkpoints, OAuth token storage |
+| **Sandbox**  | OpenSandbox (optional)        | Isolated code execution for agents            |
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌──────────────────┐
@@ -27,32 +36,58 @@ Most MCP clients today are desktop apps tied to a single user. **auxilia** is di
 │   (React)   │◀────│   (proxy)   │◀────│   (LangGraph)    │
 └─────────────┘     └─────────────┘     └────────┬─────────┘
                                                  │
-                                        ┌────────▼─────────┐
-                                        │  Remote MCP      │
-                                        │  Servers         │
-                                        └──────────────────┘
+                                    ┌────────────┼────────────┐
+                                    │            │            │
+                         ┌──────────▼──┐ ┌───────▼──────┐ ┌───▼──────────┐
+                         │ Remote MCP  │ │  PostgreSQL  │ │  OpenSandbox │
+                         │  Servers    │ │  + Redis     │ │  (optional)  │
+                         └─────────────┘ └──────────────┘ └──────────────┘
 ```
 
-## Key Concepts
+## Key concepts
 
 ### Agents
 
-An agent is an AI assistant configured with a system prompt and a set of MCP server bindings. Each agent can use tools from multiple MCP servers simultaneously.
+An **agent** is defined by a system prompt, an avatar (emoji + color), a set of MCP server bindings, and optional subagents. Each agent can use tools from multiple MCP servers at once.
 
-### MCP Servers
+### MCP servers
 
-**auxilia** connects to remote MCP servers over HTTP. You can register **official** pre-configured servers or add **custom** ones with your own URLs and credentials.
+**auxilia** connects to **remote** MCP servers over HTTP (Streamable HTTP transport). Servers are registered at the **workspace level** by admins and can be bound to any agent.
 
-### Tool Settings
+### Tools
 
-Each tool exposed by an MCP server can be configured per-agent with one of three states: **always allow**, **needs approval**, or **disabled**.
+Each tool exposed by an MCP server can be set to one of three states per agent: **always allow**, **needs approval**, or **disabled**. Approvals happen inline in the chat (or in Slack).
 
-## Supported LLM Providers
+### Sandbox
 
-| Provider  | Models                       |
-| --------- | ---------------------------- |
-| Anthropic | Claude Haiku / Sonnet / Opus |
-| OpenAI    | GPT-4o mini                  |
-| Google    | Gemini 3 Flash / Pro         |
-| DeepSeek  | DeepSeek Chat / Reasoner     |
-| LiteLLM   | Any model via proxy          |
+Turn on the **sandbox** for an agent to give it a Linux code-execution environment with `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, and `execute`. Useful for data analysis, scripting, and file manipulation tasks.
+
+### Workspace roles
+
+- **admin** — manage MCP servers, invites, personal access tokens, agent permissions
+- **editor** — create and edit agents
+- **member** — chat with agents the admin has shared with them
+
+## Supported LLM providers
+
+| Provider  | Models                                                        |
+| --------- | ------------------------------------------------------------- |
+| Anthropic | Claude Haiku 4.5, Sonnet 4.6, Opus 4.6                        |
+| OpenAI    | GPT-4o mini                                                   |
+| Google    | Gemini 3 Flash Preview, Gemini 3 Pro Preview                  |
+| DeepSeek  | DeepSeek Chat, DeepSeek Reasoner                              |
+
+Configure one or more providers via environment variables. At least one is required.
+
+## Integrations
+
+- **[Slack](/docs/integrations/slack)** — invoke workspace agents, approve tool calls, and stream responses from Slack threads
+- **[Langfuse](/docs/integrations/langfuse)** — trace LLM calls, tool calls, and costs per agent and user
+
+## Next steps
+
+- **[Get Started](/docs/get-started)** — run **auxilia** locally with Docker Compose
+- **[Deployment](/docs/deployment)** — deploy on Google Cloud Run or any Docker host
+- **[MCP Servers](/docs/mcp-servers)** — register workspace MCP servers
+- **[Agents](/docs/agents)** — create and configure agents
+- **[Sandbox](/docs/sandbox)** — enable code execution for an agent

--- a/docs/content/integrations/index.mdx
+++ b/docs/content/integrations/index.mdx
@@ -1,29 +1,38 @@
 # Integrations
 
-**auxilia** can be extended with integrations for observability, notifications, and more.
+**auxilia** ships with two first-party integrations plus a pluggable LLM provider layer.
 
-## Available Integrations
+## First-party integrations
 
-| Integration                             | Purpose                         | Status  |
-| --------------------------------------- | ------------------------------- | ------- |
-| [Langfuse](/docs/integrations/langfuse) | LLM observability and tracing   | Planned |
-| [Slack](/docs/integrations/slack)       | Notifications and bot interface | Planned |
+| Integration                               | Purpose                                            |
+| ----------------------------------------- | -------------------------------------------------- |
+| **[Slack](/docs/integrations/slack)**       | Invoke agents, approve tool calls, and stream responses inside Slack threads |
+| **[Langfuse](/docs/integrations/langfuse)** | Trace LLM calls, tool calls, token costs, and agent runs |
 
-## LLM Providers
+Both integrations are activated by setting environment variables — there is nothing else to install.
 
-**auxilia** supports multiple LLM providers out of the box. Configure API keys in your environment variables:
+## LLM providers
 
-| Provider  | Environment Variable | Models                       |
-| --------- | -------------------- | ---------------------------- |
-| OpenAI    | `OPENAI_API_KEY`     | GPT-4o mini                  |
-| Anthropic | `ANTHROPIC_API_KEY`  | Claude Haiku / Sonnet / Opus |
-| Google    | `GOOGLE_API_KEY`     | Gemini 3 Flash / Pro         |
-| DeepSeek  | `DEEPSEEK_API_KEY`   | DeepSeek Chat / Reasoner     |
-| LiteLLM   | `LITELLM_BASE_URL`   | Any model via proxy          |
+**auxilia** supports multiple providers out of the box. At least one key is required; every configured provider shows up in the model picker.
 
-## Authentication Providers
+| Provider  | Environment Variable | Models                                              |
+| --------- | -------------------- | --------------------------------------------------- |
+| Anthropic | `ANTHROPIC_API_KEY`  | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6` |
+| OpenAI    | `OPENAI_API_KEY`     | `gpt-4o-mini`                                       |
+| Google    | `GOOGLE_API_KEY`     | `gemini-3-flash-preview`, `gemini-3-pro-preview`    |
+| DeepSeek  | `DEEPSEEK_API_KEY`   | `deepseek-chat`, `deepseek-reasoner`                |
 
-| Provider       | Environment Variables                                             |
-| -------------- | ----------------------------------------------------------------- |
-| Email/Password | Built-in (no extra config)                                        |
-| Google OAuth   | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` |
+Anthropic models run with thinking enabled by default; Google models run with `include_thoughts=True`. Change the defaults in `app/model_providers/catalog.py`.
+
+## Authentication providers
+
+| Provider       | Environment variables                                                  |
+| -------------- | ---------------------------------------------------------------------- |
+| Email/password | Built-in                                                                |
+| Google OAuth   | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`       |
+
+Set `AUTH_GOOGLE_EXCLUSIVE=true` if you want to disable the email/password path and force Google sign-in.
+
+## Personal access tokens
+
+For headless usage (scripts, CI, external services), workspace admins can mint **personal access tokens** from **Settings → Tokens**. PATs authenticate API calls as the creating admin; they're hashed at rest and shown once at creation time.

--- a/docs/content/integrations/langfuse.mdx
+++ b/docs/content/integrations/langfuse.mdx
@@ -1,26 +1,28 @@
 # Langfuse
 
-[Langfuse](https://langfuse.com/) is an open-source LLM observability platform. Integrating Langfuse with **auxilia** allows you to trace agent executions, monitor token usage, and debug tool calls.
+[Langfuse](https://langfuse.com/) is an open-source LLM observability platform. **auxilia** ships with a built-in Langfuse callback that traces every agent run — model calls, tool invocations, token counts, latency, and cost — without any code changes.
 
-> This integration is **planned** and not yet available. This page documents the intended setup.
+## What you get
 
-## What Langfuse Provides
+- **Traces** — per-message traces showing LLM calls, MCP tool calls, latencies, and token usage
+- **Cost tracking** — token and cost breakdowns per agent, user, or thread
+- **Evaluation** — score and annotate agent responses in the Langfuse UI
+- **Prompt versioning** — manage and compare system prompts across agents
 
-- **Tracing** — See the full execution flow of each agent interaction, including LLM calls, tool invocations, and response times
-- **Cost tracking** — Monitor token usage and estimated costs per agent, user, or thread
-- **Evaluation** — Score and annotate agent responses for quality monitoring
-- **Prompt management** — Version and manage system prompts centrally
+## Enable it
 
-## Planned Configuration
-
-The integration will use the LangChain callback handler for Langfuse. Configuration will be done via environment variables:
+Set these three environment variables on the backend:
 
 ```env
-LANGFUSE_PUBLIC_KEY=pk-...
-LANGFUSE_SECRET_KEY=sk-...
-LANGFUSE_HOST=https://cloud.langfuse.com  # or self-hosted URL
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_BASE_URL=https://cloud.langfuse.com  # or your self-hosted URL
 ```
 
-## Self-Hosted Langfuse
+On startup, the backend instantiates a shared `Langfuse` client and attaches a `CallbackHandler` to every LangGraph invocation. If any of the three variables is missing, the integration is silently disabled.
 
-Langfuse can be self-hosted alongside **auxilia** for full data control. See the [Langfuse self-hosting guide](https://langfuse.com/docs/deployment/self-host) for setup instructions.
+See `app/integrations/langfuse/callback.py` for the wiring.
+
+## Self-hosted Langfuse
+
+Langfuse is itself open source. You can run it alongside **auxilia** for full data ownership — follow the [Langfuse self-hosting guide](https://langfuse.com/self-hosting) and point `LANGFUSE_BASE_URL` at your instance.

--- a/docs/content/integrations/slack.mdx
+++ b/docs/content/integrations/slack.mdx
@@ -1,36 +1,71 @@
 # Slack
 
-Integrating Slack with \*auxilia enables your team to interact with agents directly from Slack channels and receive notifications about agent activity.
+The Slack integration lets your team talk to workspace agents directly from Slack threads. It reuses the same agents, MCP servers, and tool-approval flows as the web app — responses stream token-by-token, tool-call approvals come through as Block Kit messages.
 
-> This integration is **planned** and not yet available. This page documents the intended setup.
+## What it does
 
-## Planned Features
+- **Agent picker** — mention `@auxilia` in a channel or start an assistant thread; the bot replies with a list of agents the Slack user has access to
+- **Thread-based chat** — each Slack thread maps to a persistent **auxilia** thread, so the agent remembers context across messages
+- **Tool approvals** — tools set to "needs approval" post **Approve / Reject** buttons in the thread
+- **Streaming** — assistant replies are updated in-place as the LLM generates them
 
-### Slack Bot
+## How a Slack user is matched to an **auxilia** user
 
-- **Chat with agents** — Mention the bot in a channel or DM to interact with a specific agent
-- **Thread-based conversations** — Each Slack thread maps to an **auxilia** chat thread
-- **Tool approval in Slack** — Approve or reject tool calls directly from Slack notifications
+When a Slack message comes in, **auxilia** looks up the Slack user's email via `users.info` and matches it against the workspace's user table. If there's no match, the bot replies with a message telling the user to sign in to **auxilia** first (which creates the account).
 
-### Notifications
+Slack users therefore need an **auxilia** account with the **same email address** as their Slack profile.
 
-- **Agent activity alerts** — Get notified when an agent completes a task or encounters an error
-- **Approval requests** — Receive Slack messages when a tool call needs human approval
+## Configure the integration
 
-## Planned Configuration
+Set these environment variables on the backend:
 
 ```env
-SLACK_BOT_TOKEN=xoxb-...
 SLACK_SIGNING_SECRET=...
-SLACK_APP_TOKEN=xapp-...
+SLACK_BOT_TOKEN=xoxb-...
 ```
 
-## Creating a Slack App
+If either value is missing, the Slack endpoints still mount but will reject all incoming requests.
 
-When available, setup will involve:
+## Create the Slack app
 
-1. Create a new Slack app at [api.slack.com/apps](https://api.slack.com/apps)
-2. Enable **Socket Mode** for real-time events
-3. Add **Bot Token Scopes**: `chat:write`, `app_mentions:read`, `channels:history`
-4. Install the app to your workspace
-5. Copy the tokens to your **auxilia** environment
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App → From scratch**
+2. Give it a name (e.g. `auxilia`) and pick your workspace
+3. Under **OAuth & Permissions**, add the **Bot Token Scopes**:
+   - `app_mentions:read`
+   - `assistant:write`
+   - `channels:history`, `groups:history`, `im:history`, `mpim:history`
+   - `chat:write`
+   - `users:read`
+   - `users:read.email`
+4. Install the app to your workspace and copy the **Bot User OAuth Token** (`xoxb-...`) into `SLACK_BOT_TOKEN`
+5. Copy the **Signing Secret** from **Basic Information** into `SLACK_SIGNING_SECRET`
+
+## Event subscriptions
+
+Under **Event Subscriptions**, point Slack at:
+
+```
+<BACKEND_URL>/integrations/slack/events
+```
+
+Subscribe to bot events:
+
+- `app_mention`
+- `assistant_thread_started`
+- `message.channels`, `message.groups`, `message.im`, `message.mpim`
+
+Under **Interactivity & Shortcuts**, enable interactivity and set the **Request URL** to:
+
+```
+<BACKEND_URL>/integrations/slack/interactions
+```
+
+This is where **Approve / Reject** button clicks are delivered.
+
+## Usage
+
+- `@auxilia` in any channel the bot is in → posts an agent picker
+- Pick an agent → starts a thread
+- Send messages in the thread → the agent streams replies and may request tool approvals
+
+To reuse an agent across multiple Slack threads, just start a new thread and pick the same agent — each thread has its own memory.

--- a/docs/content/mcp-servers/authentication.mdx
+++ b/docs/content/mcp-servers/authentication.mdx
@@ -1,70 +1,76 @@
 # MCP Server Authentication
 
-**auxilia** supports three authentication methods for connecting to remote MCP servers.
+**auxilia** supports three authentication methods for remote MCP servers.
 
-## No Authentication
+## None
 
-Some MCP servers don't require any credentials. Select **None** as the auth type when adding the server.
+Some MCP servers don't require credentials (e.g. DeepWiki). Select **None** as the auth type.
 
 ## Bearer Token (API Key)
 
 For servers that accept a static API key or token:
 
 1. Select **API Key** as the auth type
-2. Enter your API key or token
+2. Paste the key
 
-**auxilia** encrypts the key with AES before storing it in the database. On each request to the MCP server, the key is sent as a `Bearer` token in the `Authorization` header:
+**auxilia** encrypts the key with **AES-GCM** before writing it to the database (the encryption key is derived from the `SALT` environment variable — see `app/mcp/servers/encryption.py`). On every request the key is sent as:
 
 ```
-Authorization: Bearer your-api-key
+Authorization: Bearer <your-api-key>
 ```
+
+The key is shared across all users of the workspace.
 
 ## OAuth 2.0
 
-For servers that use OAuth 2.0, **auxilia** supports two credential management approaches:
+For servers that use OAuth, **auxilia** supports two credential-management styles:
 
 ### Dynamic Client Registration (DCR)
 
-With DCR, **auxilia** automatically registers itself as an OAuth client with the MCP server. This is the simplest setup — just click **Connect** and authorize through the provider's consent screen.
+With DCR, **auxilia** registers itself as an OAuth client with the MCP server on the fly — you don't need to create anything in the provider's dashboard.
 
-**How it works:**
+Flow:
 
-1. You click **Connect** on the MCP server
-2. **auxilia** contacts the server's OAuth metadata endpoint
-3. If the server supports DCR, **auxilia** registers a client dynamically
-4. You're redirected to the provider's consent screen
-5. After authorization, tokens are stored in Redis per user
+1. User clicks **Connect** on the server card
+2. **auxilia** fetches the server's OAuth metadata
+3. If DCR is supported, a client is registered automatically
+4. User is redirected to the provider's consent screen
+5. On callback, tokens are stored in Redis, scoped to that user
 
-DCR is used by most official servers (Notion, Linear, Sentry, Stripe, etc.).
+DCR is used by most official servers (Notion, Linear, Sentry, Stripe, Supabase, Canva, Intercom, Amplitude, Atlassian, Slack).
 
-### Static OAuth Credentials
+### Static OAuth credentials
 
-Some providers require you to create an OAuth application manually and provide the credentials to **auxilia**.
+Some providers require you to create an OAuth application yourself and give **auxilia** the client ID and secret.
 
-When adding or editing the MCP server:
+Flow:
 
-1. Select **OAuth 2.0** as the auth type
-2. Enter the **Client ID** and **Client Secret** from your OAuth app
+1. Admin creates an OAuth app in the provider's dashboard
+2. Admin enters **Client ID** + **Client Secret** when installing the server in **auxilia**
+3. User clicks **Connect**
+4. **auxilia** uses the pre-registered credentials with a PKCE challenge
+5. User is redirected to the provider's consent screen
+6. On callback, tokens are stored in Redis, scoped to that user
 
-**How it works:**
+Static credentials are currently used by **GitHub**, **HubSpot**, and **BigQuery** from the official catalog.
 
-1. You click **Connect** on the MCP server
-2. **auxilia** uses your pre-registered client credentials
-3. A PKCE challenge is generated for security
-4. You're redirected to the provider's consent screen
-5. After authorization, **auxilia** exchanges the code for tokens
-6. Tokens are stored in Redis, scoped to your user account
+The redirect URI you need to configure in the provider is always:
 
-### Token Storage
+```
+<FRONTEND_URL>/api/backend/mcp-servers/oauth/callback
+```
 
-OAuth tokens are stored in Redis with the key pattern:
+## Token storage
+
+OAuth tokens live in Redis under keys of the form:
 
 ```
 mcp:{user_id}:{mcp_server_id}:tokens
 ```
 
-Each user has their own set of tokens per MCP server. Tokens are refreshed automatically when they expire.
+Each user has their own token set for every MCP server they've connected. Tokens are refreshed automatically when they expire. OAuth client secrets (for static-credential servers) are encrypted with AES-GCM in Postgres.
 
-### Reconnecting
+## Reconnecting and resetting
 
-If a token expires or is revoked, click **Connect** again on the MCP server to re-authorize. The existing tokens will be replaced.
+- **Reconnect** — click **Connect** again to re-authorize. Existing tokens are replaced.
+- **Reset** — admins can wipe all stored OAuth state for a server (all users, all clients). Useful after changing static credentials or rotating an OAuth app.

--- a/docs/content/mcp-servers/examples/bigquery.mdx
+++ b/docs/content/mcp-servers/examples/bigquery.mdx
@@ -2,22 +2,22 @@
 
 This guide walks through connecting the BigQuery MCP server to **auxilia**. BigQuery uses **Google OAuth 2.0** with static credentials.
 
-## 1. Create a Google Cloud OAuth Client
+## 1. Create a Google Cloud OAuth client
 
 1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
-2. Select your project (or create a new one)
-3. Navigate to **APIs & Services** → **Credentials**
-4. Click **Create Credentials** → **OAuth client ID**
+2. Select (or create) your project
+3. **APIs & Services** → **Credentials**
+4. **Create Credentials** → **OAuth client ID**
 5. If prompted, configure the OAuth consent screen first:
    - **User Type**: External (or Internal for Google Workspace)
-   - **App name**: **auxilia** MCP
-   - **Scopes**: Add `https://www.googleapis.com/auth/bigquery`
+   - **App name**: auxilia MCP
+   - **Scopes**: add `https://www.googleapis.com/auth/bigquery`
 6. Back in **Create OAuth client ID**:
    - **Application type**: Web application
-   - **Name**: **auxilia** MCP
-   - **Authorized redirect URIs**: Add:
+   - **Name**: auxilia MCP
+   - **Authorized redirect URIs**:
      ```
-     https://your-auxilia-domain.com/api/backend/mcp-servers/oauth/callback
+     <FRONTEND_URL>/api/backend/mcp-servers/oauth/callback
      ```
      For local development:
      ```
@@ -28,65 +28,49 @@ This guide walks through connecting the BigQuery MCP server to **auxilia**. BigQ
 
 ## 2. Enable the BigQuery API
 
-Make sure the BigQuery API is enabled for your project:
-
 ```bash
 gcloud services enable bigquery.googleapis.com \
   --project=your-project-id
 ```
 
-## 3. Install the BigQuery MCP Server
+## 3. Install the BigQuery MCP server
 
-In **auxilia**, navigate to **MCP Servers**:
+In **auxilia**:
 
 1. Find **BigQuery** in the official servers list
 2. Click **Install**
-3. Enter the credentials from your Google Cloud OAuth client:
-   - **Client ID**: Your Google OAuth client ID
-   - **Client Secret**: Your Google OAuth client secret
+3. Enter the **Client ID** and **Client Secret** from step 1
 
-## 4. Connect Your Account
+## 4. Connect your account
 
-1. Click the **Connect** button on the BigQuery server card
-2. You'll be redirected to Google's consent screen
-3. Select your Google account
-4. Grant BigQuery access permissions
-5. You'll be redirected back to **auxilia**
+1. Click **Connect** on the BigQuery server card
+2. Pick your Google account on the consent screen
+3. Grant BigQuery access
 
-**auxilia** automatically requests the `https://www.googleapis.com/auth/bigquery` scope.
+**auxilia** requests the `https://www.googleapis.com/auth/bigquery` scope automatically.
 
-## 5. Add to an Agent
+## 5. Add to an agent
 
-1. Navigate to an agent's configuration page
-2. Click **Add MCP Server**
-3. Select **BigQuery** from the list
-4. Configure [tool settings](/docs/tools/settings) as needed
+1. Open an agent's configuration page
+2. **Add MCP Server** → **BigQuery**
+3. Configure [tool settings](/docs/tools/settings) — `execute_sql_readonly` is safe to auto-approve; `execute_sql` (write) is a good candidate for **needs approval**
 
-## Available Tools
+## Available tools
 
-The BigQuery MCP server typically provides tools for:
+The BigQuery MCP server provides tools for:
 
-- Listing datasets and tables in a project
-- Querying data with SQL
-- Describing table schemas
-- Listing dataset IDs
+- `list_dataset_ids`, `list_table_ids`
+- `get_dataset_info`, `get_table_info`
+- `execute_sql_readonly`, `execute_sql`
 
 ## Troubleshooting
 
-### "Access denied" error
+### "Access denied"
 
-Ensure that:
-
-- The BigQuery API is enabled in your Google Cloud project
-- Your Google account has BigQuery permissions in the target project
-- The OAuth consent screen includes the BigQuery scope
+- The BigQuery API must be enabled in your Google Cloud project
+- The Google account you connected must have BigQuery permissions on the target project
+- The OAuth consent screen must include the BigQuery scope
 
 ### "Redirect URI mismatch"
 
-The redirect URI in your Google Cloud OAuth client must exactly match:
-
-```
-https://your-auxilia-domain.com/api/backend/mcp-servers/oauth/callback
-```
-
-Make sure there are no trailing slashes or protocol mismatches.
+The redirect URI in your Google Cloud OAuth client must match `<FRONTEND_URL>/api/backend/mcp-servers/oauth/callback` exactly — no trailing slashes, no protocol mismatches.

--- a/docs/content/mcp-servers/examples/github.mdx
+++ b/docs/content/mcp-servers/examples/github.mdx
@@ -1,17 +1,17 @@
 # GitHub MCP Server
 
-This guide walks through connecting the GitHub MCP server to **auxilia**. GitHub uses **static OAuth credentials**, requiring you to create a GitHub OAuth App or GitHub App.
+This guide walks through connecting the GitHub MCP server to **auxilia**. GitHub uses **static OAuth credentials**, so you need to create a GitHub OAuth App first.
 
-## 1. Create a GitHub OAuth App
+## 1. Create a GitHub OAuth app
 
 1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
-2. Click **OAuth Apps** → **New OAuth App**
-3. Fill in the details:
-   - **Application name**: **auxilia** MCP
-   - **Homepage URL**: `https://your-auxilia-domain.com`
+2. **OAuth Apps** → **New OAuth App**
+3. Fill in:
+   - **Application name**: auxilia MCP
+   - **Homepage URL**: your deployment URL, e.g. `https://auxilia.example.com`
    - **Authorization callback URL**:
      ```
-     https://your-auxilia-domain.com/api/backend/mcp-servers/oauth/callback
+     <FRONTEND_URL>/api/backend/mcp-servers/oauth/callback
      ```
      For local development:
      ```
@@ -21,49 +21,33 @@ This guide walks through connecting the GitHub MCP server to **auxilia**. GitHub
 5. Copy the **Client ID**
 6. Click **Generate a new client secret** and copy it
 
-## 2. Install the GitHub MCP Server
+## 2. Install the GitHub MCP server
 
 In **auxilia**, navigate to **MCP Servers**:
 
 1. Find **GitHub** in the official servers list
 2. Click **Install**
-3. Enter the credentials from your GitHub OAuth App:
-   - **Client ID**: Your GitHub app's client ID
-   - **Client Secret**: Your GitHub app's client secret
+3. Enter the **Client ID** and **Client Secret**
 
-## 3. Connect Your Account
+## 3. Connect your account
 
-1. Click the **Connect** button on the GitHub server card
-2. You'll be redirected to GitHub's authorization page
-3. Review the permissions and click **Authorize**
-4. You'll be redirected back to **auxilia**
+1. Click **Connect** on the GitHub server card
+2. Review the permissions on GitHub's authorization page and click **Authorize**
+3. You're redirected back to **auxilia**
 
-## 4. Add to an Agent
+## 4. Add to an agent
 
-1. Navigate to an agent's configuration page
-2. Click **Add MCP Server**
-3. Select **GitHub** from the list
-4. Configure [tool settings](/docs/tools/settings) as needed
+1. Open an agent's configuration page
+2. Click **Add MCP Server** → **GitHub**
+3. Set [tool permissions](/docs/tools/settings) — PR / issue creation and commit-writing tools are good candidates for **needs approval**
 
-## Available Tools
+## Alternative: personal access token
 
-The GitHub MCP server typically provides tools for:
-
-- Searching repositories, issues, and pull requests
-- Reading file contents and repository structure
-- Creating and updating issues
-- Managing pull requests
-- Working with GitHub Actions
-- Accessing organization and user data
-
-## Alternative: Personal Access Token
-
-If you prefer not to set up OAuth, you can also connect using a GitHub Personal Access Token:
+If you'd rather skip OAuth, connect with a GitHub PAT instead:
 
 1. Go to [GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens](https://github.com/settings/tokens?type=beta)
-2. Click **Generate new token**
-3. Select the repositories and permissions your agent needs
-4. Copy the token
-5. In **auxilia**, add the GitHub MCP server as a **custom server** with auth type **API Key** and paste your token
+2. **Generate new token** → pick the repositories and permissions the agent needs
+3. Copy the token
+4. In **auxilia**, **Add MCP Server** as a **custom** server, auth type **API key**, URL `https://api.githubcopilot.com/mcp`, token pasted into the **API key** field
 
-This approach is simpler but the token is tied to a single user account and has a fixed expiration.
+The PAT is tied to a single GitHub account and has a fixed expiration, but it's simpler than OAuth for personal or single-user workspaces.

--- a/docs/content/mcp-servers/examples/hubspot.mdx
+++ b/docs/content/mcp-servers/examples/hubspot.mdx
@@ -1,71 +1,67 @@
 # HubSpot MCP Server
 
-This guide walks through connecting the HubSpot MCP server to **auxilia**. HubSpot uses **static OAuth credentials**, so you need to create an OAuth app in HubSpot first.
+This guide walks through connecting the HubSpot MCP server to **auxilia**. HubSpot uses **static OAuth credentials**, so you need to register an OAuth app in HubSpot first.
 
-## 1. Create a HubSpot OAuth App
+## 1. Create a HubSpot OAuth app
 
 1. Go to the [HubSpot Developer Portal](https://developers.hubspot.com/)
-2. Navigate to **Apps** → **Create app**
+2. **Apps** → **Create app**
 3. Fill in the app details:
    - **App name**: auxilia MCP
    - **Description**: MCP integration for auxilia
-4. Go to the **Auth** tab
+4. Open the **Auth** tab
 5. Set the **Redirect URL** to:
    ```
-   https://your-auxilia-domain.com/api/backend/mcp-servers/oauth/callback
+   <FRONTEND_URL>/api/backend/mcp-servers/oauth/callback
+   ```
+   For example:
+   ```
+   https://auxilia.example.com/api/backend/mcp-servers/oauth/callback
    ```
    For local development:
    ```
    http://localhost:3000/api/backend/mcp-servers/oauth/callback
    ```
-6. Under **Scopes**, add the scopes required by the HubSpot MCP server (typically CRM scopes like `crm.objects.contacts.read`, `crm.objects.deals.read`, etc.)
+6. Under **Scopes**, add the scopes required by the HubSpot MCP server (CRM scopes — typically `crm.objects.contacts.read`, `crm.objects.deals.read`, `crm.objects.companies.read`, and the matching write scopes if the agent needs to mutate data)
 7. Click **Create app**
 8. Copy the **Client ID** and **Client Secret** from the Auth tab
 
-## 2. Install the HubSpot MCP Server
+## 2. Install the HubSpot MCP server
 
 In **auxilia**, navigate to **MCP Servers**:
 
 1. Find **HubSpot** in the official servers list
 2. Click **Install**
-3. Enter the credentials from your HubSpot OAuth app:
-   - **Client ID**: Your HubSpot app's client ID
-   - **Client Secret**: Your HubSpot app's client secret
+3. Enter:
+   - **Client ID** — from the HubSpot Auth tab
+   - **Client Secret** — from the HubSpot Auth tab
 
-## 3. Connect Your Account
+## 3. Connect your account
 
-1. Click the **Connect** button on the HubSpot server card
-2. You'll be redirected to HubSpot's authorization page
+1. Click **Connect** on the HubSpot server card
+2. You're redirected to HubSpot's authorization page
 3. Select the HubSpot account to connect
 4. Grant the requested permissions
-5. You'll be redirected back to **auxilia**
+5. You're redirected back to **auxilia**
 
-The server card should now show a connected status.
+The server card now shows as connected.
 
-## 4. Add to an Agent
+## 4. Add to an agent
 
-1. Navigate to an agent's configuration page
-2. Click **Add MCP Server**
-3. Select **HubSpot** from the list
-4. Configure [tool settings](/docs/tools/settings) for each HubSpot tool
-
-## Available Tools
-
-The HubSpot MCP server typically provides tools for:
-
-- Searching and managing contacts
-- Managing deals and pipelines
-- Working with companies
-- Querying HubSpot CRM data
+1. Open an agent's configuration page
+2. Click **Add MCP Server** and pick **HubSpot**
+3. Configure [tool settings](/docs/tools/settings) — for HubSpot, write tools are a good candidate for **needs approval**
 
 ## Troubleshooting
 
-### "Invalid redirect URI" error
+### "Invalid redirect URI"
 
-Make sure the redirect URL in your HubSpot app exactly matches your **auxilia** deployment URL, including the path `/api/backend/mcp-servers/oauth/callback`.
+Make sure the redirect URL in your HubSpot app matches `<FRONTEND_URL>/api/backend/mcp-servers/oauth/callback` exactly — no trailing slash, protocol, or subdomain mismatches.
 
-### "Token exchange failed" error
+### "Token exchange failed"
 
 Verify that:
 
-- Your HubSpot app has the required scopes enabled
+- Your HubSpot app has the scopes the MCP server requests
+- The client secret you entered in **auxilia** matches the one shown in HubSpot
+- The HubSpot app has been fully created (not still in draft)

--- a/docs/content/mcp-servers/index.mdx
+++ b/docs/content/mcp-servers/index.mdx
@@ -1,30 +1,44 @@
 # MCP Servers
 
-**auxilia** connects to remote [Model Context Protocol](https://modelcontextprotocol.io/) servers to give agents access to external tools and data sources. Unlike desktop MCP clients, **auxilia** only supports **remote MCP servers** — it connects over HTTP with Server-Sent Events (SSE), not local stdio processes.
+**auxilia** connects to remote [Model Context Protocol](https://modelcontextprotocol.io/) servers to give agents access to external tools and data sources. Unlike desktop MCP clients, **auxilia** only supports **remote MCP servers** — it talks to them over HTTP using the [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport, not local stdio processes.
 
-## How It Works
+## How it works
 
 ```
-┌──────────────┐           HTTPS           ┌──────────────────┐
-│   auxilia    │ ◀──────────────────────▶  │   Remote MCP     │
-│   Backend    │    Tool calls + Results   │   Server         │
-└──────────────┘                           └──────────────────┘
+┌──────────────┐        Streamable HTTP       ┌──────────────────┐
+│   auxilia    │ ◀──────────────────────────▶ │   Remote MCP     │
+│   Backend    │   tools/list + tools/call    │   Server         │
+└──────────────┘                              └──────────────────┘
 ```
 
-When an agent runs, **auxilia**'s backend establishes connections to all MCP servers bound to that agent. It discovers available tools, filters them based on [tool settings](/docs/tools/settings), and makes them available to the LLM.
+When an agent runs, the backend opens a fresh MCP session for each server bound to the agent, authenticates (API key or per-user OAuth tokens), discovers the available tools, filters them by the agent's [tool settings](/docs/tools/settings), and hands them to the LLM.
 
-## Workspace-Level Registration
+## Workspace-level registration
 
-MCP servers are registered at the **workspace level**. Once added, any agent in the workspace can be configured to use them. This avoids duplicate setup across agents.
+![MCP servers page](https://pub-7a6e8912b3c448b8a8bfa47a0363f7bc.r2.dev/docs/mcp_servers.png)
 
-## Adding an MCP Server
+MCP servers are registered at the **workspace level** by an admin. Once registered, any agent in the workspace can bind them. This avoids duplicate setup across agents and centralizes credential management.
 
-Navigate to the **MCP Servers** page from the sidebar. You can:
+Only users with the **admin** role can add, edit, or delete MCP servers. Editors and members can see which servers exist and bind them to agents they own.
 
-1. **Install an official server** — Choose from pre-configured servers like HubSpot, GitHub, Notion, and more
-2. **Add a custom server** — Enter the URL and credentials for any remote MCP server
+## Adding an MCP server
 
-## Next Steps
+Navigate to **MCP Servers** in the sidebar. You have two options:
+
+1. **Set up an official server** — a pre-configured server from the built-in catalog (Notion, Linear, GitHub, Sentry, Stripe, HubSpot, BigQuery, …). Click **Install** and, if required, supply OAuth client credentials.
+2. **Add a custom server** — any remote MCP server. Click **Add MCP Server** and supply the URL, a display name, and the authentication method.
+
+![MCP servers page](https://pub-7a6e8912b3c448b8a8bfa47a0363f7bc.r2.dev/docs/mcp_servers_dialog.png)
+
+See [Official vs Custom](/docs/mcp-servers/official-vs-custom) for the difference between the two.
+
+## Per-user connections
+
+Registering a server at the workspace level does **not** connect it for everyone automatically. OAuth-based servers require each user to click **Connect** on the server card and complete the consent flow. Tokens are stored per-user in Redis.
+
+API-key servers share a single encrypted key across the workspace.
+
+## Next
 
 - [Official vs Custom servers](/docs/mcp-servers/official-vs-custom)
 - [Authentication methods](/docs/mcp-servers/authentication)

--- a/docs/content/mcp-servers/official-vs-custom.mdx
+++ b/docs/content/mcp-servers/official-vs-custom.mdx
@@ -1,51 +1,61 @@
 # Official vs Custom MCP Servers
 
-**auxilia** supports two categories of MCP servers: **official** (pre-configured) and **custom** (user-registered).
+**auxilia** distinguishes two categories of MCP servers: **official** (pre-configured in the catalog) and **custom** (user-registered by URL).
 
-## Official MCP Servers
+## Official MCP servers
 
-Official servers are pre-configured in **auxilia** with their URLs, metadata, and OAuth capabilities. They appear in a dedicated section on the MCP Servers page with an **Install** button.
+Official servers are seeded into the database with their URL, icon, and authentication type. They appear under an **Official** section on the MCP Servers page with an **Install** button.
 
-Currently available official servers include:
+| Server     | Auth      | OAuth style        |
+| ---------- | --------- | ------------------ |
+| Notion     | OAuth 2.0 | DCR                |
+| Atlassian  | OAuth 2.0 | DCR                |
+| Linear     | OAuth 2.0 | DCR                |
+| Sentry     | OAuth 2.0 | DCR                |
+| Stripe     | OAuth 2.0 | DCR                |
+| Canva      | OAuth 2.0 | DCR                |
+| Intercom   | OAuth 2.0 | DCR                |
+| DeepWiki   | None      | —                  |
+| Supabase   | OAuth 2.0 | DCR                |
+| Amplitude  | OAuth 2.0 | DCR                |
+| GitHub     | OAuth 2.0 | Static credentials |
+| HubSpot    | OAuth 2.0 | Static credentials |
+| BigQuery   | OAuth 2.0 | Static credentials |
+| Slack      | OAuth 2.0 | DCR                |
 
-| Server    | Auth Type | OAuth Method       |
-| --------- | --------- | ------------------ |
-| Notion    | OAuth 2.0 | DCR                |
-| Atlassian | OAuth 2.0 | DCR                |
-| Linear    | OAuth 2.0 | DCR                |
-| Sentry    | OAuth 2.0 | DCR                |
-| Stripe    | OAuth 2.0 | DCR                |
-| Canva     | OAuth 2.0 | DCR                |
-| Intercom  | OAuth 2.0 | DCR                |
-| Supabase  | OAuth 2.0 | DCR                |
-| HubSpot   | OAuth 2.0 | Static credentials |
-| GitHub    | OAuth 2.0 | Static credentials |
-| BigQuery  | OAuth 2.0 | Static credentials |
+Installing an official server creates a workspace MCP server entry pointing at the correct URL with the correct auth type.
 
-When you install an official server, **auxilia** creates a workspace MCP server entry with the correct URL and authentication configuration.
+### DCR servers
 
-### DCR Servers
+Servers that support [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) handle OAuth automatically. When a user clicks **Connect**, **auxilia** registers itself as an OAuth client on the fly — no client ID or secret needed.
 
-Servers that support **Dynamic Client Registration (DCR)** handle OAuth automatically. When you click **Connect**, **auxilia** registers itself as an OAuth client with the MCP server on the fly. No client ID or secret is needed from you.
+### Static-credential servers
 
-### Static Credential Servers
+Some providers (GitHub, HubSpot, BigQuery, …) require you to register an OAuth application yourself in their dashboard and supply the client ID and secret to **auxilia** at install time.
 
-Some servers (HubSpot, GitHub, BigQuery) require you to register an OAuth app yourself and provide the client ID and secret. See the [setup examples](/docs/mcp-servers/examples/hubspot) for step-by-step guides.
+See the step-by-step guides:
 
-## Custom MCP Servers
+- [HubSpot](/docs/mcp-servers/examples/hubspot)
+- [GitHub](/docs/mcp-servers/examples/github)
+- [BigQuery](/docs/mcp-servers/examples/bigquery)
 
-You can add any remote MCP server by providing its URL. Click **Add MCP Server** and fill in:
+## Custom MCP servers
 
-| Field       | Required | Description                                   |
-| ----------- | -------- | --------------------------------------------- |
-| URL         | Yes      | The MCP server endpoint (must support SSE)    |
-| Name        | Yes      | Display name in the UI                        |
-| Description | No       | Brief description of what the server provides |
-| Icon URL    | No       | URL to an icon for the server card            |
-| Auth Type   | Yes      | `None`, `API Key`, or `OAuth 2.0`             |
+You can add any remote MCP server by URL. Click **Add MCP Server** and fill in:
 
-### When to Use Custom Servers
+| Field       | Required | Description                                          |
+| ----------- | -------- | ---------------------------------------------------- |
+| URL         | yes      | MCP endpoint (must support Streamable HTTP)          |
+| Name        | yes      | Display name                                         |
+| Description | no       | Short description shown on the server card           |
+| Icon URL    | no       | Icon displayed on the card                           |
+| Auth Type   | yes      | `none`, `api_key`, or `oauth2`                       |
+| API key     | if `api_key`     | Sent as `Authorization: Bearer <key>`        |
+| OAuth creds | if `oauth2` (and no DCR) | Client ID + Secret                   |
 
-- Self-hosted MCP servers within your infrastructure
-- MCP servers not yet in the official list
-- Servers requiring specific authentication configurations
+### When to use a custom server
+
+- Self-hosted MCP servers inside your own infrastructure
+- MCP servers not yet in the official catalog
+- Static API-key servers (not in the official list)
+- Temporary / experimental servers

--- a/docs/content/sandbox/_meta.js
+++ b/docs/content/sandbox/_meta.js
@@ -1,0 +1,6 @@
+export default {
+  index: 'Overview',
+  setup: 'Setup',
+  tools: 'Tools',
+  security: 'Security'
+}

--- a/docs/content/sandbox/index.mdx
+++ b/docs/content/sandbox/index.mdx
@@ -1,0 +1,70 @@
+# Sandbox
+
+The **sandbox** gives an agent a private, isolated Linux environment for executing code, reading and writing files, searching, and running shell commands. It turns any agent into a lightweight data-analysis or scripting agent without handing it access to the host.
+
+## Why a sandbox
+
+MCP servers cover most structured actions (query HubSpot, search Sentry, open a PR in GitHub). But some tasks don't fit that shape — they need a **scratch environment** with a filesystem and a Python shell:
+
+- Analyze a CSV the user uploads and produce a chart
+- Write, lint, and run a Python script against live data
+- Iterate on a SQL query using `bq` or `psql`
+- Transform a payload with `jq` before feeding it to another tool
+
+The sandbox provides that environment and exposes it to the agent as a toolset.
+
+## How it works
+
+**auxilia**'s sandbox integration is built on [OpenSandbox](https://github.com/langchain-ai/opensandbox), an open-source sandbox runtime that spawns short-lived Linux containers on demand. The wiring:
+
+```
+┌─────────────────────┐      create_sandbox()      ┌────────────────────┐
+│  Agent (LangGraph)  │ ───────────────────────▶   │   OpenSandbox      │
+│                     │ ◀───── sandbox_id ──────── │   controller       │
+└─────────────────────┘                            └─────────┬──────────┘
+         │                                                   │
+         │  execute("python script.py")                      │
+         │  read_file("/tmp/out.json")                       │
+         │  …                                                ▼
+         │                                        ┌──────────────────────┐
+         │                                        │   Container          │
+         └──────────────────────────────────────▶ │   (python:3.12-slim) │
+                                                  └──────────────────────┘
+```
+
+The sandbox is **lazy**: it is not created when an agent starts. The LLM decides when (and whether) to call `create_sandbox`, and only then does a container come up. A default container has a **30-minute TTL** that can be renewed via `connect_sandbox`.
+
+Inside a conversation, the agent can create one sandbox, keep reusing it across turns, and reconnect to it after a browser refresh.
+
+## Enable it for an agent
+
+1. Configure the sandbox runtime (see [Setup](/docs/sandbox/setup))
+2. On the agent's configuration page, toggle **Code execution** on
+
+When the toggle is on (and `OPEN_SANDBOX_DOMAIN` is configured on the backend), the agent is built with LangGraph's `create_deep_agent` — which layers in the sandbox management tools plus the standard file-ops tools.
+
+If the runtime is **not** configured, the toggle is still visible but has no effect — the backend only enables the sandbox branch when `OPEN_SANDBOX_DOMAIN` is set.
+
+## What the agent can do
+
+Once the agent calls `create_sandbox`, it gets this toolset automatically:
+
+| Tool              | What it does                                                        |
+| ----------------- | ------------------------------------------------------------------- |
+| `create_sandbox`  | Spin up a new container (lazy; first call only)                     |
+| `connect_sandbox` | Reconnect to an existing container by ID and renew its TTL          |
+| `ls`              | List files in a directory with metadata (size, mtime)               |
+| `read_file`       | Read a file with line numbers; supports offset/limit for big files  |
+| `write_file`      | Create a new file                                                   |
+| `edit_file`       | Exact string replacement in an existing file (with global mode)     |
+| `glob`            | Find files matching a pattern (`**/*.py`)                           |
+| `grep`            | Search file contents; outputs files-only, content, or counts        |
+| `execute`         | Run a shell command                                                 |
+
+See [Tools](/docs/sandbox/tools) for details.
+
+## Next
+
+- **[Setup](/docs/sandbox/setup)** — run OpenSandbox and point **auxilia** at it
+- **[Tools](/docs/sandbox/tools)** — details on every sandbox tool
+- **[Security](/docs/sandbox/security)** — isolation, volume mounts, timeouts

--- a/docs/content/sandbox/security.mdx
+++ b/docs/content/sandbox/security.mdx
@@ -1,0 +1,57 @@
+# Sandbox Security
+
+The sandbox lets an LLM run arbitrary shell commands against a filesystem. That is a powerful capability and worth thinking about carefully.
+
+## Isolation model
+
+Every sandbox is a short-lived container managed by [OpenSandbox](https://github.com/langchain-ai/opensandbox). Containers:
+
+- Are **per-conversation** — the sandbox tied to thread A cannot be reached from thread B
+- Have a **TTL** (default 30 minutes); after expiry they are destroyed and any state inside is lost
+- Are created **on demand** when the LLM calls `create_sandbox` — no idle containers sit around
+
+The **auxilia** backend never executes commands itself — it always delegates to the OpenSandbox controller. So the blast radius of a malicious prompt is whatever your OpenSandbox deployment allows the container to do.
+
+## Volume mounts
+
+You can mount host paths into every sandbox via `OPEN_SANDBOX_VOLUME_MOUNTS`:
+
+```env
+OPEN_SANDBOX_VOLUME_MOUNTS=/srv/shared:/workspace:ro,/tmp/auxilia:/mnt/scratch
+```
+
+Format: `host_path:sandbox_path[:ro]`, comma-separated.
+
+- Each entry becomes a volume on every sandbox spun up by this backend
+- The `:ro` suffix mounts read-only
+- Host paths that don't exist are skipped with a warning at startup
+- Host paths with `~` are expanded to the backend's home directory
+
+Treat the host paths you mount as **public** to any agent with the sandbox enabled. If you mount `/srv/data` read-only, every sandboxed agent can read it. If you mount `/tmp/auxilia` read-write, every sandbox can write to it — it is a shared scratch space.
+
+## Timeouts
+
+Two timeouts apply:
+
+- **Per-command timeout** — `OPEN_SANDBOX_TIMEOUT` (default 1800s). If a single `execute` call doesn't finish in this window, **auxilia** cancels it and returns `exit_code=124`.
+- **Container TTL** — default 30 minutes; renewed each time `connect_sandbox` is called.
+
+Keep the per-command timeout tight. Long-running commands are rare in practice and chew up OpenSandbox capacity.
+
+## Authentication
+
+The OpenSandbox controller authenticates requests with the `OPEN_SANDBOX_API_KEY`. Put the controller on a private network (VPC, internal DNS) and only let the **auxilia** backend reach it.
+
+Setting `OPEN_SANDBOX_USE_SERVER_PROXY=true` routes the agent's file reads/writes through the OpenSandbox server rather than direct container ports, which is simpler in firewalled environments.
+
+## Recommended posture
+
+A safe default for most teams:
+
+- Run OpenSandbox on an **internal-only** host or VPC
+- **Never mount** sensitive host paths — let the sandbox stay ephemeral
+- Keep the per-command timeout at 30 min or less
+- Turn **Code execution** on only for agents whose owners trust the LLM to run code against the configured image
+- Use **tool approvals** on non-sandbox write tools (HubSpot writes, GitHub PRs) to keep a human in the loop even when the agent is autonomous inside the sandbox
+
+If you need stronger guarantees, gate the sandbox toggle behind a workspace-admin-only agent, and use the [permissions model](/docs/agents/permissions) to restrict who can chat with it.

--- a/docs/content/sandbox/setup.mdx
+++ b/docs/content/sandbox/setup.mdx
@@ -1,0 +1,69 @@
+# Sandbox Setup
+
+The sandbox runtime is external — **auxilia** is a client of it. You can run [OpenSandbox](https://github.com/langchain-ai/opensandbox) alongside **auxilia** or point **auxilia** at a managed OpenSandbox instance.
+
+## 1. Run OpenSandbox
+
+Follow the [OpenSandbox installation guide](https://github.com/langchain-ai/opensandbox) to run the controller. The simplest setup is a Docker container on the same host or VPC as your **auxilia** backend.
+
+Once it's running, note:
+
+- The **domain** (e.g. `localhost:8083` in dev, or a private DNS name in prod)
+- An **API key** if the controller is configured to require one
+
+## 2. Configure auxilia
+
+Set these environment variables on the backend:
+
+```env
+# Required: where OpenSandbox is reachable
+OPEN_SANDBOX_DOMAIN=localhost:8083
+
+# Optional: API key if your controller requires one
+OPEN_SANDBOX_API_KEY=your-key
+
+# Connect through the OpenSandbox server's proxy (recommended)
+OPEN_SANDBOX_USE_SERVER_PROXY=true
+```
+
+As soon as `OPEN_SANDBOX_DOMAIN` is set, the backend's `/sandbox/status` endpoint reports `{"enabled": true}` and agents with **Code execution** turned on will use the sandbox. If the variable is missing, the integration is silently disabled and the toggle on agents has no effect.
+
+## 3. Tune the runtime (optional)
+
+The remaining variables let you shape the default container:
+
+```env
+# Base image — whatever OpenSandbox supports; defaults to python:3.12-slim
+OPEN_SANDBOX_DEFAULT_IMAGE=python:3.12-slim
+
+# Packages installed via pip on first boot
+# (comma-separated or list syntax, depending on your loader)
+OPEN_SANDBOX_DEFAULT_PACKAGES=["pandas","matplotlib","duckdb"]
+
+# Per-command timeout (seconds). Default: 1800 (30 minutes)
+OPEN_SANDBOX_TIMEOUT=1800
+
+# Volume mounts — host_path:sandbox_path[:ro], comma-separated
+OPEN_SANDBOX_VOLUME_MOUNTS=/srv/shared:/workspace:ro,/tmp/auxilia:/mnt/scratch
+```
+
+All settings live in `app/sandbox/settings.py` and use the `OPEN_SANDBOX_` prefix.
+
+## 4. Enable on an agent
+
+1. Open the agent's configuration page
+2. Scroll to **Code execution**
+3. Toggle it on
+
+The next message you send will expose `create_sandbox` / `connect_sandbox` (plus the file-ops toolset) to the LLM. The agent decides when to spin up the container — usually right before it needs to run code.
+
+## Check the status
+
+From the backend, you can confirm the runtime is reachable:
+
+```bash
+curl -H "Cookie: auth_token=..." https://your-auxilia.example.com/api/backend/sandbox/status
+# {"enabled": true}
+```
+
+If you get `{"enabled": false}`, `OPEN_SANDBOX_DOMAIN` is not set. If the flag is `true` but `create_sandbox` fails at runtime, check the OpenSandbox controller logs.

--- a/docs/content/sandbox/tools.mdx
+++ b/docs/content/sandbox/tools.mdx
@@ -1,0 +1,67 @@
+# Sandbox Tools
+
+When an agent has **Code execution** enabled, **auxilia** exposes two sandbox-lifecycle tools plus a full file-ops toolset inherited from the OpenSandbox base backend.
+
+## Lifecycle tools
+
+### `create_sandbox(timeout_minutes: int = 30)`
+
+Create a new container for this conversation. Returns the sandbox ID plus the TTL.
+
+The LLM is instructed to call this **before** any code execution. A single sandbox is reused across turns until it expires or the user starts a new thread.
+
+### `connect_sandbox(sandbox_id: str)`
+
+Reconnect to an existing sandbox by ID. Useful when the conversation is resumed after the TTL has started ticking. On success, the TTL is renewed for another 30 minutes.
+
+If the sandbox no longer exists, the tool returns an error and the LLM is expected to call `create_sandbox` instead.
+
+## File-ops tools
+
+All of these operate against the container's filesystem. They come from the [OpenSandbox `BaseSandbox`](https://github.com/langchain-ai/opensandbox) implementation and route through a single `execute()` call under the hood.
+
+### `ls(path)`
+
+List a directory. Returns entries with their size and modification time, suitable for quick inspection.
+
+### `read_file(path, offset=0, limit=2000)`
+
+Read a file with line numbers. For files larger than the default limit, pass `offset` and `limit` to paginate. Good default behavior for the LLM: read what it needs, not the whole file.
+
+### `write_file(path, content)`
+
+Create a new file. Fails if the file already exists — use `edit_file` for updates.
+
+### `edit_file(path, old_string, new_string, replace_all=false)`
+
+Do an exact string replacement inside an existing file. If `old_string` is ambiguous (appears more than once) the tool errors unless `replace_all=true`.
+
+### `glob(pattern)`
+
+Find files matching a glob — e.g. `**/*.py`, `data/*.csv`. Returns paths sorted by mtime.
+
+### `grep(pattern, path=".", mode="files_with_matches")`
+
+Regex search over file contents. Modes:
+
+- `files_with_matches` — only paths
+- `content` — lines that match (supports `-A` / `-B` / `-C` context)
+- `count` — match counts per file
+
+### `execute(command, timeout=None)`
+
+Run an arbitrary shell command. The command runs in the background and is polled until it finishes or hits the timeout (default 30 min). Returns stdout + stderr combined and the exit code.
+
+Timeouts are enforced on the server side — if you pass a very large `timeout`, it is clamped by the OpenSandbox controller's own limits.
+
+## Typical usage pattern
+
+A data-analysis agent's first few turns look like:
+
+1. `create_sandbox()` → sandbox `sb_abc123`, TTL 30 min
+2. `execute("pip install pandas matplotlib")` (only if not in `OPEN_SANDBOX_DEFAULT_PACKAGES`)
+3. `write_file("/tmp/analysis.py", "...")`
+4. `execute("python /tmp/analysis.py")`
+5. `read_file("/tmp/result.json")`
+
+Because the sandbox lives for the length of the conversation, subsequent turns can just `execute` or `read_file` without rebuilding state.

--- a/docs/content/tools/index.mdx
+++ b/docs/content/tools/index.mdx
@@ -1,26 +1,34 @@
 # Tools
 
-Tools are the actions an agent can perform through MCP servers. Each MCP server exposes a set of tools — functions the agent can call during a conversation to fetch data, create records, or perform actions in external systems.
+Tools are the actions an agent can perform. Most tools come from MCP servers bound to the agent; a few additional ones come from the [sandbox](/docs/sandbox) when code execution is enabled.
 
-## How Tools Work
+## How tools flow through the runtime
 
-1. **auxilia** connects to an MCP server and discovers its available tools
-2. Each tool has a name, description, and input schema
-3. The LLM decides when to call a tool based on the conversation context
-4. **auxilia** executes the tool call against the MCP server
-5. The result is returned to the LLM to incorporate into its response
+1. The backend connects to every MCP server bound to the agent
+2. For each server it calls `tools/list` and receives the tool schemas
+3. It filters the list using the agent's [tool settings](/docs/tools/settings) (disabled tools are removed; "needs approval" tools are marked as HITL interrupts)
+4. If the sandbox is on, it appends `create_sandbox`, `connect_sandbox`, and the standard file-ops tools (`ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `execute`)
+5. If subagents are attached, it wraps each one as a tool
+6. The resulting toolset is handed to the LLM via LangGraph
 
-## Tool Discovery
+## Tool discovery
 
-When you bind an MCP server to an agent, **auxilia** fetches the list of tools from the server. These appear in the agent's configuration with their names and descriptions.
+Tool schemas are fetched from the MCP server when you bind or **Sync tools** on an agent-server binding. They are **not** re-fetched on every message — this avoids the ~15 s deadlock some servers exhibit when they hold the Streamable HTTP GET stream open before responding to `tools/list`.
 
-Tools are refreshed each time the agent handles a message, so new tools added to an MCP server are picked up automatically.
+Use **Sync tools** on the agent page whenever the underlying MCP server publishes new tools or changes descriptions.
 
-## Tool Execution in Chat
+## Tool calls in chat
 
-During a conversation, tool calls appear in the chat as expandable blocks showing:
+Every tool call appears in the thread as an expandable block showing:
 
-- The **tool name** and which MCP server it belongs to
-- The **input parameters** sent to the tool
-- The **result** returned by the tool
-- Whether the call was **auto-approved** or required **manual approval**
+- The **tool name** and the MCP server it belongs to
+- The **input arguments** the LLM passed
+- The **result** the server returned (or the error, if it failed)
+- Whether the call was **auto-approved** or **user-approved**
+
+Errors are surfaced inline. The LLM sees the error string as the tool result and decides whether to retry, call a different tool, or explain the problem to the user.
+
+## Next
+
+- [Tool Settings](/docs/tools/settings) — per-tool approval rules
+- [Sandbox](/docs/sandbox) — the code-execution toolset

--- a/docs/content/tools/settings.mdx
+++ b/docs/content/tools/settings.mdx
@@ -1,58 +1,54 @@
 # Tool Settings
 
-Every tool bound to an agent can be configured with one of three permission states. This gives you fine-grained control over what actions an agent can take autonomously versus what requires human oversight.
+Each tool on an agent-server binding has one of three statuses. This is how you give an agent tight, read-only access to one server and full write access to another — without having to juggle separate agents.
 
-## The Three States
+## The three states
 
-### Always Allow
+### Always allow
 
-The tool executes immediately when the LLM decides to call it. No user intervention is needed.
+The tool runs immediately when the LLM calls it. No prompt, no interrupt.
 
-**Use for:** Read-only tools, low-risk actions, tools you trust completely.
+**Use for:** read-only tools, low-risk actions, tools you trust completely.
 
-### Needs Approval
+### Needs approval
 
-When the LLM calls this tool, execution pauses and the user is shown an approval prompt in the chat. The user can review the tool name and input parameters, then approve or reject the call.
+When the LLM calls the tool, the LangGraph run hits a [HITL interrupt](https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/). The chat shows an approval card with the tool name and the exact arguments. The user can:
 
-**Use for:** Write operations, actions with side effects, tools that modify external data, or any tool where you want human oversight.
+- **Approve** — the call proceeds and the agent resumes
+- **Reject** — the tool returns a rejection message to the LLM, which decides what to do next
 
-**How it works:**
+In Slack, approvals are posted as Block Kit messages with **Approve** and **Reject** buttons.
 
-1. The LLM decides to call the tool
-2. **auxilia** pauses the agent execution
-3. The chat shows the pending tool call with its parameters
-4. The user clicks **Approve** or **Reject**
-5. If approved, the tool executes and the agent continues
-6. If rejected, the agent is informed and adjusts its response
+**Use for:** write operations, actions with side effects, tools that modify external data.
 
 ### Disabled
 
-The tool is completely excluded from the agent's toolset. The LLM doesn't know the tool exists and can't call it.
+The tool is stripped from the toolset the LLM sees. The model cannot call it and does not know it exists.
 
-**Use for:** Tools that are irrelevant to the agent's purpose, or tools you want to temporarily turn off.
+**Use for:** tools that are off-topic for the agent, or tools you want to temporarily kill-switch.
 
-## Configuring Tool Settings
+## Changing tool settings
 
 1. Open the agent's configuration page
-2. Find the MCP server section
-3. Each tool shows a three-state toggle:
+2. In the MCP server section, click through the tool list
+3. Cycle each tool through the three states
 
 ```
-   ✓  Always Allow
-   ⏸  Needs Approval
-   ✗  Disabled
+✓  Always allow
+⏸  Needs approval
+✗  Disabled
 ```
 
-4. Click the toggle to cycle between states
+## Defaults
 
-## Default Behavior
+When an MCP server is first bound to an agent, every tool defaults to **Always allow**. Review the list and tighten writes before exposing the agent to users.
 
-When an MCP server is first bound to an agent, all tools default to **Always Allow**. Review the tool list and adjust permissions based on your needs.
+## Per-agent, per-server
 
-## Per-Agent Configuration
+Tool settings live on the agent-server binding, so the same MCP server can have different permissions on different agents:
 
-Tool settings are scoped to each agent-server binding. The same MCP server can have different tool permissions across different agents. For example:
+- A **Read-only CRM Agent** might have every HubSpot write tool **disabled**
+- A **Sales Assistant** might have HubSpot writes set to **needs approval**
+- An **Automation Agent** owned by an admin might have everything **always allow**
 
-- A "Read-Only CRM Agent" might have all HubSpot write tools **disabled**
-- A "Sales Assistant" might have HubSpot write tools set to **needs approval**
-- An "Automation Agent" might have all tools set to **always allow**
+Changing settings takes effect on the next message — existing thread checkpoints are unaffected.

--- a/docs/src/app/globals.css
+++ b/docs/src/app/globals.css
@@ -1,8 +1,150 @@
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap");
+
+/* ---------------------------------------------------------------- *
+ * Auxilia design tokens — kept in sync with web/src/app/globals.css
+ * ---------------------------------------------------------------- */
 :root {
-  --nextra-primary-hue: 0deg;
-  --nextra-primary-saturation: 0%;
+  /* Sage green (same hex as --sidebar-primary: #4ca882) */
+  --auxilia-primary: #4ca882;
+  --auxilia-primary-hover: #3d8b63;
+
+  --auxilia-fg: #1e2d28;           /* foreground text */
+  --auxilia-muted: #6b7f76;        /* muted foreground */
+
+  --auxilia-surface: #f1f6f4;      /* app --surface */
+  --auxilia-sidebar: #ffffff;
+  --auxilia-sidebar-accent: #edf4f0;
+  --auxilia-sidebar-border: #e8efe9;
+  --auxilia-sidebar-hover: #f8faf9;
+
+  --auxilia-border: #e0e8e4;
+  --auxilia-border-strong: #c9d6cf;
+  --auxilia-card: #ffffff;
+  --auxilia-inner-card: #fafcfb;
+
+  /* Rounded scale — matches app (radius base = 0.625rem) */
+  --auxilia-radius: 0.625rem;
+  --auxilia-radius-lg: 1rem;
+  --auxilia-radius-xl: 1.25rem;
+  --auxilia-radius-full: 9999px;
+
+  /* Nextra primary colour wheel → sage green
+   * primary-hue + primary-saturation + primary-lightness is the HSL base
+   * Nextra interpolates all highlight/link shades from this triplet. */
+  --nextra-primary-hue: 154deg;
+  --nextra-primary-saturation: 38%;
+  --nextra-primary-lightness: 48%;
+
+  /* Body background (RGB channels — Nextra uses rgb(var(--nextra-bg))) */
+  --nextra-bg: 255, 255, 255; /* #FFFFFF */
 }
 
+.dark {
+  --auxilia-primary: #5abf94;
+  --auxilia-primary-hover: #4ca882;
+
+  --auxilia-fg: #e6efea;
+  --auxilia-muted: #94a69d;
+
+  --auxilia-surface: #1a2420;
+  --auxilia-sidebar: #161f1b;
+  --auxilia-sidebar-accent: #1f2a26;
+  --auxilia-sidebar-border: #243029;
+  --auxilia-sidebar-hover: #1d2722;
+
+  --auxilia-border: #243029;
+  --auxilia-border-strong: #2e3c36;
+  --auxilia-card: #1a2420;
+  --auxilia-inner-card: #1e2823;
+
+  --nextra-primary-hue: 154deg;
+  --nextra-primary-saturation: 42%;
+  --nextra-primary-lightness: 55%;
+
+  --nextra-bg: 20, 28, 25; /* a touch darker than --auxilia-surface */
+}
+
+/* ---------------------------------------------------------------- *
+ * Typography
+ * ---------------------------------------------------------------- */
+html {
+  font-family:
+    "Plus Jakarta Sans",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  font-feature-settings: "ss01", "cv11";
+  color: var(--auxilia-fg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code,
+pre,
+kbd,
+samp,
+.nextra-code {
+  font-family:
+    "Geist Mono",
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    "Liberation Mono",
+    "Courier New",
+    monospace;
+  font-feature-settings: "calt" 1, "ss02" 1;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Plus Jakarta Sans", sans-serif;
+  letter-spacing: -0.015em;
+  color: var(--auxilia-fg);
+}
+
+h1 {
+  font-weight: 700;
+  letter-spacing: -0.035em;
+}
+
+h2 {
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  border-bottom: 1px solid var(--auxilia-border);
+  padding-bottom: 0.4em;
+}
+
+h3 {
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.dark h1,
+.dark h2,
+.dark h3,
+.dark h4,
+.dark h5,
+.dark h6 {
+  color: var(--auxilia-fg);
+}
+
+/* ---------------------------------------------------------------- *
+ * Logo swap
+ * ---------------------------------------------------------------- */
 .logo-dark {
   display: none;
 }
@@ -15,16 +157,294 @@ html.dark .logo-dark {
   display: block;
 }
 
-html {
-  font-family:
-    'Geist',
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    'Helvetica Neue',
-    Arial,
-    sans-serif;
+/* ---------------------------------------------------------------- *
+ * Navbar — translucent sage-tinted pill, matches the app chrome
+ * ---------------------------------------------------------------- */
+.nextra-navbar-blur {
+  background-color: rgb(255 255 255 / 0.72) !important;
+  backdrop-filter: saturate(180%) blur(14px);
+  border-bottom: 1px solid var(--auxilia-sidebar-border) !important;
+}
+
+.dark .nextra-navbar-blur {
+  background-color: rgb(22 31 27 / 0.75) !important;
+  border-bottom-color: var(--auxilia-sidebar-border) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Navbar-hosted ThemeSwitch — compact button that matches search
+ * ---------------------------------------------------------------- */
+.nextra-navbar nav > :last-child [title="Change theme"] {
+  /* Strip the default select chrome so the theme switch looks like an icon button. */
+  background: transparent !important;
+  border: 1px solid var(--auxilia-sidebar-border) !important;
+  color: var(--auxilia-muted) !important;
+  border-radius: var(--auxilia-radius) !important;
+  padding: 0.375rem 0.5rem !important;
+  transition: background-color 0.15s ease, color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.nextra-navbar nav > :last-child [title="Change theme"]:hover {
+  background-color: var(--auxilia-sidebar-accent) !important;
+  color: var(--auxilia-primary-hover) !important;
+  border-color: var(--auxilia-border) !important;
+}
+
+.dark .nextra-navbar nav > :last-child [title="Change theme"]:hover {
+  color: var(--auxilia-primary) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Sidebar — sage-tinted border, rounded hover chips
+ * ---------------------------------------------------------------- */
+.nextra-sidebar,
+.nextra-mobile-nav {
+  --tw-bg-opacity: 1;
+}
+
+.nextra-sidebar a,
+.nextra-sidebar button {
+  border-radius: var(--auxilia-radius) !important;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.nextra-sidebar a:hover:not([aria-current="page"]),
+.nextra-sidebar button:hover {
+  background-color: var(--auxilia-sidebar-accent) !important;
+  color: var(--auxilia-fg) !important;
+}
+
+.nextra-sidebar a[aria-current="page"] {
+  background-color: var(--auxilia-sidebar-accent) !important;
+  color: var(--auxilia-primary-hover) !important;
+  font-weight: 600;
+}
+
+.dark .nextra-sidebar a[aria-current="page"] {
+  color: var(--auxilia-primary) !important;
+}
+
+/* Hide the sidebar footer — the theme switch lives in the navbar now. */
+.nextra-sidebar-footer {
+  display: none !important;
+}
+
+/* The vertical active-section rail Nextra paints — re-tint it. */
+.nextra-sidebar [class*="border-l"] {
+  border-color: var(--auxilia-sidebar-border) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * TOC
+ * ---------------------------------------------------------------- */
+.nextra-toc a {
+  border-radius: var(--auxilia-radius);
+  transition: color 0.15s ease;
+}
+
+.nextra-toc a:hover {
+  color: var(--auxilia-primary-hover) !important;
+}
+
+.dark .nextra-toc a:hover {
+  color: var(--auxilia-primary) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Links in prose
+ * ---------------------------------------------------------------- */
+article a:not(.nextra-copy-icon):not(.nextra-focus) {
+  color: var(--auxilia-primary-hover);
+  text-decoration-color: color-mix(in srgb, var(--auxilia-primary) 35%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+article a:not(.nextra-copy-icon):not(.nextra-focus):hover {
+  color: var(--auxilia-primary);
+  text-decoration-color: var(--auxilia-primary);
+}
+
+.dark article a:not(.nextra-copy-icon):not(.nextra-focus) {
+  color: var(--auxilia-primary);
+}
+
+/* ---------------------------------------------------------------- *
+ * Inline code
+ * ---------------------------------------------------------------- */
+article :not(pre) > code {
+  background-color: color-mix(in srgb, var(--auxilia-primary) 10%, var(--auxilia-surface)) !important;
+  border: 1px solid var(--auxilia-sidebar-border) !important;
+  color: var(--auxilia-fg) !important;
+  border-radius: calc(var(--auxilia-radius) - 2px) !important;
+  padding: 0.12em 0.38em !important;
+  font-size: 0.875em;
+}
+
+.dark article :not(pre) > code {
+  background-color: color-mix(in srgb, var(--auxilia-primary) 14%, var(--auxilia-surface)) !important;
+  border-color: var(--auxilia-border) !important;
+  color: var(--auxilia-fg) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Code blocks — rounded sage card
+ * ---------------------------------------------------------------- */
+article pre.nextra-code,
+.nextra-code pre {
+  border-radius: var(--auxilia-radius-lg) !important;
+  border: 1.5px solid var(--auxilia-border) !important;
+  background-color: var(--auxilia-inner-card) !important;
+}
+
+.dark article pre.nextra-code,
+.dark .nextra-code pre {
+  background-color: color-mix(in srgb, #000 30%, var(--auxilia-surface)) !important;
+  border-color: var(--auxilia-border) !important;
+}
+
+.nextra-code > pre {
+  padding: 1rem 1.25rem !important;
+}
+
+/* Filename tag above code blocks */
+.nextra-code [data-filename],
+.nextra-code [data-language] {
+  border-top-left-radius: var(--auxilia-radius-lg) !important;
+  border-top-right-radius: var(--auxilia-radius-lg) !important;
+  background-color: color-mix(in srgb, var(--auxilia-primary) 8%, var(--auxilia-surface)) !important;
+  border-color: var(--auxilia-border) !important;
+}
+
+.nextra-copy-icon {
+  border-radius: calc(var(--auxilia-radius) - 2px) !important;
+}
+
+.nextra-copy-icon:hover {
+  background-color: var(--auxilia-sidebar-accent) !important;
+  color: var(--auxilia-primary-hover) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Callouts
+ * ---------------------------------------------------------------- */
+.nextra-callout {
+  border-radius: var(--auxilia-radius-lg) !important;
+  border-width: 1.5px !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Tables — clean sage-bordered, no zebra stripes
+ * ---------------------------------------------------------------- */
+article table {
+  /* Nextra wraps tables in display:block for horizontal scroll, which
+   * leaves the outer border floating past narrow cells. Force a real
+   * table with width:100% so cells always fill the container. */
+  display: table !important;
+  width: 100% !important;
+  border-collapse: separate !important;
+  border-spacing: 0;
+  border: 1.5px solid var(--auxilia-border);
+  border-radius: var(--auxilia-radius-lg);
+  overflow: hidden;
+  margin: 1.25em 0;
+}
+
+article table th,
+article table td {
+  border: none !important;
+  padding: 0.625rem 1rem !important;
+  background-color: transparent;
+}
+
+article table th {
+  background-color: var(--auxilia-sidebar-accent) !important;
+  color: var(--auxilia-fg) !important;
+  font-weight: 600 !important;
+  text-align: left;
+  border-bottom: 1px solid var(--auxilia-border) !important;
+}
+
+/* Every body row: plain white/card background, no zebra striping. */
+article table tr {
+  background-color: var(--auxilia-card) !important;
+}
+
+/* Row separators — everything except the last row. */
+article table tbody tr:not(:last-child) td {
+  border-bottom: 1px solid var(--auxilia-border) !important;
+}
+
+.dark article table tr {
+  background-color: var(--auxilia-card) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Blockquotes
+ * ---------------------------------------------------------------- */
+article blockquote {
+  border-left: 3px solid var(--auxilia-primary) !important;
+  background: color-mix(in srgb, var(--auxilia-primary) 6%, transparent);
+  border-top-right-radius: var(--auxilia-radius);
+  border-bottom-right-radius: var(--auxilia-radius);
+  padding: 0.25rem 1rem;
+  color: var(--auxilia-fg);
+  font-style: normal;
+}
+
+/* ---------------------------------------------------------------- *
+ * Horizontal rule
+ * ---------------------------------------------------------------- */
+article hr,
+.nextra-border {
+  border-color: var(--auxilia-border) !important;
+}
+
+/* ---------------------------------------------------------------- *
+ * Body background — softly tinted surface like the app
+ * ---------------------------------------------------------------- */
+body {
+  background-color: rgb(var(--nextra-bg));
+  color: var(--auxilia-fg);
+}
+
+/* ---------------------------------------------------------------- *
+ * Focus ring — sage, not blue
+ * ---------------------------------------------------------------- */
+.nextra-focus:focus-visible,
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--nextra-bg)),
+    0 0 0 4px var(--auxilia-primary);
+  border-radius: calc(var(--auxilia-radius) - 2px);
+}
+
+/* ---------------------------------------------------------------- *
+ * Scrollbar — thin sage
+ * ---------------------------------------------------------------- */
+.nextra-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--auxilia-border-strong) transparent;
+}
+
+.nextra-scrollbar::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.nextra-scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--auxilia-border-strong);
+  border-radius: 9999px;
+}
+
+/* ---------------------------------------------------------------- *
+ * Steps — match the rounded sage feel
+ * ---------------------------------------------------------------- */
+.nextra-steps h3::before,
+.nextra-steps h4::before {
+  background-color: var(--auxilia-sidebar-accent) !important;
+  border-color: var(--auxilia-border) !important;
+  color: var(--auxilia-primary-hover) !important;
 }

--- a/docs/src/app/layout.jsx
+++ b/docs/src/app/layout.jsx
@@ -1,4 +1,4 @@
-import { Footer, Layout, Navbar } from "nextra-theme-docs";
+import { Footer, Layout, Navbar, ThemeSwitch } from "nextra-theme-docs";
 import { Head } from "nextra/components";
 import { getPageMap } from "nextra/page-map";
 import "nextra-theme-docs/style.css";
@@ -10,7 +10,7 @@ export const metadata = {
 		default: "auxilia – Open-Source Web MCP Client",
 	},
 	description:
-		"Host and share MCP-powered AI assistants for your team. Open-source, self-hosted",
+		"Host and share MCP-powered AI assistants for your team. Open-source, self-hosted.",
 	applicationName: "auxilia",
 	icons: {
 		icon: "/logo.svg",
@@ -28,28 +28,73 @@ export default async function RootLayout({ children }) {
 	const navbar = (
 		<Navbar
 			logo={
-				<span style={{ display: "flex", alignItems: "center", gap: "0.5rem", fontWeight: 700, fontSize: "1.1rem" }}>
-					<img src="/logo.svg" alt="auxilia" className="logo-light" style={{ height: "1.5rem" }} />
-					<img src="/logo-dark.svg" alt="auxilia" className="logo-dark" style={{ height: "1.5rem" }} />
+				<span
+					style={{
+						display: "inline-flex",
+						alignItems: "center",
+						gap: "0.5rem",
+						fontFamily: "'Plus Jakarta Sans', sans-serif",
+						fontWeight: 700,
+						fontSize: "1.1rem",
+						letterSpacing: "-0.02em",
+						color: "var(--auxilia-fg)",
+					}}
+				>
+					<img
+						src="/logo.svg"
+						alt="auxilia"
+						className="logo-light"
+						style={{ height: "1.5rem" }}
+					/>
+					<img
+						src="/logo-dark.svg"
+						alt="auxilia"
+						className="logo-dark"
+						style={{ height: "1.5rem" }}
+					/>
 					auxilia
 				</span>
 			}
 			projectLink="https://github.com/keurcien/auxilia"
-		/>
+		>
+			<ThemeSwitch lite />
+		</Navbar>
 	);
 	const pageMap = await getPageMap();
 	return (
 		<html lang="en" dir="ltr" suppressHydrationWarning>
-			<Head faviconGlyph="◆" />
+			<Head
+				backgroundColor={{
+					light: "#ffffff",
+					dark: "#141c19",
+				}}
+				color={{
+					hue: 154,
+					saturation: 38,
+					lightness: { light: 48, dark: 55 },
+				}}
+			/>
 			<body>
 				<Layout
 					navbar={navbar}
 					footer={
-						<Footer>AGPL-3.0 {new Date().getFullYear()} © auxilia.</Footer>
+						<Footer
+							style={{
+								backgroundColor: "transparent",
+								borderTop: "1px solid var(--auxilia-sidebar-border)",
+								color: "var(--auxilia-muted)",
+								fontSize: "0.875rem",
+							}}
+						>
+							<span>
+								AGPL-3.0 {new Date().getFullYear()} © auxilia — open-source web
+								MCP client
+							</span>
+						</Footer>
 					}
 					editLink="Edit this page on GitHub"
 					docsRepositoryBase="https://github.com/keurcien/auxilia/tree/main/docs"
-					sidebar={{ defaultMenuCollapseLevel: 1 }}
+					sidebar={{ defaultMenuCollapseLevel: 1, toggleButton: false }}
 					pageMap={pageMap}
 				>
 					{children}


### PR DESCRIPTION
## Summary
- Rewrote and expanded the core docs pages (index, get-started, agents, MCP servers, tools, integrations, deployment) for clarity and consistency
- Added new pages: `agents/permissions`, `agents/subagents`, and a full `sandbox/` section (index, setup, tools, security)
- Polished layout (navbar theme switch, logo typography) and `globals.css` (sage theme tokens, tables, callouts, code blocks)
- Added Cloudflare R2-hosted screenshots to the MCP Servers page

## Test plan
- [x] `cd docs && npm run dev` — verify pages render, sidebar shows new entries (Sandbox, Permissions, Subagents)
- [x] Check MCP Servers page: two screenshots load from R2, dialog image sized correctly
- [x] Light/dark theme toggle works from the navbar
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes and expands the docs for clarity, adds a new Sandbox section, and includes Cloudflare R2-hosted screenshots on the MCP Servers page. Also updates the docs UI with a theme switch and improved styles.

- **New Features**
  - Rewrote core guides: index, get-started, agents, MCP servers, tools, integrations, deployment.
  - Added `agents/permissions`, `agents/subagents`, and `sandbox/{index,setup,tools,security}`.
  - Added R2-hosted screenshots on the MCP Servers page.

- **Refactors**
  - Added theme switch to the navbar and tuned logo typography.
  - Introduced `globals.css` design tokens and improved tables, callouts, and code blocks.

<sup>Written for commit 5e4f09a32ce05d0a73cbfdc933d0ae9246c993df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

