### PR TITLE
chore(slack): remove dead code

### DIFF
--- a/backend/app/integrations/slack/commands/chat.py
+++ b/backend/app/integrations/slack/commands/chat.py
@@ -5,9 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agents.core.service import AgentService
 from app.agents.models import AgentDB
 from app.database import AsyncSessionLocal
-from app.integrations.slack.models import SlackEvent, SlackInteractionPayload
+from app.integrations.slack.models import SlackInteractionPayload
 from app.integrations.slack.settings import slack_settings
-from app.integrations.slack.utils import get_user_info, resolve_user
+from app.integrations.slack.utils import get_user_info
 from app.threads.service import get_or_create_thread
 from app.users.models import WorkspaceRole
 from app.users.repository import UserRepository
@@ -75,24 +75,6 @@ async def post_agent_picker(
         blocks=blocks,
         text="Choose an agent",
     )
-
-
-async def handle_app_mention(event: SlackEvent, **_: object) -> None:
-    """Handle an ``app_mention`` event — post an agent picker in the thread."""
-    thread_ts = event.thread_ts or event.ts
-    if not event.channel or not thread_ts:
-        return
-
-    user = await resolve_user(event.user)
-
-    if not user:
-        return
-
-    async with AsyncSessionLocal() as db:
-        client = AsyncWebClient(token=slack_settings.slack_bot_token)
-        await post_agent_picker(
-            client, event.channel, thread_ts, db, user.id, user_role=user.role,
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -4,7 +4,6 @@
 # (triggered by @auxilia mention).  Subsequent messages in that thread
 # are routed to the configured agent.
 
-import httpx
 from slack_sdk.web.async_client import AsyncWebClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -17,34 +16,11 @@ from app.integrations.slack.blocks import build_tool_approval_blocks
 from app.integrations.slack.commands.chat import post_agent_picker
 from app.integrations.slack.models import SlackEvent, SlackInteractionPayload
 from app.integrations.slack.settings import slack_settings
-from app.integrations.slack.utils import get_user_info
+from app.integrations.slack.utils import get_user_info, resolve_user
 from app.mcp.servers.models import MCPServerDB
 from app.mcp.utils import check_mcp_server_connected
 from app.threads.models import ThreadDB
-from app.users.models import UserDB
 from app.users.repository import UserRepository
-
-
-SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
-
-
-async def send_slack_message(channel: str, thread_ts: str, text: str) -> None:
-    """Post a message to a Slack channel/thread."""
-    async with httpx.AsyncClient() as client:
-        await client.post(
-            SLACK_POST_MESSAGE_URL,
-            headers={"Authorization": f"Bearer {slack_settings.slack_bot_token}"},
-            json={"channel": channel, "text": text, "thread_ts": thread_ts},
-        )
-
-
-async def resolve_user(slack_user_id: str) -> UserDB | None:
-    """Map a Slack user ID to an internal user via email lookup."""
-    user_info = await get_user_info(slack_user_id)
-    if not user_info or not user_info.profile.email:
-        return None
-    async with AsyncSessionLocal() as db:
-        return await UserRepository(db).get_by_email(user_info.profile.email)
 
 
 async def post_tool_approval_block(


### PR DESCRIPTION
## Summary
- Drop unused `send_slack_message` helper (no callers; was raw `httpx` while the rest of the integration uses `slack_sdk`)
- Drop duplicate `resolve_user` in `handlers.py`; import the existing one from `utils.py`
- Drop `handle_app_mention` — never wired into the router

First pass of a planned Slack integration cleanup; pure dead-code removal, no behavior change.

## Test plan
- [ ] `uv run ruff check app/integrations/slack/` passes
- [ ] Slack `/events` (assistant_thread_started + message) still works end-to-end
- [ ] Slack `/interactions` (agent picker + tool approve/reject) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead code in the Slack integration to simplify maintenance and align on `slack_sdk`; no behavior change.

- **Refactors**
  - Deleted unused `send_slack_message` (`httpx`-based).
  - Removed duplicate `resolve_user` from `handlers.py`; import from `utils.py`.
  - Removed `handle_app_mention` (never routed).

<sup>Written for commit 478aba09efbec677f7380efd1168d34fed65ca3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

