### PR TITLE
fix: scope HITL decisions to hanging tool calls only

### DIFF
--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -46,16 +46,23 @@ async def read_thread(
         if todos:
             values["todos"] = todos
 
-        interrupted = any(
-            channel == "__interrupt__"
-            for (_, channel, _) in (checkpoint_tuple.pending_writes or [])
-        )
+        interrupt_value = None
+        for _, channel, value in checkpoint_tuple.pending_writes or []:
+            if channel != "__interrupt__":
+                continue
+            batch = value if isinstance(value, (list, tuple)) else [value]
+            if not batch:
+                continue
+            first = batch[0]
+            interrupt_value = getattr(first, "value", first)
+            break
 
         return {
             "messages": deserialize_to_ui_messages(lc_messages),
             "values": values,
             "thread": thread_read,
-            "interrupted": interrupted,
+            "interrupted": interrupt_value is not None,
+            "interrupt_value": interrupt_value,
         }
 
 

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -280,12 +280,31 @@ type ToolRenderState =
 function getToolRenderState(
 	tc: LocalToolCall,
 	isInterrupted: boolean,
+	hitlToolNames?: Set<string> | null,
 ): ToolRenderState {
 	if (tc.state === "completed") return "output-available";
 	if (tc.state === "error") return "output-error";
 	// pending
-	if (isInterrupted) return "approval-requested";
+	if (isInterrupted && (!hitlToolNames || hitlToolNames.has(tc.call.name))) {
+		return "approval-requested";
+	}
 	return "input-available";
+}
+
+// Extracts the set of tool names that require human approval from an HITL
+// interrupt payload. Tolerates both snake_case (live SSE) and camelCase
+// (rehydrated via the axios interceptor) shapes.
+function extractHitlToolNames(value: unknown): Set<string> | null {
+	if (!value || typeof value !== "object") return null;
+	const v = value as Record<string, unknown>;
+	const arr = (v.action_requests ?? v.actionRequests) as
+		| Array<{ name?: string }>
+		| undefined;
+	if (!Array.isArray(arr)) return null;
+	const names = arr
+		.map((r) => (r && typeof r.name === "string" ? r.name : null))
+		.filter((n): n is string => n != null);
+	return new Set(names);
 }
 
 function getMcpAppInfoFromToolCall(tc: LocalToolCall): McpAppToolInfo | null {
@@ -342,6 +361,8 @@ const ChatPage = () => {
 		unknown
 	> | null>(null);
 	const [rehydratedInterrupt, setRehydratedInterrupt] = useState(false);
+	const [rehydratedInterruptValue, setRehydratedInterruptValue] =
+		useState<unknown>(null);
 
 	const { mcpServers } = useMcpServersStore();
 	const {
@@ -378,6 +399,7 @@ const ChatPage = () => {
 	const submit = useCallback<typeof rawSubmit>(
 		(input, opts) => {
 			setRehydratedInterrupt(false);
+			setRehydratedInterruptValue(null);
 			return rawSubmit(input, opts);
 		},
 		[rawSubmit],
@@ -401,6 +423,19 @@ const ChatPage = () => {
 		streamMessages.length > 0 || isLoading ? streamMessages : initMessages;
 
 	const isInterrupted = interrupt != null || rehydratedInterrupt;
+
+	// The HITL middleware only "hangs" tool calls whose name is in interrupt_on.
+	// Other parallel tool calls in the same AI message auto-execute on resume.
+	// Scope approval UI and decisions to the hanging subset so the decision count
+	// matches the backend's hanging count.
+	const hitlToolNames = useMemo(() => {
+		const liveValue = (interrupt as { value?: unknown } | null | undefined)
+			?.value;
+		return (
+			extractHitlToolNames(liveValue) ??
+			extractHitlToolNames(rehydratedInterruptValue)
+		);
+	}, [interrupt, rehydratedInterruptValue]);
 
 	// Tool calls: use stream tool calls when streaming, else compute from messages
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -519,9 +554,11 @@ const ChatPage = () => {
 	const pendingToolCalls = useMemo(
 		() =>
 			toolCalls.filter(
-				(tc) => getToolRenderState(tc, isInterrupted) === "approval-requested",
+				(tc) =>
+					getToolRenderState(tc, isInterrupted, hitlToolNames) ===
+					"approval-requested",
 			),
-		[toolCalls, isInterrupted],
+		[toolCalls, isInterrupted, hitlToolNames],
 	);
 
 	const { decisions, recordDecision } = useHitlApprovals({
@@ -628,6 +665,9 @@ const ChatPage = () => {
 
 			if (data.interrupted) {
 				setRehydratedInterrupt(true);
+				if (data.interruptValue !== undefined) {
+					setRehydratedInterruptValue(data.interruptValue);
+				}
 			}
 
 			const pendingMessage = consumePendingMessage(threadId);
@@ -785,7 +825,11 @@ const ChatPage = () => {
 
 										{/* Tool calls */}
 										{msgToolCalls.map((tc) => {
-											const toolState = getToolRenderState(tc, isInterrupted);
+											const toolState = getToolRenderState(
+												tc,
+												isInterrupted,
+												hitlToolNames,
+											);
 											const { serverName, toolName } = getToolMetadata(
 												tc.call.name,
 												knownServerNames,


### PR DESCRIPTION
## Summary
- When the LLM emits parallel tool calls where some require approval and some don't, the backend `HumanInTheLoopMiddleware` only hangs the ones in `interrupt_on`, but the frontend treated every pending tool call as awaiting approval — sending N decisions for K hanging calls and tripping `ValueError: Number of human decisions (N) does not match number of hanging tool calls (K)`.
- Use the HITL interrupt payload's `action_requests` to derive the set of hanging tool names and scope both the approval UI and the decisions array to that subset; non-HITL parallel calls now render as `input-available` (queued for auto-execution on resume).
- `GET /threads/{thread_id}` now also returns `interrupt_value` so the rehydration path (page reload while interrupted) has the same information the live SSE stream provides; helper handles both snake_case (live) and camelCase (rehydrated via axios) shapes.

## Test plan
- [x] Configure an agent with two MCP tools where both are `needs_approval`; verify a parallel call hangs both, both approve buttons appear, approving both resumes cleanly.
- [x] Configure an agent with one `needs_approval` tool and one `always_allow` tool; verify a parallel call only shows approve/reject on the HITL tool, and resuming runs both successfully (previously errored).
- [x] Reload the chat page mid-interrupt and verify the approval UI re-renders correctly for the right subset of tools.
- [x] Regression: single HITL tool call still works (approval, rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mismatched HITL decisions when the LLM emits parallel tool calls by scoping approvals to only the hanging calls, preventing decision count errors and allowing clean resume.

- **Bug Fixes**
  - Frontend derives hanging tool names from the interrupt payload’s `action_requests` and only shows approve/reject for those tools; others render as input-available and auto-run on resume.
  - Decisions array is now scoped to the hanging subset, eliminating “Number of human decisions does not match number of hanging tool calls” errors.
  - `GET /threads/{thread_id}` now returns `interrupt_value` so reloads rehydrate HITL state; helper accepts both snake_case (live SSE) and camelCase (rehydrated).

<sup>Written for commit b0e2009760301c56018baf14c3ad836eae43bd0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

