### PR TITLE
Remove unused LiteLLM integration

### DIFF
--- a/backend/app/model_providers/models.py
+++ b/backend/app/model_providers/models.py
@@ -7,4 +7,3 @@ class ModelProviderType(str, Enum):
     anthropic = "anthropic"
     google = "google"
     ollama = "ollama"
-    litellm = "litellm"

--- a/backend/app/model_providers/router.py
+++ b/backend/app/model_providers/router.py
@@ -1,4 +1,3 @@
-import requests
 from fastapi import APIRouter
 
 from app.model_providers.models import ModelProviderType
@@ -8,17 +7,6 @@ from .settings import model_provider_settings
 
 
 router = APIRouter(prefix="/model-providers", tags=["model-providers"])
-
-
-def get_litellm_models() -> list[dict]:
-    response = requests.get(
-        f"{model_provider_settings.litellm_api_base}/v1/models",
-        headers={
-            "Authorization": f"Bearer {model_provider_settings.litellm_api_key}",
-            "Content-Type": "application/json"
-        }
-    )
-    return response.json()["data"]
 
 
 @router.get("/", response_model=list[ModelProviderResponse])
@@ -71,16 +59,5 @@ async def get_models() -> list[ModelResponse]:
             ModelResponse(name="Gemini 3 Pro Preview", providers=[
                       ModelProviderType.google], id="gemini-3-pro-preview", chef="Google", chefSlug="google"),
         ])
-    # if model_provider_settings.litellm_api_key:
-    #     if not model_provider_settings.litellm_api_base:
-    #         raise ValueError("LITELLM_API_BASE is not set")
-
-    #     litellm_models = get_litellm_models()
-
-    #     for model in litellm_models:
-    #         _, model_id = model["id"].split("/")
-    #         models.extend([
-    #             ModelResponse(name=model_id, providers=[ModelProviderType.litellm], id=model_id, chef="LiteLLM", chefSlug="litellm")
-    #         ])
 
     return list(models)

--- a/backend/app/model_providers/settings.py
+++ b/backend/app/model_providers/settings.py
@@ -13,8 +13,6 @@ class ModelProviderSettings(BaseSettings):
     deepseek_api_key: str | None = None
     anthropic_api_key: str | None = None
     google_api_key: str | None = None
-    litellm_api_key: str | None = None
-    litellm_api_base: str | None = None
 
     model_config: ConfigDict = ConfigDict(
         env_file=ROOT_ENV,


### PR DESCRIPTION
## Summary

- Remove the `litellm` variant from `ModelProviderType`
- Drop the unused `litellm_api_key` / `litellm_api_base` settings fields
- Delete the `get_litellm_models()` helper and the commented-out model-fetch block in the providers router
- Remove the now-unused `requests` import

LiteLLM support was never actually wired up — the code that would have registered its models was commented out. The public docs and README only advertise Anthropic, OpenAI, Google, and DeepSeek, so this aligns the codebase with what we ship.

## Test plan

- [x] `ruff check app/model_providers/` passes
- [x] Module imports cleanly (`from app.model_providers.router import router`)
- [x] `/model-providers` and `/model-providers/models` endpoints return the expected providers in a local run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `litellm` integration from model providers to align with supported providers and simplify configuration. No user-facing changes to `/model-providers` endpoints.

- **Refactors**
  - Dropped `litellm` from `ModelProviderType`.
  - Removed `litellm_api_key` and `litellm_api_base` settings.
  - Deleted `get_litellm_models()` and the commented-out model fetch block.
  - Removed unused `requests` import.

<sup>Written for commit 786946035384c30e825194ed05dcd3c777ba2c44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

