### PR TITLE
Fix/large tool output lag

### DIFF
--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
@@ -33,7 +33,7 @@ export default function MCPServerCard({ server, onClick }: MCPServerCardProps) {
 					alt={server.name}
 					width={48}
 					height={48}
-					className="shrink-0 rounded-xl bg-muted transition-transform duration-300 group-hover:rotate-[-8deg] group-hover:scale-110"
+					className="shrink-0 rounded-xl transition-transform duration-300 group-hover:rotate-[-8deg] group-hover:scale-110"
 				/>
 				<div className="min-w-0">
 					<h3 className="font-[family-name:var(--font-jakarta-sans)] text-[16px] font-bold text-[#1a1a2e] dark:text-foreground tracking-tight leading-tight truncate">

--- a/web/src/components/ai-elements/code-block.tsx
+++ b/web/src/components/ai-elements/code-block.tsx
@@ -71,6 +71,11 @@ export async function highlightCode(
 	]);
 }
 
+// Above this size, Shiki's regex tokenizer + the resulting highlighted DOM
+// freeze the main thread and bog down scrolling. Stay on the plain <pre>
+// fallback for these — indentation is preserved, only syntax colors are lost.
+export const SHIKI_MAX_CHARS = 30_000;
+
 export const CodeBlock = ({
 	code,
 	language,
@@ -83,6 +88,14 @@ export const CodeBlock = ({
 	const [darkHtml, setDarkHtml] = useState<string>("");
 
 	useEffect(() => {
+		if (code.length > SHIKI_MAX_CHARS) {
+			// Reset in case the same CodeBlock instance just shrank/grew across the
+			// threshold; otherwise stale highlighted HTML would linger.
+			setHtml("");
+			setDarkHtml("");
+			return;
+		}
+
 		let isMounted = true;
 
 		highlightCode(code, language, showLineNumbers).then(([light, dark]) => {

--- a/web/src/components/ai-elements/code-block.tsx
+++ b/web/src/components/ai-elements/code-block.tsx
@@ -121,7 +121,7 @@ export const CodeBlock = ({
 			>
 				<div className="relative min-w-0 max-w-full">
 					{!html ? (
-						<div className="min-w-0 max-w-full overflow-x-auto [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm">
+						<div className="min-w-0 max-w-full overflow-x-auto bg-background [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm">
 							<pre>
 								<code>{code}</code>
 							</pre>
@@ -129,12 +129,12 @@ export const CodeBlock = ({
 					) : (
 						<>
 							<div
-								className="min-w-0 max-w-full overflow-x-auto dark:hidden [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+								className="min-w-0 max-w-full overflow-x-auto bg-background dark:hidden [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
 								// biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
 								dangerouslySetInnerHTML={{ __html: html }}
 							/>
 							<div
-								className="hidden min-w-0 max-w-full overflow-x-auto dark:block [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
+								className="hidden min-w-0 max-w-full overflow-x-auto bg-background dark:block [&>pre]:m-0 [&>pre]:bg-background! [&>pre]:p-4 [&>pre]:text-foreground! [&>pre]:text-sm [&_code]:font-mono [&_code]:text-sm"
 								// biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed."
 								dangerouslySetInnerHTML={{ __html: darkHtml }}
 							/>

--- a/web/src/components/ai-elements/tool.tsx
+++ b/web/src/components/ai-elements/tool.tsx
@@ -17,7 +17,7 @@ import {
 import Image from "next/image";
 import type { ComponentProps, ReactNode } from "react";
 import { isValidElement, useState } from "react";
-import { CodeBlock } from "./code-block";
+import { CodeBlock, SHIKI_MAX_CHARS } from "./code-block";
 
 export type ToolProps = ComponentProps<typeof Collapsible> & {
 	toolState?: ToolUIPart["state"];
@@ -236,19 +236,17 @@ export const ToolOutput = ({
 	const content = errorText ?? output;
 
 	let Output: ReactNode = null;
+	let highlightingDisabled = false;
 
 	if (content != null) {
 		if (typeof content === "object" && !isValidElement(content)) {
-			Output = (
-				<CodeBlock
-					code={JSON.stringify(content, null, 2).replace(/\\n/g, "\n")}
-					language="json"
-				/>
-			);
+			const code = JSON.stringify(content, null, 2).replace(/\\n/g, "\n");
+			highlightingDisabled = code.length > SHIKI_MAX_CHARS;
+			Output = <CodeBlock code={code} language="json" />;
 		} else if (typeof content === "string") {
-			Output = (
-				<CodeBlock code={content.replace(/\\n/g, "\n")} language="json" />
-			);
+			const code = content.replace(/\\n/g, "\n");
+			highlightingDisabled = code.length > SHIKI_MAX_CHARS;
+			Output = <CodeBlock code={code} language="json" />;
 		} else {
 			Output = <div>{content as ReactNode}</div>;
 		}
@@ -259,9 +257,17 @@ export const ToolOutput = ({
 			className={cn("min-w-0 space-y-2 overflow-hidden p-3", className)}
 			{...props}
 		>
-			<h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-				Result
-			</h4>
+			<div className="flex items-baseline gap-2">
+				<h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+					Result
+				</h4>
+				{highlightingDisabled && (
+					<span className="text-muted-foreground/70 text-xs">
+						— syntax highlighting is disabled for outputs exceeding{" "}
+						{SHIKI_MAX_CHARS.toLocaleString()} characters
+					</span>
+				)}
+			</div>
 			<div className="min-w-0 overflow-x-auto rounded-md bg-muted/60 text-foreground text-xs [&_table]:w-full max-h-80 overflow-y-auto">
 				{Output}
 			</div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes UI freezes when opening very large tool outputs by skipping `shiki` highlighting above 30k characters and falling back to a plain pre block. Adds a small inline hint explaining when highlighting is disabled, and aligns code backgrounds to `bg-background`.

- **Bug Fixes**
  - Introduced `SHIKI_MAX_CHARS = 30_000`; `CodeBlock` stays on the plain pre fallback when content exceeds the limit and clears stale highlighted HTML.
  - `ToolOutput` uses the same threshold, disables highlighting for big results, and shows a short notice next to “Result.”
  - Set code block containers to `bg-background` and removed the muted background on the MCP server card image to avoid gray boxes.

<sup>Written for commit d40da6d6021fcf256ce2c5757f7fcc50954713c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

