### PR TITLE
Restyle chat UI to match sage design system

### DIFF
--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -59,7 +59,7 @@ class ChatModelFactory:
                 return ChatAnthropic(
                     model=model_id,
                     temperature=1,
-                    max_tokens=2048,
+                    max_tokens=16384,
                     streaming=True,
                     timeout=None,
                     thinking={"type": "enabled", "budget_tokens": 1024},

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	Fragment,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import Image from "next/image";
 import {
 	MessageActions,
@@ -149,7 +156,9 @@ function getFileAttachments(message: LCMessage): AttachmentData[] {
 
 		// File blocks: {"type": "file", "mime_type"/"mimeType": "...", "base64": "...", "filename": "..."}
 		if (block.type === "file") {
-			const mimeType = (block.mime_type ?? block.mimeType ?? "application/octet-stream") as string;
+			const mimeType = (block.mime_type ??
+				block.mimeType ??
+				"application/octet-stream") as string;
 			const base64 = (block.base64 ?? "") as string;
 			const filename = (block.filename ?? "file") as string;
 			const dataUrl = `data:${mimeType};base64,${base64}`;
@@ -284,13 +293,17 @@ function getMcpAppInfoFromToolCall(tc: LocalToolCall): McpAppToolInfo | null {
 	if (!artifact || typeof artifact !== "object") return null;
 	const a = artifact as Record<string, unknown>;
 	// Handle both camelCase (Axios/history) and snake_case (stream)
-	const resourceUri = (a.mcpAppResourceUri ?? a.mcp_app_resource_uri) as string | undefined;
+	const resourceUri = (a.mcpAppResourceUri ?? a.mcp_app_resource_uri) as
+		| string
+		| undefined;
 	const serverId = (a.mcpServerId ?? a.mcp_server_id) as string | undefined;
 	if (!resourceUri || !serverId) return null;
 	return { resourceUri, serverId };
 }
 
-function getStructuredContentFromToolCall(tc: LocalToolCall): Record<string, unknown> | undefined {
+function getStructuredContentFromToolCall(
+	tc: LocalToolCall,
+): Record<string, unknown> | undefined {
 	const artifact = tc.result?.artifact;
 	if (!artifact || typeof artifact !== "object") return undefined;
 	const a = artifact as Record<string, unknown>;
@@ -358,13 +371,7 @@ const ChatPage = () => {
 		},
 	} as Parameters<typeof useStream<Record<string, unknown>>>[0]);
 
-	const {
-		isLoading,
-		error,
-		interrupt,
-		submit: rawSubmit,
-		stop,
-	} = thread;
+	const { isLoading, error, interrupt, submit: rawSubmit, stop } = thread;
 
 	// Once anything is dispatched, the live stream owns interrupt state — drop
 	// the rehydrated fallback so it can't shadow a fresh post-resume answer.
@@ -389,9 +396,7 @@ const ChatPage = () => {
 	// of the whole conversation (and per-token markdown re-parses).
 	const streamMessagesRaw = thread.messages as LCMessage[];
 	const streamMessages = useThrottledValue(streamMessagesRaw, 60);
-	const initMessages = (
-		initialValues?.messages ?? []
-	) as LCMessage[];
+	const initMessages = (initialValues?.messages ?? []) as LCMessage[];
 	const messages =
 		streamMessages.length > 0 || isLoading ? streamMessages : initMessages;
 
@@ -399,7 +404,8 @@ const ChatPage = () => {
 
 	// Tool calls: use stream tool calls when streaming, else compute from messages
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const streamToolCallsRaw = ((thread as any).toolCalls ?? []) as LocalToolCall[];
+	const streamToolCallsRaw = ((thread as any).toolCalls ??
+		[]) as LocalToolCall[];
 	const streamToolCalls = useThrottledValue(streamToolCallsRaw, 60);
 	const localToolCalls = useMemo(
 		() => computeToolCallsFromMessages(messages),
@@ -499,7 +505,12 @@ const ChatPage = () => {
 		submit(
 			{ messages: [{ type: "human", content }] },
 			{
-				optimisticValues: { messages: [...messages, { type: "human", content, id: crypto.randomUUID() }] },
+				optimisticValues: {
+					messages: [
+						...messages,
+						{ type: "human", content, id: crypto.randomUUID() },
+					],
+				},
 				streamSubgraphs: true,
 			},
 		);
@@ -550,7 +561,9 @@ const ChatPage = () => {
 
 		// Find subagents that were reconstructed but have no internal messages
 		const toFetch = [...subagentApi.subagents.entries()].filter(
-			([, s]) => s.messages.length === 0 && (s.status === "complete" || s.status === "error"),
+			([, s]) =>
+				s.messages.length === 0 &&
+				(s.status === "complete" || s.status === "error"),
 		);
 		if (toFetch.length === 0) return;
 
@@ -559,7 +572,8 @@ const ChatPage = () => {
 		// Access the private subagentManager to call updateSubagentFromSubgraphState
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const streamManager = thread as any;
-		const subagentManager = streamManager.subagentManager ?? streamManager._subagentManager;
+		const subagentManager =
+			streamManager.subagentManager ?? streamManager._subagentManager;
 
 		Promise.all(
 			toFetch.map(async ([toolCallId]) => {
@@ -639,7 +653,7 @@ const ChatPage = () => {
 		<div className="h-full flex flex-col w-full overflow-hidden">
 			<div className="h-full relative flex flex-1 flex-col min-h-0 w-full">
 				<Conversation>
-					<ConversationContent className="max-w-4xl mx-auto w-full lg:px-10 px-6">
+					<ConversationContent className="max-w-4xl mx-auto w-full lg:px-10 sm:px-6 px-2">
 						{coordinatorTodos.length > 0 && (
 							<TodoList
 								todos={coordinatorTodos}
@@ -651,10 +665,7 @@ const ChatPage = () => {
 							if (message.type === "tool") return null;
 
 							// ---- Human message ----
-							if (
-								message.type === "human" ||
-								message.type === "user"
-							) {
+							if (message.type === "human" || message.type === "user") {
 								const text = getTextContent(message);
 								const attachments = getFileAttachments(message);
 
@@ -664,8 +675,7 @@ const ChatPage = () => {
 											<div className="flex justify-end">
 												<Attachments variant="inline">
 													{attachments.map((attachment) => {
-														const mediaCategory =
-															getMediaCategory(attachment);
+														const mediaCategory = getMediaCategory(attachment);
 														const label = getAttachmentLabel(attachment);
 														return (
 															<AttachmentHoverCard key={attachment.id}>
@@ -689,9 +699,7 @@ const ChatPage = () => {
 																						alt={label}
 																						className="object-contain"
 																						height={200}
-																						src={
-																							attachment.url as string
-																						}
+																						src={attachment.url as string}
 																						width={200}
 																					/>
 																				</div>
@@ -721,10 +729,7 @@ const ChatPage = () => {
 							}
 
 							// ---- AI message ----
-							if (
-								message.type === "ai" ||
-								message.type === "assistant"
-							) {
+							if (message.type === "ai" || message.type === "assistant") {
 								const text = getTextContent(message);
 								const reasoning = getReasoningContent(message);
 								const msgToolCalls = getToolCallsForMessage(message);
@@ -742,9 +747,7 @@ const ChatPage = () => {
 										{reasoning && (
 											<Reasoning
 												className="w-full"
-												isStreaming={
-													assistantIsStreaming && isLastMessage
-												}
+												isStreaming={assistantIsStreaming && isLastMessage}
 											>
 												<ReasoningTrigger />
 												<ReasoningContent>{reasoning}</ReasoningContent>
@@ -806,8 +809,7 @@ const ChatPage = () => {
 															mcpServerName={serverName}
 															mcpServerIcon={
 																mcpServers.find(
-																	(server) =>
-																		server.name === serverName,
+																	(server) => server.name === serverName,
 																)?.iconUrl
 															}
 														/>
@@ -820,24 +822,19 @@ const ChatPage = () => {
 																	tc.state === "error" ||
 																	tc.state === "pending") && (
 																	<ToolOutput
-																		output={
-																			output as React.ReactNode
-																		}
+																		output={output as React.ReactNode}
 																		errorText={
-																			tc.state === "error" &&
-																			tc.result
-																				? (typeof tc.result
-																						.content === "string"
-																						? tc.result.content
-																						: "Tool execution failed")
+																			tc.state === "error" && tc.result
+																				? typeof tc.result.content === "string"
+																					? tc.result.content
+																					: "Tool execution failed"
 																				: undefined
 																		}
 																	/>
 																)}
 															</ToolContentInner>
 															{/* HITL Approval UI */}
-															{toolState ===
-																"approval-requested" && (
+															{toolState === "approval-requested" && (
 																<ToolFooter>
 																	<Button
 																		variant="default"
@@ -876,7 +873,9 @@ const ChatPage = () => {
 															<McpAppWidget
 																input={tc.call.args}
 																output={getToolOutputContent(tc)}
-																structuredContent={getStructuredContentFromToolCall(tc)}
+																structuredContent={getStructuredContentFromToolCall(
+																	tc,
+																)}
 																errorText={
 																	tc.state === "error" && tc.result
 																		? typeof tc.result.content === "string"
@@ -903,7 +902,11 @@ const ChatPage = () => {
 												<div className="space-y-2 mt-1">
 													<SubAgentProgress subagents={turnSubagents} />
 													{turnSubagents.map((sub) => (
-														<SubAgentCard key={sub.id} subagent={sub} mcpServers={mcpServers} />
+														<SubAgentCard
+															key={sub.id}
+															subagent={sub}
+															mcpServers={mcpServers}
+														/>
 													))}
 													<SynthesisIndicator
 														subagents={turnSubagents}
@@ -969,7 +972,7 @@ const ChatPage = () => {
 			</div>
 			<div className="w-full shrink-0 bg-background">
 				{agentArchived ? (
-					<div className="w-full max-w-4xl mx-auto lg:px-10 px-6 py-6">
+					<div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-6">
 						<div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
 							<ArchiveIcon className="size-5 shrink-0 text-muted-foreground" />
 							<p className="text-sm text-muted-foreground">
@@ -980,7 +983,7 @@ const ChatPage = () => {
 						</div>
 					</div>
 				) : agentStatus === "not_configured" ? (
-					<div className="w-full max-w-4xl mx-auto lg:px-10 px-6 py-4">
+					<div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-4">
 						<div className="w-full flex items-center justify-center border border-red-200 bg-red-50 rounded-lg px-4 py-8">
 							<p className="text-md text-center text-red-700">
 								Agent is not configured yet. Contact agent owner to configure it
@@ -992,7 +995,7 @@ const ChatPage = () => {
 					<ChatPromptInput
 						onSubmit={handleSubmit}
 						status={isLoading ? "streaming" : "ready"}
-						className="w-full max-w-4xl mx-auto lg:px-10 px-6 py-4"
+						className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-4"
 						stop={stop}
 						selectedModel={threadModel}
 						readOnlyModel={true}

--- a/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
@@ -142,7 +142,7 @@ const ChatPromptInput = ({
 					"min-h-40 transition-all duration-200",
 					// Sage-style InputGroup container
 					"[&>[data-slot=input-group]]:rounded-[28px]",
-					"[&>[data-slot=input-group]]:border-[1.5px]",
+					"[&>[data-slot=input-group]]:border-[3px]",
 					"[&>[data-slot=input-group]]:border-[#E0E8E4]",
 					"dark:[&>[data-slot=input-group]]:border-white/10",
 					"[&>[data-slot=input-group]]:bg-white",

--- a/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
@@ -1,18 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import {
-	ModelSelector,
-	ModelSelectorContent,
-	ModelSelectorEmpty,
-	ModelSelectorGroup,
-	ModelSelectorInput,
-	ModelSelectorItem,
-	ModelSelectorList,
-	ModelSelectorLogo,
-	ModelSelectorName,
-	ModelSelectorTrigger,
-} from "@/components/ai-elements/model-selector";
+import { ModelSelectorLogo } from "@/components/ai-elements/model-selector";
 import {
 	PromptInput,
 	PromptInputAddAttachmentButton,
@@ -32,6 +21,29 @@ import { useModelsStore } from "@/stores/models-store";
 import { Model } from "@/types/models";
 import { MCPServer } from "@/types/mcp-servers";
 import { ConnectServersDialog } from "./connect-servers-dialog";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+	Dialog,
+	DialogContent,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { SearchBar } from "@/components/ui/search-bar";
+
+const sagePromptToolButtonClass = cn(
+	"h-9 px-3 gap-2 rounded-full",
+	"font-[family-name:var(--font-dm-sans)] text-[13px] font-medium",
+	"text-[#1E2D28] dark:text-white/90",
+	"bg-[#F5F8F6] dark:bg-white/5",
+	"hover:bg-[#EDF4F0] dark:hover:bg-white/10",
+	"data-[state=open]:bg-[#EDF4F0] dark:data-[state=open]:bg-white/10",
+	"disabled:opacity-60 disabled:cursor-not-allowed",
+	"transition-colors",
+);
 
 interface ChatPromptInputProps {
 	onSubmit: (message: PromptInputMessage) => void;
@@ -63,10 +75,12 @@ const ChatPromptInput = ({
 	const fetchModels = useModelsStore((state) => state.fetchModels);
 	const [model, setModel] = useState<string | undefined>(undefined);
 	const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
+	const [modelSearch, setModelSearch] = useState("");
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
 	const currentModel = externalSelectedModel ?? model;
 	const selectedModelData = models.find((m) => m.id === currentModel);
+	const isDeepseek = selectedModelData?.chefSlug === "deepseek";
 
 	const handleModelChange = (modelId: string) => {
 		setModel(modelId);
@@ -74,7 +88,15 @@ const ChatPromptInput = ({
 	};
 
 	const groupedModels = useMemo(() => {
-		return models.reduce(
+		const q = modelSearch.trim().toLowerCase();
+		const filtered = q
+			? models.filter(
+					(m) =>
+						m.name.toLowerCase().includes(q) ||
+						m.chef.toLowerCase().includes(q),
+				)
+			: models;
+		return filtered.reduce(
 			(acc, model) => {
 				acc[model.chef] = acc[model.chef] || [];
 				acc[model.chef].push(model);
@@ -82,7 +104,14 @@ const ChatPromptInput = ({
 			},
 			{} as Record<string, Model[]>,
 		);
-	}, [models]);
+	}, [models, modelSearch]);
+
+	const hasModelResults = Object.keys(groupedModels).length > 0;
+
+	const handleModelSelectorOpenChange = (open: boolean) => {
+		setModelSelectorOpen(open);
+		if (!open) setModelSearch("");
+	};
 
 	const handleSubmit = (message: PromptInputMessage) => {
 		if (!message) return;
@@ -109,91 +138,180 @@ const ChatPromptInput = ({
 				globalDrop
 				multiple
 				onSubmit={handleSubmit}
-				className={cn("min-h-40 transition-all duration-200", className)}
+				className={cn(
+					"min-h-40 transition-all duration-200",
+					// Sage-style InputGroup container
+					"[&>[data-slot=input-group]]:rounded-[28px]",
+					"[&>[data-slot=input-group]]:border-[1.5px]",
+					"[&>[data-slot=input-group]]:border-[#E0E8E4]",
+					"dark:[&>[data-slot=input-group]]:border-white/10",
+					"[&>[data-slot=input-group]]:bg-white",
+					"dark:[&>[data-slot=input-group]]:bg-[#1C1C1C]",
+					"[&>[data-slot=input-group]]:shadow-[0_8px_24px_-12px_rgba(30,45,40,0.08)]",
+					"dark:[&>[data-slot=input-group]]:shadow-[0_8px_24px_-12px_rgba(0,0,0,0.3)]",
+					"[&>[data-slot=input-group]]:transition-colors",
+					"[&>[data-slot=input-group]:focus-within]:border-[#4CA882]",
+					"dark:[&>[data-slot=input-group]:focus-within]:border-[#4CA882]",
+					// Remove default focus ring
+					"[&>[data-slot=input-group]]:has-[[data-slot=input-group-control]:focus-visible]:ring-0",
+					className,
+				)}
 			>
-				<PromptInputAttachments>
+				<PromptInputAttachments className="px-5 pt-4">
 					{(attachment) => <PromptInputAttachment data={attachment} />}
 				</PromptInputAttachments>
 				<PromptInputBody>
-					<PromptInputTextarea ref={textareaRef} disabled={agentReady === false} />
+					<PromptInputTextarea
+						ref={textareaRef}
+						disabled={agentReady === false}
+						className={cn(
+							"font-[family-name:var(--font-dm-sans)]",
+							"text-[15px] font-medium leading-relaxed",
+							"text-[#1E2D28] dark:text-white",
+							"placeholder:text-[#A3B5AD] dark:placeholder:text-white/30",
+							"px-5 pt-5 pb-2",
+						)}
+					/>
 				</PromptInputBody>
-				<PromptInputFooter>
-					<PromptInputTools>
-						<PromptInputAddAttachmentButton disabled={agentReady === false} />
+				<PromptInputFooter className="px-4 pb-4">
+					<PromptInputTools className="gap-1.5">
+						{isDeepseek ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span>
+										<PromptInputAddAttachmentButton
+											disabled
+											className={sagePromptToolButtonClass}
+										/>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>
+									DeepSeek models do not support attachments.
+								</TooltipContent>
+							</Tooltip>
+						) : (
+							<PromptInputAddAttachmentButton
+								disabled={agentReady === false}
+								className={sagePromptToolButtonClass}
+							/>
+						)}
 						{/* <PromptInputSpeechButton textareaRef={textareaRef} />
 						<PromptInputButton>
 							<GlobeIcon size={16} />
 							<span>Search</span>
 						</PromptInputButton> */}
 						{readOnlyModel ? (
-							<PromptInputButton disabled>
+							<PromptInputButton
+								disabled
+								className={sagePromptToolButtonClass}
+							>
 								{selectedModelData?.chefSlug && (
 									<ModelSelectorLogo provider={selectedModelData.chefSlug} />
 								)}
 								{selectedModelData?.name && (
-									<ModelSelectorName>
+									<span className="truncate text-left">
 										{selectedModelData.name}
-									</ModelSelectorName>
+									</span>
 								)}
 							</PromptInputButton>
 						) : (
-							<ModelSelector
-								onOpenChange={setModelSelectorOpen}
+							<Dialog
 								open={modelSelectorOpen}
+								onOpenChange={handleModelSelectorOpenChange}
 							>
-								<ModelSelectorTrigger asChild>
-									<PromptInputButton>
+								<DialogTrigger asChild>
+									<PromptInputButton className={sagePromptToolButtonClass}>
 										{selectedModelData ? (
 											<>
 												<ModelSelectorLogo
 													provider={selectedModelData.chefSlug}
 												/>
-												<ModelSelectorName>
+												<span className="truncate text-left">
 													{selectedModelData.name}
-												</ModelSelectorName>
+												</span>
 											</>
 										) : (
-											<>
-												<ModelSelectorName className="text-muted-foreground">
-													Select model
-												</ModelSelectorName>
-											</>
+											<span className="truncate text-left text-[#8FA89E] dark:text-white/40">
+												Select model
+											</span>
 										)}
 									</PromptInputButton>
-								</ModelSelectorTrigger>
-								<ModelSelectorContent>
-									<ModelSelectorInput placeholder="Search models..." />
-									<ModelSelectorList>
-										<ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
+								</DialogTrigger>
+								<DialogContent
+									className="sm:max-w-[480px] rounded-[28px] p-0 gap-0 overflow-hidden"
+									showCloseButton={false}
+								>
+									<div className="flex items-start justify-between px-7 pt-6 pb-4">
+										<div>
+											<DialogTitle className="font-[family-name:var(--font-jakarta-sans)] text-[20px] font-extrabold text-[#111111] dark:text-white tracking-[-0.02em]">
+												Select a model
+											</DialogTitle>
+											<p className="font-[family-name:var(--font-dm-sans)] text-[13px] text-[#8FA89E] dark:text-muted-foreground font-medium mt-1">
+												Choose the model powering this chat
+											</p>
+										</div>
+									</div>
 
-										{Object.entries(groupedModels).map(
-											([chefName, chefModels]) => (
-												<ModelSelectorGroup heading={chefName} key={chefName}>
-													{chefModels.map((m) => (
-														<ModelSelectorItem
-															key={m.id}
-															onSelect={() => {
-																handleModelChange(m.id);
-																setModelSelectorOpen(false);
-															}}
-															value={m.id}
-														>
-															<ModelSelectorLogo provider={m.chefSlug} />
-															<ModelSelectorName>{m.name}</ModelSelectorName>
+									<div className="px-7 pb-3">
+										<SearchBar
+											placeholder="Search models..."
+											value={modelSearch}
+											onChange={setModelSearch}
+										/>
+									</div>
 
-															{currentModel === m.id ? (
-																<CheckIcon className="ml-auto size-4" />
-															) : (
-																<div className="ml-auto size-4" />
-															)}
-														</ModelSelectorItem>
-													))}
-												</ModelSelectorGroup>
-											),
+									<div className="px-4 pb-5 max-h-[55vh] overflow-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+										{!hasModelResults ? (
+											<div className="font-[family-name:var(--font-dm-sans)] px-4 py-8 text-center text-[13px] text-[#A3B5AD] dark:text-muted-foreground">
+												No models found.
+											</div>
+										) : (
+											Object.entries(groupedModels).map(
+												([chefName, chefModels]) => (
+													<div key={chefName} className="px-2 pt-2">
+														<div className="font-[family-name:var(--font-dm-sans)] px-3 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8FA89E] dark:text-muted-foreground">
+															{chefName}
+														</div>
+														<div className="flex flex-col gap-0.5">
+															{chefModels.map((m) => {
+																const isActive = currentModel === m.id;
+																return (
+																	<button
+																		key={m.id}
+																		type="button"
+																		onClick={() => {
+																			handleModelChange(m.id);
+																			handleModelSelectorOpenChange(false);
+																		}}
+																		className={cn(
+																			"flex w-full items-center gap-3 px-3 py-2.5 rounded-[14px] cursor-pointer transition-colors text-left outline-none",
+																			"font-[family-name:var(--font-dm-sans)] text-[14px] font-medium",
+																			isActive
+																				? "bg-[#F8FAF9] dark:bg-white/5 text-[#1E2D28] dark:text-white"
+																				: "text-[#1E2D28] dark:text-white/90 hover:bg-[#F8FAF9] dark:hover:bg-white/5",
+																		)}
+																	>
+																		<ModelSelectorLogo provider={m.chefSlug} />
+																		<span className="flex-1 truncate">
+																			{m.name}
+																		</span>
+																		{isActive && (
+																			<CheckIcon
+																				className="ml-auto size-4 shrink-0 text-[#4CA882]"
+																				strokeWidth={3}
+																			/>
+																		)}
+																	</button>
+																);
+															})}
+														</div>
+													</div>
+												),
+											)
 										)}
-									</ModelSelectorList>
-								</ModelSelectorContent>
-							</ModelSelector>
+									</div>
+								</DialogContent>
+							</Dialog>
 						)}
 					</PromptInputTools>
 					{agentReady === false ? (
@@ -238,8 +356,8 @@ const SubmitButton = ({
 			className={cn(
 				"flex items-center justify-center rounded-full w-10 h-10 transition-all",
 				isDisabled
-					? "bg-gray-200 dark:bg-gray-800 text-gray-400 dark:text-gray-600 cursor-not-allowed"
-					: "bg-black dark:bg-white text-white font-bold dark:text-black hover:scale-105 cursor-pointer",
+					? "bg-[#EDF4F0] dark:bg-white/5 text-[#A3B5AD] dark:text-white/30 cursor-not-allowed"
+					: "bg-[#4CA882] text-white hover:bg-[#3F8F70] hover:scale-105 cursor-pointer shadow-[0_4px_12px_-4px_rgba(76,168,130,0.4)]",
 			)}
 		>
 			{isStreaming ? (
@@ -274,7 +392,9 @@ const ConnectButton = ({ onClick }: { onClick: () => void }) => {
 			onClick={onClick}
 			className={cn(
 				"flex items-center gap-2 rounded-full px-4 h-10 transition-all cursor-pointer",
-				"bg-black text-white font-medium hover:bg-gray-800",
+				"font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold",
+				"bg-[#4CA882] text-white hover:bg-[#3F8F70]",
+				"shadow-[0_4px_12px_-4px_rgba(76,168,130,0.4)]",
 			)}
 		>
 			<PlugIcon size={16} />

--- a/web/src/components/ai-elements/code-block.tsx
+++ b/web/src/components/ai-elements/code-block.tsx
@@ -51,7 +51,7 @@ const lineNumberTransformer: ShikiTransformer = {
 export async function highlightCode(
 	code: string,
 	language: BundledLanguage,
-	showLineNumbers = false
+	showLineNumbers = false,
 ) {
 	const transformers: ShikiTransformer[] = showLineNumbers
 		? [lineNumberTransformer]
@@ -101,8 +101,8 @@ export const CodeBlock = ({
 		<CodeBlockContext.Provider value={{ code }}>
 			<div
 				className={cn(
-					"group relative min-w-0 w-full max-w-full overflow-hidden rounded-md border bg-background text-foreground",
-					className
+					"group relative min-w-0 w-full max-w-full overflow-hidden rounded-md border border-border/30 text-foreground",
+					className,
 				)}
 				{...props}
 			>

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -57,8 +57,8 @@ export const MessageContent = ({
 		<div
 			onCopy={handleCopy}
 			className={cn(
-				"is-user:dark flex w-fit flex-col gap-2 overflow-hidden text-base leading-7",
-				"group-[.is-user]:ml-auto group-[.is-user]:rounded-3xl group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground md:group-[.is-user]:max-w-[60%] group-[.is-user]:max-w-[80%]",
+				"flex w-fit flex-col gap-2 overflow-hidden text-base leading-7",
+				"group-[.is-user]:ml-auto group-[.is-user]:rounded-3xl group-[.is-user]:bg-[#F3F8F5] dark:group-[.is-user]:bg-[#1E2D28]/40 group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-[#1E2D28] dark:group-[.is-user]:text-white md:group-[.is-user]:max-w-[60%] group-[.is-user]:max-w-[80%]",
 				"group-[.is-assistant]:text-foreground group-[.is-assistant]:w-full",
 				className,
 			)}

--- a/web/src/components/ai-elements/tool.tsx
+++ b/web/src/components/ai-elements/tool.tsx
@@ -24,7 +24,12 @@ export type ToolProps = ComponentProps<typeof Collapsible> & {
 	lockOpen?: boolean;
 };
 
-export const Tool = ({ className, toolState, lockOpen, ...props }: ToolProps) => {
+export const Tool = ({
+	className,
+	toolState,
+	lockOpen,
+	...props
+}: ToolProps) => {
 	const [userOpenPreference, setUserOpenPreference] = useState<boolean | null>(
 		null,
 	);
@@ -37,7 +42,7 @@ export const Tool = ({ className, toolState, lockOpen, ...props }: ToolProps) =>
 			open={isOpen}
 			onOpenChange={(open) => setUserOpenPreference(open)}
 			className={cn(
-				"not-prose group w-full min-w-0 overflow-hidden rounded-xl bg-muted/50 transition-colors hover:bg-muted/70",
+				"not-prose group w-full min-w-0 overflow-hidden rounded-xl bg-white dark:bg-[#1C1C1C] border-[1.5px] border-[#E0E8E4] dark:border-white/10 transition-colors hover:border-[#C8D8CF] dark:hover:border-white/15",
 				className,
 			)}
 			{...props}
@@ -173,7 +178,7 @@ export const ToolContentInner = ({
 }: ToolContentInnerProps) => (
 	<div
 		className={cn(
-			"mx-3 mb-3 min-w-0 space-y-3 rounded-lg bg-background/50 border border-border/30 overflow-hidden",
+			"mx-3 mb-3 min-w-0 space-y-3 rounded-lg bg-background/50 overflow-hidden",
 			className,
 		)}
 		{...props}
@@ -251,10 +256,7 @@ export const ToolOutput = ({
 
 	return (
 		<div
-			className={cn(
-				"min-w-0 space-y-2 overflow-hidden p-3 border-t border-border/30",
-				className,
-			)}
+			className={cn("min-w-0 space-y-2 overflow-hidden p-3", className)}
 			{...props}
 		>
 			<h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">

--- a/web/src/components/ai-elements/tool.tsx
+++ b/web/src/components/ai-elements/tool.tsx
@@ -42,7 +42,7 @@ export const Tool = ({
 			open={isOpen}
 			onOpenChange={(open) => setUserOpenPreference(open)}
 			className={cn(
-				"not-prose group w-full min-w-0 overflow-hidden rounded-xl bg-white dark:bg-[#1C1C1C] border-[1.5px] border-[#E0E8E4] dark:border-white/10 transition-colors hover:border-[#C8D8CF] dark:hover:border-white/15",
+				"not-prose group w-full min-w-0 overflow-hidden rounded-[20px] bg-white dark:bg-[#1C1C1C] border-[3px] border-[#E0E8E4] dark:border-white/10 transition-colors hover:border-[#C8D8CF] dark:hover:border-white/15",
 				className,
 			)}
 			{...props}
@@ -126,7 +126,7 @@ export const ToolHeader = ({
 	return (
 		<CollapsibleTrigger
 			className={cn(
-				"flex w-full items-center justify-between gap-4 px-4 py-3 cursor-pointer",
+				"flex w-full items-center justify-between gap-4 px-4 py-4 cursor-pointer",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
- **Prompt input**: sage-bordered 28px card, DM Sans textarea, rounded-pill tool buttons, sage-green submit/connect actions
- **Model picker**: replaced the `cmdk` dialog with a sage-styled selector (jakarta-sans title, `SearchBar`, grouped sage-tinted rows)
- **DeepSeek attachments**: attachment button stays visible but is disabled with a tooltip explaining DeepSeek doesn't support multimodal inputs yet
- **Tool call container**: white card with a 1.5px sage border (`#E0E8E4`) instead of muted gray
- **User message bubbles**: very light sage fill (`#F3F8F5`), borderless
- **Code block**: lighter `border-border/30`, transparent surface so it blends with the sage tool card
- **Backend**: bump Anthropic `max_tokens` from 2048 → 16384

## Test plan
- [ ] Open a chat — verify prompt input matches sage style (border, focus, fonts)
- [ ] Select a DeepSeek model — attachment button is disabled with tooltip
- [ ] Open the model selector — verify sage dialog styling and search filtering
- [ ] Trigger a tool call — confirm white card with sage border, sage user bubble
- [ ] Dark mode parity for all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyled the chat UI to the Sage design system with a Sage-styled model selector and search for faster model picking. Also raised Anthropic `max_tokens` to 16384 for longer responses.

- New Features
  - Prompt input: 28px rounded card with a 3px sage border, DM Sans textarea, pill tool buttons, and sage-green submit/connect.
  - Model picker: replaced `cmdk` dialog with a Sage `Dialog` + `SearchBar`, grouped providers, clear active state; search resets on close.
  - DeepSeek: attachment button stays visible but is disabled with a tooltip (no multimodal support).
  - Tool calls: white card with 3px sage border, rounded 20px, subtle hover; header spacing (py-4) adjusted.
  - User messages: borderless bubbles with very light sage fill (dark mode tint).
  - Code blocks: lighter `border-border/30` and transparent surface for better blending.
  - Responsive spacing: tighter horizontal padding on small screens for messages and the prompt input.
  - Backend: increased Anthropic `max_tokens` from 2048 to 16384.

<sup>Written for commit c932a4c5c2049beffde3aae7946efdafdbda37c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

