### PR TITLE
feat: enforce auth on agent routes and update related tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ dev-backend:
 	cd backend && uv run uvicorn app.main:app --reload
 
 dev-frontend:
-	cd web && npm run dev
+	cd web && npm i && npm run dev
 
 dev:
 	make -j 3 dev-stack dev-backend dev-frontend

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -20,7 +20,7 @@ from app.agents.schemas import (
 )
 from app.agents.subagents.service import SubagentService
 from app.database import get_db
-from app.exceptions import NotFoundError
+from app.exceptions import NotFoundError, PermissionDeniedError
 from app.mcp.servers.models import MCPServerDB
 from app.mcp.utils import check_mcp_server_connected
 from app.service import BaseService
@@ -59,9 +59,10 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         user_role: WorkspaceRole | None,
     ) -> list[AgentResponse]:
         agent_ids = [a.id for a in agents]
-        subagents_map, is_subagent_ids = (
-            await self.subagent_service.load_all_subagent_data(agent_ids)
-        )
+        (
+            subagents_map,
+            is_subagent_ids,
+        ) = await self.subagent_service.load_all_subagent_data(agent_ids)
         return [
             AgentResponse(
                 **agent.model_dump(),
@@ -152,12 +153,22 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
     ) -> AgentResponse:
+        existing = await self.get_agent(agent_id, user_id=user_id, user_role=user_role)
+        if existing.current_user_permission not in ("owner", "admin", "editor"):
+            raise PermissionDeniedError("Not authorized to edit this agent")
         agent = await self.get_or_404(agent_id)
         await self.repository.update(agent, data)
         return await self.get_agent(agent_id, user_id=user_id, user_role=user_role)
 
-    async def delete_agent(self, agent_id: UUID) -> None:
+    async def delete_agent(
+        self,
+        agent_id: UUID,
+        user_id: UUID | None = None,
+        user_role: WorkspaceRole | None = None,
+    ) -> None:
         agent = await self.get_or_404(agent_id)
+        if agent.owner_id != user_id and user_role != WorkspaceRole.admin:
+            raise PermissionDeniedError("Not authorized to delete this agent")
         await self.subagent_service.delete_all_for_agent(agent_id)
         await self.repository.archive(agent)
 

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -22,7 +22,6 @@ from app.agents.schemas import (
 from app.agents.subagents.service import SubagentService, get_subagent_service
 from app.auth.dependencies import (
     get_current_user,
-    get_current_user_optional,
     require_admin,
     require_editor,
 )
@@ -56,13 +55,13 @@ async def get_agents(
 @router.get("/{agent_id}", response_model=AgentResponse, response_model_by_alias=True)
 async def get_agent(
     agent_id: UUID,
-    current_user: UserDB | None = Depends(get_current_user_optional),
+    current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> AgentResponse:
     return await service.get_agent(
         agent_id,
-        user_id=current_user.id if current_user else None,
-        user_role=current_user.role if current_user else None,
+        user_id=current_user.id,
+        user_role=current_user.role,
     )
 
 
@@ -81,6 +80,7 @@ async def update_agent(
 @router.delete("/{agent_id}", status_code=204)
 async def delete_agent(
     agent_id: UUID,
+    _: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> None:
     await service.delete_agent(agent_id)
@@ -129,6 +129,7 @@ async def update_mcp_server(
     agent_id: UUID,
     server_id: UUID,
     data: AgentMCPServerPatch,
+    _: UserDB = Depends(get_current_user),
     service: AgentMCPServerService = Depends(get_agent_mcp_server_service),
 ) -> AgentMCPServerResponse:
     return await service.update(agent_id, server_id, data)
@@ -138,6 +139,7 @@ async def update_mcp_server(
 async def delete_mcp_server(
     agent_id: UUID,
     server_id: UUID,
+    _: UserDB = Depends(get_current_user),
     service: AgentMCPServerService = Depends(get_agent_mcp_server_service),
 ) -> None:
     await service.delete(agent_id, server_id)

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -80,10 +80,12 @@ async def update_agent(
 @router.delete("/{agent_id}", status_code=204)
 async def delete_agent(
     agent_id: UUID,
-    _: UserDB = Depends(get_current_user),
+    current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> None:
-    await service.delete_agent(agent_id)
+    await service.delete_agent(
+        agent_id, user_id=current_user.id, user_role=current_user.role
+    )
 
 
 @router.get("/{agent_id}/permissions", response_model=list[AgentPermissionResponse])

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.agents.models import AgentDB
@@ -111,7 +112,8 @@ def test_get_agent(client: TestClient, mock_db, current_user):
     assert data["name"] == agent.name
 
 
-def test_get_agent_not_found(client: TestClient, mock_db, _current_user):
+@pytest.mark.usefixtures("current_user")
+def test_get_agent_not_found(client: TestClient, mock_db):
     """Test getting a non-existent agent returns 404."""
     fake_id = uuid4()
 
@@ -131,7 +133,7 @@ def test_get_agent_requires_auth(client: TestClient):
 
 
 def test_update_agent(client: TestClient, mock_db, current_user):
-    """Test updating an agent."""
+    """Test updating an agent (owner)."""
     agent_id = uuid4()
     owner_id = current_user.id
     agent = AgentDB(
@@ -151,10 +153,11 @@ def test_update_agent(client: TestClient, mock_db, current_user):
         return r
 
     mock_db.execute.side_effect = [
-        make_result(scalar=agent),  # repository.get
-        make_result(rows=[(agent, None)]),  # get_agent reload
-        make_result(scalars_list=[]),  # load_subagents → get_for_coordinator
-        make_result(scalar=None),  # is_subagent
+        make_result(rows=[(agent, None)]),  # get_agent (auth): list_with_permissions
+        make_result(scalars_list=[]),  # get_agent (auth): load_all_subagent_data
+        make_result(scalar=agent),  # get_or_404: repository.get
+        make_result(rows=[(agent, None)]),  # get_agent (return): list_with_permissions
+        make_result(scalars_list=[]),  # get_agent (return): load_all_subagent_data
     ]
 
     update_data = {
@@ -171,12 +174,13 @@ def test_update_agent(client: TestClient, mock_db, current_user):
     assert data["mcp_servers"] == []
 
 
-def test_update_agent_not_found(client: TestClient, mock_db, _current_user):
+@pytest.mark.usefixtures("current_user")
+def test_update_agent_not_found(client: TestClient, mock_db):
     """Test updating a non-existent agent returns 404."""
     fake_id = uuid4()
 
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None
+    mock_result.all.return_value = []
     mock_db.execute.return_value = mock_result
 
     update_data = {"name": "Updated Name"}
@@ -185,15 +189,45 @@ def test_update_agent_not_found(client: TestClient, mock_db, _current_user):
     assert response.json()["detail"] == "Agent not found"
 
 
-def test_delete_agent(client: TestClient, mock_db, _current_user):
-    """Test deleting an agent."""
+def test_update_agent_forbidden_for_non_owner(
+    client: TestClient, mock_db, current_user
+):
+    """A member who is neither owner nor admin cannot update an agent."""
     agent_id = uuid4()
-    owner_id = uuid4()
+    other_owner = uuid4()
+    assert other_owner != current_user.id
+    agent = AgentDB(
+        id=agent_id,
+        name="Someone Else's Agent",
+        instructions="...",
+        owner_id=other_owner,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    def make_result(*, rows=None, scalars_list=None):
+        r = MagicMock()
+        r.all.return_value = rows or []
+        r.scalars.return_value.all.return_value = scalars_list or []
+        return r
+
+    mock_db.execute.side_effect = [
+        make_result(rows=[(agent, None, None)]),  # list_with_permissions: no grant
+        make_result(scalars_list=[]),  # load_all_subagent_data
+    ]
+
+    response = client.patch(f"/agents/{agent_id}", json={"name": "Pwned"})
+    assert response.status_code == 403
+
+
+def test_delete_agent(client: TestClient, mock_db, current_user):
+    """Owner can delete their own agent."""
+    agent_id = uuid4()
     agent = AgentDB(
         id=agent_id,
         name="Agent to Delete",
         instructions="This agent will be deleted",
-        owner_id=owner_id,
+        owner_id=current_user.id,
         created_at=datetime.now(),
         updated_at=datetime.now(),
     )
@@ -207,7 +241,8 @@ def test_delete_agent(client: TestClient, mock_db, _current_user):
     assert agent.is_archived is True
 
 
-def test_delete_agent_not_found(client: TestClient, mock_db, _current_user):
+@pytest.mark.usefixtures("current_user")
+def test_delete_agent_not_found(client: TestClient, mock_db):
     """Test deleting a non-existent agent returns 404."""
     fake_id = uuid4()
 
@@ -218,6 +253,52 @@ def test_delete_agent_not_found(client: TestClient, mock_db, _current_user):
     response = client.delete(f"/agents/{fake_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == "Agent not found"
+
+
+def test_delete_agent_forbidden_for_non_owner(
+    client: TestClient, mock_db, current_user
+):
+    """A member who is neither owner nor admin cannot delete an agent."""
+    other_owner = uuid4()
+    assert other_owner != current_user.id
+    agent = AgentDB(
+        id=uuid4(),
+        name="Someone Else's Agent",
+        instructions="...",
+        owner_id=other_owner,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = agent
+    mock_db.execute.return_value = mock_result
+
+    response = client.delete(f"/agents/{agent.id}")
+    assert response.status_code == 403
+    assert agent.is_archived is False
+
+
+def test_delete_agent_allows_workspace_admin(client: TestClient, mock_db, admin_user):
+    """Workspace admin can delete any agent."""
+    other_owner = uuid4()
+    assert other_owner != admin_user.id
+    agent = AgentDB(
+        id=uuid4(),
+        name="Other User's Agent",
+        instructions="...",
+        owner_id=other_owner,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = agent
+    mock_db.execute.return_value = mock_result
+
+    response = client.delete(f"/agents/{agent.id}")
+    assert response.status_code == 204
+    assert agent.is_archived is True
 
 
 def test_delete_agent_requires_auth(client: TestClient):

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -111,7 +111,7 @@ def test_get_agent(client: TestClient, mock_db, current_user):
     assert data["name"] == agent.name
 
 
-def test_get_agent_not_found(client: TestClient, mock_db):
+def test_get_agent_not_found(client: TestClient, mock_db, _current_user):
     """Test getting a non-existent agent returns 404."""
     fake_id = uuid4()
 
@@ -122,6 +122,12 @@ def test_get_agent_not_found(client: TestClient, mock_db):
     response = client.get(f"/agents/{fake_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == "Agent not found"
+
+
+def test_get_agent_requires_auth(client: TestClient):
+    """Test that GET /agents/{id} returns 401 without auth."""
+    response = client.get(f"/agents/{uuid4()}")
+    assert response.status_code == 401
 
 
 def test_update_agent(client: TestClient, mock_db, current_user):
@@ -145,10 +151,10 @@ def test_update_agent(client: TestClient, mock_db, current_user):
         return r
 
     mock_db.execute.side_effect = [
-        make_result(scalar=agent),         # repository.get
-        make_result(rows=[(agent, None)]), # get_agent reload
-        make_result(scalars_list=[]),       # load_subagents → get_for_coordinator
-        make_result(scalar=None),          # is_subagent
+        make_result(scalar=agent),  # repository.get
+        make_result(rows=[(agent, None)]),  # get_agent reload
+        make_result(scalars_list=[]),  # load_subagents → get_for_coordinator
+        make_result(scalar=None),  # is_subagent
     ]
 
     update_data = {
@@ -165,7 +171,7 @@ def test_update_agent(client: TestClient, mock_db, current_user):
     assert data["mcp_servers"] == []
 
 
-def test_update_agent_not_found(client: TestClient, mock_db, current_user):
+def test_update_agent_not_found(client: TestClient, mock_db, _current_user):
     """Test updating a non-existent agent returns 404."""
     fake_id = uuid4()
 
@@ -179,7 +185,7 @@ def test_update_agent_not_found(client: TestClient, mock_db, current_user):
     assert response.json()["detail"] == "Agent not found"
 
 
-def test_delete_agent(client: TestClient, mock_db):
+def test_delete_agent(client: TestClient, mock_db, _current_user):
     """Test deleting an agent."""
     agent_id = uuid4()
     owner_id = uuid4()
@@ -201,7 +207,7 @@ def test_delete_agent(client: TestClient, mock_db):
     assert agent.is_archived is True
 
 
-def test_delete_agent_not_found(client: TestClient, mock_db):
+def test_delete_agent_not_found(client: TestClient, mock_db, _current_user):
     """Test deleting a non-existent agent returns 404."""
     fake_id = uuid4()
 
@@ -212,3 +218,9 @@ def test_delete_agent_not_found(client: TestClient, mock_db):
     response = client.delete(f"/agents/{fake_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == "Agent not found"
+
+
+def test_delete_agent_requires_auth(client: TestClient):
+    """Test that DELETE /agents/{id} returns 401 without auth."""
+    response = client.delete(f"/agents/{uuid4()}")
+    assert response.status_code == 401

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -12,13 +12,14 @@ from app.agents.models import (
     ToolStatus,
 )
 from app.agents.schemas import AgentCreateDB, AgentPatch, AgentResponse
-from app.exceptions import NotFoundError
+from app.exceptions import NotFoundError, PermissionDeniedError
 from app.users.models import WorkspaceRole
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_db():
@@ -68,6 +69,7 @@ def service(mock_db, mock_repo, mock_subagent_service):
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def make_agent(**kwargs):
     defaults = dict(
         id=uuid4(),
@@ -100,6 +102,7 @@ def _make_mock_execute_result(*, rows=_UNSET, scalar=_UNSET, scalars_list=_UNSET
 # create_agent
 # ---------------------------------------------------------------------------
 
+
 async def test_create_agent_delegates_to_repository(service, mock_repo):
     agent = make_agent()
     mock_repo.create.return_value = agent
@@ -114,6 +117,7 @@ async def test_create_agent_delegates_to_repository(service, mock_repo):
 # ---------------------------------------------------------------------------
 # get_agent
 # ---------------------------------------------------------------------------
+
 
 async def test_get_agent_returns_agent_read(service, mock_repo):
     agent = make_agent()
@@ -190,6 +194,7 @@ async def test_get_agent_skips_null_bindings(service, mock_repo):
 # list_agents
 # ---------------------------------------------------------------------------
 
+
 async def test_list_agents_returns_empty_when_no_agents(service, mock_repo):
     mock_repo.list_with_permissions.return_value = []
 
@@ -211,14 +216,25 @@ async def test_list_agents_returns_one_per_agent(service, mock_repo):
 async def test_list_agents_deduplicates_multiple_bindings_per_agent(service, mock_repo):
     agent = make_agent()
     binding1 = AgentMCPServerDB(
-        id=uuid4(), agent_id=agent.id, mcp_server_id=uuid4(),
-        tools=None, created_at=datetime.now(), updated_at=datetime.now(),
+        id=uuid4(),
+        agent_id=agent.id,
+        mcp_server_id=uuid4(),
+        tools=None,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
     )
     binding2 = AgentMCPServerDB(
-        id=uuid4(), agent_id=agent.id, mcp_server_id=uuid4(),
-        tools=None, created_at=datetime.now(), updated_at=datetime.now(),
+        id=uuid4(),
+        agent_id=agent.id,
+        mcp_server_id=uuid4(),
+        tools=None,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
     )
-    mock_repo.list_with_permissions.return_value = [(agent, binding1), (agent, binding2)]
+    mock_repo.list_with_permissions.return_value = [
+        (agent, binding1),
+        (agent, binding2),
+    ]
 
     result = await service.list_agents(user_role=WorkspaceRole.admin)
 
@@ -252,7 +268,9 @@ async def test_list_agents_granted_permission_from_row(service, mock_repo):
         (agent, None, PermissionLevel.editor)
     ]
 
-    result = await service.list_agents(user_id=non_owner_id, user_role=WorkspaceRole.member)
+    result = await service.list_agents(
+        user_id=non_owner_id, user_role=WorkspaceRole.member
+    )
 
     assert result[0].current_user_permission == "editor"
 
@@ -262,12 +280,16 @@ async def test_list_agents_no_permission_when_not_granted(service, mock_repo):
     non_owner_id = uuid4()
     mock_repo.list_with_permissions.return_value = [(agent, None, None)]
 
-    result = await service.list_agents(user_id=non_owner_id, user_role=WorkspaceRole.member)
+    result = await service.list_agents(
+        user_id=non_owner_id, user_role=WorkspaceRole.member
+    )
 
     assert result[0].current_user_permission is None
 
 
-async def test_list_agents_no_user_returns_agents_with_no_permission(service, mock_repo):
+async def test_list_agents_no_user_returns_agents_with_no_permission(
+    service, mock_repo
+):
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
@@ -280,12 +302,15 @@ async def test_list_agents_no_user_returns_agents_with_no_permission(service, mo
 # update_agent
 # ---------------------------------------------------------------------------
 
+
 async def test_update_agent_delegates_to_repository(service, mock_repo):
     agent = make_agent()
     mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.update_agent(agent.id, AgentPatch(name="Updated"))
+    result = await service.update_agent(
+        agent.id, AgentPatch(name="Updated"), user_id=agent.owner_id
+    )
 
     mock_repo.get.assert_awaited_once_with(agent.id)
     call_args = mock_repo.update.call_args[0]
@@ -302,7 +327,9 @@ async def test_update_agent_passes_only_set_fields(service, mock_repo):
     mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    await service.update_agent(agent.id, AgentPatch(name="New Name"))
+    await service.update_agent(
+        agent.id, AgentPatch(name="New Name"), user_id=agent.owner_id
+    )
 
     update_schema = mock_repo.update.call_args[0][1]
     assert isinstance(update_schema, AgentPatch)
@@ -310,7 +337,7 @@ async def test_update_agent_passes_only_set_fields(service, mock_repo):
 
 
 async def test_update_agent_raises_404_when_not_found(service, mock_repo):
-    mock_repo.get.return_value = None
+    mock_repo.list_with_permissions.return_value = []
 
     with pytest.raises(NotFoundError) as exc_info:
         await service.update_agent(uuid4(), AgentPatch(name="X"))
@@ -319,15 +346,44 @@ async def test_update_agent_raises_404_when_not_found(service, mock_repo):
     mock_repo.update.assert_not_called()
 
 
+async def test_update_agent_raises_403_when_no_permission(service, mock_repo):
+    agent = make_agent()
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+
+    with pytest.raises(PermissionDeniedError):
+        await service.update_agent(agent.id, AgentPatch(name="X"), user_id=uuid4())
+
+    mock_repo.get.assert_not_called()
+    mock_repo.update.assert_not_called()
+
+
+async def test_update_agent_allows_workspace_admin(service, mock_repo):
+    agent = make_agent()
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+
+    await service.update_agent(
+        agent.id,
+        AgentPatch(name="Renamed"),
+        user_id=uuid4(),
+        user_role=WorkspaceRole.admin,
+    )
+
+    mock_repo.update.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # delete_agent
 # ---------------------------------------------------------------------------
 
-async def test_delete_agent_delegates_to_repository(service, mock_repo, mock_subagent_service):
+
+async def test_delete_agent_delegates_to_repository(
+    service, mock_repo, mock_subagent_service
+):
     agent = make_agent()
     mock_repo.get.return_value = agent
 
-    await service.delete_agent(agent.id)
+    await service.delete_agent(agent.id, user_id=agent.owner_id)
 
     mock_repo.get.assert_awaited_once_with(agent.id)
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
@@ -344,9 +400,35 @@ async def test_delete_agent_raises_404_when_not_found(service, mock_repo):
     mock_repo.archive.assert_not_called()
 
 
+async def test_delete_agent_raises_403_for_non_owner(
+    service, mock_repo, mock_subagent_service
+):
+    agent = make_agent()
+    mock_repo.get.return_value = agent
+
+    with pytest.raises(PermissionDeniedError):
+        await service.delete_agent(agent.id, user_id=uuid4())
+
+    mock_subagent_service.delete_all_for_agent.assert_not_called()
+    mock_repo.archive.assert_not_called()
+
+
+async def test_delete_agent_allows_workspace_admin(
+    service, mock_repo, mock_subagent_service
+):
+    agent = make_agent()
+    mock_repo.get.return_value = agent
+
+    await service.delete_agent(agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin)
+
+    mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
+    mock_repo.archive.assert_awaited_once_with(agent)
+
+
 # ---------------------------------------------------------------------------
 # check_ready
 # ---------------------------------------------------------------------------
+
 
 async def test_check_ready_returns_ready_when_no_mcp_servers(service, mock_repo):
     agent = make_agent()
@@ -359,7 +441,9 @@ async def test_check_ready_returns_ready_when_no_mcp_servers(service, mock_repo)
     assert result["disconnected_servers"] == []
 
 
-async def test_check_ready_returns_not_configured_when_tools_is_none(service, mock_repo):
+async def test_check_ready_returns_not_configured_when_tools_is_none(
+    service, mock_repo
+):
     agent = make_agent()
     server_id = uuid4()
     binding = AgentMCPServerDB(
@@ -378,7 +462,9 @@ async def test_check_ready_returns_not_configured_when_tools_is_none(service, mo
     assert result["status"] == "not_configured"
 
 
-async def test_check_ready_returns_ready_when_all_servers_connected(service, mock_db, mock_repo):
+async def test_check_ready_returns_ready_when_all_servers_connected(
+    service, mock_db, mock_repo
+):
     agent = make_agent()
     server_id = uuid4()
     binding = AgentMCPServerDB(
@@ -405,7 +491,9 @@ async def test_check_ready_returns_ready_when_all_servers_connected(service, moc
     assert result["disconnected_servers"] == []
 
 
-async def test_check_ready_returns_not_ready_when_server_disconnected(service, mock_db, mock_repo):
+async def test_check_ready_returns_not_ready_when_server_disconnected(
+    service, mock_db, mock_repo
+):
     agent = make_agent()
     server_id = uuid4()
     binding = AgentMCPServerDB(
@@ -461,6 +549,7 @@ async def test_check_ready_disconnected_status_label(service, mock_db, mock_repo
 # ---------------------------------------------------------------------------
 # _resolve_permission (unit tests for the private helper)
 # ---------------------------------------------------------------------------
+
 
 def test_resolve_permission_returns_owner_when_owner(service):
     owner_id = uuid4()

--- a/web/src/app/(protected)/agents/[id]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from "next/headers";
 import { Agent } from "@/types/agents";
 import AgentEditor from "../components/agent-editor";
 import { api } from "@/lib/api/client";
@@ -8,9 +9,10 @@ interface AgentPageProps {
 
 export default async function AgentPage({ params }: AgentPageProps) {
 	const { id } = await params;
+	const cookieStore = await cookies();
 
-	const agent: Agent = await api.get(`/agents/${id}`).then((res) => {
-		return res.data;
+	const { data: agent } = await api.get<Agent>(`/agents/${id}`, {
+		headers: { Cookie: cookieStore.toString() },
 	});
 
 	return <AgentEditor agent={agent} />;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require authentication and caller-based authorization on agent endpoints. Forward SSR cookies so the agent detail page loads under server-side rendering; add 401/403 tests; auto-install frontend deps in dev.

- **New Features**
  - Require auth on `GET /agents/{id}`, `PATCH /agents/{id}`, `DELETE /agents/{id}`, and MCP server update/delete; router forwards `user_id`/`user_role`. `GET` returns 401 if unauthenticated. `PATCH` allows owner, workspace admin, or granted editor/admin; `DELETE` allows owner or workspace admin. Added 401/403 tests.
  - Web: forward the `Cookie` header from `next/headers` when fetching `/agents/{id}` on the server.

- **Dependencies**
  - `make dev-frontend` runs `npm i` before starting the dev server.

<sup>Written for commit b047eab96d20724e1c244307ad5171390fc14e14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

