### PR TITLE
Preserve server-rendered MCP app views and unblock openLink

### DIFF
--- a/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
@@ -46,6 +46,12 @@ const hasStructuredContent = (
 	"structuredContent" in output &&
 	isRecord(output.structuredContent);
 
+// When the result already carries a server-rendered view, forwarding
+// `toolInput` causes renderers like Prefab's to re-execute the LLM's `code`
+// argument client-side and overwrite the server view.
+const resultHasView = (result: CallToolResult | undefined): boolean =>
+	isRecord(result?.structuredContent) && "view" in result.structuredContent;
+
 // Content hash used to keep useMemo stable across parent re-renders that
 // rebuild the same value into a fresh reference.
 const stableKey = (value: unknown): string => {
@@ -117,6 +123,8 @@ export const McpAppWidget = ({
 		[outputKey, errorText, structuredKey],
 	);
 
+	const effectiveToolInput = resultHasView(toolResult) ? undefined : input;
+
 	const onReadResource = useCallback(
 		async ({ uri }: { uri: string }) => {
 			const response = await api.post(
@@ -160,6 +168,11 @@ export const McpAppWidget = ({
 		[serverId],
 	);
 
+	const onOpenLink = useCallback(async ({ url }: { url: string }) => {
+		const opened = window.open(url, "_blank", "noopener,noreferrer");
+		return { isError: !opened };
+	}, []);
+
 	if (typeof window === "undefined") {
 		return null;
 	}
@@ -183,10 +196,11 @@ export const McpAppWidget = ({
 				toolResourceUri={appToolInfo.resourceUri}
 				sandbox={sandboxConfig}
 				hostContext={hostContext}
-				toolInput={input}
+				toolInput={effectiveToolInput}
 				toolResult={toolResult}
 				onReadResource={onReadResource}
 				onCallTool={onCallTool}
+				onOpenLink={onOpenLink}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Suppress `toolInput` forwarding to `<AppRenderer>` once the tool result carries a `structuredContent.view`. Without this, `@mcp-ui/client`'s AppFrame fires `ui/notifications/tool-input` after the result arrives, which causes the Prefab generative renderer to re-execute the LLM's `code` argument client-side and overwrite the server-rendered view (e.g. server-augmented buttons appear briefly, then disappear).
- Wire an `onOpenLink` host callback so the renderer's `openLink` action routes through the parent window via `window.open` instead of falling back to a `window.open` call from inside the sandboxed iframe — that fallback is blocked by the browser because `allow-popups` is not (and shouldn't be) set on the sandbox.

Both changes are scoped to `web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx`. No SDK upgrade, no sandbox relaxation.

## Test plan
- [ ] Streaming-only tool (no `structuredContent.view`): rendered iframe still updates as the LLM types code; final view persists. (Existing behavior preserved by the `resultHasView` predicate.)
- [ ] View-bearing tool (e.g. `GenerativeUIWithExport`): the augmented view (Export-to-HTML button) is visible immediately when the result arrives and stays visible after the turn finishes.
- [ ] Cross-host parity: same MCP server in Claude Desktop renders identically.
- [ ] Trigger the same tool twice in one conversation — no flood of "Ignoring message from unknown source" warnings (the existing content-hash `useMemo` is untouched).
- [ ] Click a button bound to `{ action: "openLink", url: "http://…" }`: opens in a new tab, no sandboxed-popup console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves server-rendered MCP app views and makes `openLink` work from sandboxed apps by routing through the parent window.

- **Bug Fixes**
  - Stop passing `toolInput` to `<AppRenderer>` when `toolResult.structuredContent.view` exists to prevent client-side re-execution that overwrites server-rendered views (affects renderers like Prefab via `@mcp-ui/client`).
  - Add `onOpenLink` host callback to open links via `window.open` in the parent window (`_blank`, `noopener,noreferrer`), avoiding blocked popups from the sandboxed iframe.

<sup>Written for commit 75d881e007abcc673551b70e9c9a686f58a8b91f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

