### PR TITLE
feat: agent thread history page + thread source

### DIFF
--- a/backend/alembic/versions/c9a4f1d83b27_add_source_to_threads.py
+++ b/backend/alembic/versions/c9a4f1d83b27_add_source_to_threads.py
@@ -1,0 +1,39 @@
+"""Add source column to threads
+
+Revision ID: c9a4f1d83b27
+Revises: a57400e4fb11
+Create Date: 2026-05-13 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c9a4f1d83b27'
+down_revision: Union[str, Sequence[str], None] = 'a57400e4fb11'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'threads',
+        sa.Column('source', sa.String(), nullable=True),
+    )
+    # Slack threads historically used the Slack thread_ts (contains '.') as id;
+    # everything else was created via the in-app web UI.
+    op.execute("UPDATE threads SET source = 'slack' WHERE id LIKE '%.%'")
+    op.execute("UPDATE threads SET source = 'web' WHERE source IS NULL")
+    op.alter_column(
+        'threads',
+        'source',
+        existing_type=sa.String(),
+        nullable=False,
+        server_default='web',
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('threads', 'source')

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -25,6 +25,9 @@ from app.auth.dependencies import (
     require_admin,
     require_editor,
 )
+from app.exceptions import PermissionDeniedError
+from app.threads.schemas import AgentThreadResponse
+from app.threads.service import ThreadService, get_thread_service
 from app.users.models import UserDB
 
 
@@ -191,3 +194,20 @@ async def is_ready(
     service: AgentService = Depends(get_agent_service),
 ):
     return await service.check_ready(agent_id, str(current_user.id))
+
+
+@router.get("/{agent_id}/threads", response_model=list[AgentThreadResponse])
+async def list_agent_threads(
+    agent_id: UUID,
+    current_user: UserDB = Depends(get_current_user),
+    agent_service: AgentService = Depends(get_agent_service),
+    thread_service: ThreadService = Depends(get_thread_service),
+) -> list[AgentThreadResponse]:
+    """List all threads for an agent across users. Restricted to agent owners
+    and admins (workspace or agent-level)."""
+    agent = await agent_service.get_agent(
+        agent_id, user_id=current_user.id, user_role=current_user.role
+    )
+    if agent.current_user_permission not in ("owner", "admin"):
+        raise PermissionDeniedError("Not authorized to view this agent's threads")
+    return await thread_service.list_threads_for_agent(agent_id)

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Literal
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request, status
@@ -119,3 +120,17 @@ def require_role(minimum_role: WorkspaceRole) -> Callable:
 
 require_admin = require_role(WorkspaceRole.admin)
 require_editor = require_role(WorkspaceRole.editor)
+
+
+def detect_auth_method(request: Request) -> Literal["cookie", "bearer"]:
+    """Return how the current request was authenticated.
+
+    Mirrors the precedence in ``get_current_user``: cookie wins when present
+    and valid; everything else falls through to bearer. A stale/invalid cookie
+    sent alongside a valid bearer counts as bearer auth, since that's the path
+    ``get_current_user`` would have taken.
+    """
+    cookie_token = request.cookies.get(auth_settings.COOKIE_NAME)
+    if cookie_token and decode_access_token(cookie_token) is not None:
+        return "cookie"
+    return "bearer"

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -122,15 +122,21 @@ require_admin = require_role(WorkspaceRole.admin)
 require_editor = require_role(WorkspaceRole.editor)
 
 
-def detect_auth_method(request: Request) -> Literal["cookie", "bearer"]:
+def detect_auth_method(
+    request: Request, current_user: UserDB
+) -> Literal["cookie", "bearer"]:
     """Return how the current request was authenticated.
 
-    Mirrors the precedence in ``get_current_user``: cookie wins when present
-    and valid; everything else falls through to bearer. A stale/invalid cookie
-    sent alongside a valid bearer counts as bearer auth, since that's the path
-    ``get_current_user`` would have taken.
+    Mirrors the precedence in ``get_current_user``: cookie wins only when the
+    cookie decodes to the authenticated user. A cookie that merely *decodes* is
+    not enough — if its user_id no longer exists in the DB, ``get_current_user``
+    falls through to bearer and the resolved user comes from the bearer token.
+    We must do the same comparison, otherwise a stale cookie + valid bearer
+    gets misclassified as cookie auth.
     """
     cookie_token = request.cookies.get(auth_settings.COOKIE_NAME)
-    if cookie_token and decode_access_token(cookie_token) is not None:
-        return "cookie"
+    if cookie_token:
+        cookie_user_id = decode_access_token(cookie_token)
+        if cookie_user_id == current_user.id:
+            return "cookie"
     return "bearer"

--- a/backend/app/threads/models.py
+++ b/backend/app/threads/models.py
@@ -1,8 +1,19 @@
+from enum import Enum
 from uuid import UUID, uuid4
 
 from sqlmodel import Column, Field, SQLModel, String, Text
 
 from app.models import TimestampMixin
+
+
+class ThreadSource(str, Enum):
+    web = "web"
+    slack = "slack"
+    api = "api"
+
+
+# Sources considered first-party — surfaced in the user's personal thread list.
+FIRST_PARTY_SOURCES: tuple[ThreadSource, ...] = (ThreadSource.web, ThreadSource.slack)
 
 
 class ThreadBase(SQLModel):
@@ -11,6 +22,10 @@ class ThreadBase(SQLModel):
     model_id: str | None = Field(default=None, nullable=True)
     first_message_content: str | None = Field(
         default=None, sa_column=Column(Text, nullable=True)
+    )
+    source: ThreadSource = Field(
+        default=ThreadSource.web,
+        sa_column=Column(String, nullable=False, server_default=ThreadSource.web.value),
     )
 
 

--- a/backend/app/threads/repository.py
+++ b/backend/app/threads/repository.py
@@ -5,7 +5,8 @@ from sqlmodel import select
 
 from app.agents.models import AgentDB
 from app.repository import BaseRepository
-from app.threads.models import ThreadDB
+from app.threads.models import FIRST_PARTY_SOURCES, ThreadDB
+from app.users.models import UserDB
 
 
 class ThreadRepository(BaseRepository[ThreadDB]):
@@ -43,6 +44,26 @@ class ThreadRepository(BaseRepository[ThreadDB]):
             )
             .join(AgentDB, ThreadDB.agent_id == AgentDB.id)
             .where(ThreadDB.user_id == user_id)
+            .where(ThreadDB.source.in_(FIRST_PARTY_SOURCES))
+            .order_by(ThreadDB.created_at.desc())
+        )
+        result = await self.db.execute(stmt)
+        return result.all()
+
+    async def list_for_agent(self, agent_id: UUID):
+        stmt = (
+            select(
+                ThreadDB,
+                AgentDB.name,
+                AgentDB.emoji,
+                AgentDB.color,
+                AgentDB.is_archived,
+                UserDB.email,
+                UserDB.name,
+            )
+            .join(AgentDB, ThreadDB.agent_id == AgentDB.id)
+            .join(UserDB, ThreadDB.user_id == UserDB.id)
+            .where(ThreadDB.agent_id == agent_id)
             .order_by(ThreadDB.created_at.desc())
         )
         result = await self.db.execute(stmt)

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -1,12 +1,15 @@
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import StreamingResponse
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
+from app.agents.core.service import AgentService, get_agent_service
 from app.agents.runtime import AgentRuntime
 from app.agents.stream import _serialize_lc_message
-from app.auth.dependencies import get_current_user
+from app.auth.dependencies import detect_auth_method, get_current_user
 from app.database import get_db, get_psycopg_conn_string
-from app.threads.schemas import ThreadCreate, ThreadResponse
+from app.exceptions import PermissionDeniedError
+from app.threads.models import ThreadDB, ThreadSource
+from app.threads.schemas import ThreadCreate, ThreadResponse, ViewerRole
 from app.threads.serialization import deserialize_to_ui_messages
 from app.threads.service import ThreadService, get_thread_service
 from app.users.models import UserDB
@@ -15,11 +18,36 @@ from app.users.models import UserDB
 router = APIRouter(prefix="/threads", tags=["threads"])
 
 
+async def _resolve_viewer_role(
+    thread: ThreadDB,
+    current_user: UserDB,
+    agent_service: AgentService,
+) -> ViewerRole | None:
+    """Return the viewer's role on this thread, or raise 403.
+
+    - Owner of the thread → ``None`` (full access).
+    - Workspace admin or per-agent owner/admin → ``"admin"`` (read-only).
+    - Anyone else → ``PermissionDeniedError``.
+    """
+    if thread.user_id == current_user.id:
+        return None
+    agent = await agent_service.get_agent(
+        thread.agent_id, user_id=current_user.id, user_role=current_user.role
+    )
+    if agent.current_user_permission in ("owner", "admin"):
+        return "admin"
+    raise PermissionDeniedError("Not authorized to view this thread")
+
+
 @router.get("/{thread_id}")
 async def read_thread(
     thread_id: str,
+    current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
+    agent_service: AgentService = Depends(get_agent_service),
 ) -> dict:
+    thread = await service.get_thread(thread_id)
+    viewer_role = await _resolve_viewer_role(thread, current_user, agent_service)
     thread_read = await service.get_thread_with_agent(thread_id)
 
     async with AsyncPostgresSaver.from_conn_string(
@@ -35,6 +63,7 @@ async def read_thread(
                 "values": {"messages": []},
                 "thread": thread_read,
                 "interrupted": False,
+                "viewer_role": viewer_role,
             }
 
         channel_values = checkpoint_tuple.checkpoint["channel_values"]
@@ -63,6 +92,7 @@ async def read_thread(
             "thread": thread_read,
             "interrupted": interrupt_value is not None,
             "interrupt_value": interrupt_value,
+            "viewer_role": viewer_role,
         }
 
 
@@ -102,17 +132,27 @@ async def get_threads(
 @router.post("/")
 async def create_thread(
     thread_data: ThreadCreate,
+    request: Request,
     current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
 ) -> ThreadResponse:
-    return await service.create_thread(thread_data, current_user.id)
+    source = (
+        ThreadSource.web
+        if detect_auth_method(request) == "cookie"
+        else ThreadSource.api
+    )
+    return await service.create_thread(thread_data, current_user.id, source)
 
 
 @router.delete("/{thread_id}", status_code=204)
 async def delete_thread(
     thread_id: str,
+    current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
 ) -> None:
+    thread = await service.get_thread(thread_id)
+    if thread.user_id != current_user.id:
+        raise PermissionDeniedError("Not authorized to delete this thread")
     async with AsyncPostgresSaver.from_conn_string(
         get_psycopg_conn_string()
     ) as checkpointer:
@@ -128,12 +168,14 @@ async def run_stream(
     command: dict | None = Body(None, embed=True),
     config: dict | None = Body(None, embed=True),
     context: dict | None = Body(None, embed=True),  # noqa: ARG001
-    user_id: str = Depends(get_current_user),  # noqa: ARG001
+    current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
     db=Depends(get_db),
 ):
     """LangGraph native streaming endpoint for @langchain/langgraph-sdk useStream."""
     thread = await service.get_thread(thread_id)
+    if thread.user_id != current_user.id:
+        raise PermissionDeniedError("Not authorized to run this thread")
     runtime = await AgentRuntime.build(thread=thread, db=db)
 
     # Extract trigger from config.configurable if provided
@@ -169,12 +211,14 @@ async def run_invoke(
     command: dict | None = Body(None, embed=True),
     config: dict | None = Body(None, embed=True),
     context: dict | None = Body(None, embed=True),  # noqa: ARG001
-    user_id: str = Depends(get_current_user),  # noqa: ARG001
+    current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
     db=Depends(get_db),
 ):
     """Non-streaming invoke endpoint. Returns the final agent response as JSON."""
     thread = await service.get_thread(thread_id)
+    if thread.user_id != current_user.id:
+        raise PermissionDeniedError("Not authorized to run this thread")
     runtime = await AgentRuntime.build(thread=thread, db=db)
 
     trigger = None

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -138,7 +138,7 @@ async def create_thread(
 ) -> ThreadResponse:
     source = (
         ThreadSource.web
-        if detect_auth_method(request) == "cookie"
+        if detect_auth_method(request, current_user) == "cookie"
         else ThreadSource.api
     )
     return await service.create_thread(thread_data, current_user.id, source)

--- a/backend/app/threads/schemas.py
+++ b/backend/app/threads/schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from sqlmodel import SQLModel
@@ -26,3 +27,14 @@ class ThreadResponse(ThreadBase):
     agent_emoji: str | None = None
     agent_color: str | None = None
     agent_archived: bool = False
+
+
+class AgentThreadResponse(ThreadResponse):
+    user_email: str | None = None
+    user_name: str | None = None
+
+
+# Set when the requester is reading a thread they do not own but have admin
+# access. Drives read-only mode on the chat page. `None` means the requester
+# owns the thread (no special role).
+ViewerRole = Literal["admin"]

--- a/backend/app/threads/service.py
+++ b/backend/app/threads/service.py
@@ -6,9 +6,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import AsyncSessionLocal, get_db
 from app.exceptions import NotFoundError
 from app.service import BaseService
-from app.threads.models import ThreadDB
+from app.threads.models import ThreadDB, ThreadSource
 from app.threads.repository import ThreadRepository
-from app.threads.schemas import ThreadCreate, ThreadResponse
+from app.threads.schemas import AgentThreadResponse, ThreadCreate, ThreadResponse
 
 
 def _thread_with_agent(
@@ -25,6 +25,28 @@ def _thread_with_agent(
             "agent_emoji": agent_emoji,
             "agent_color": agent_color,
             "agent_archived": agent_archived,
+        },
+    )
+
+
+def _agent_thread(
+    thread: ThreadDB,
+    agent_name: str | None,
+    agent_emoji: str | None,
+    agent_color: str | None,
+    agent_archived: bool,
+    user_email: str | None,
+    user_name: str | None,
+) -> AgentThreadResponse:
+    return AgentThreadResponse.model_validate(
+        thread,
+        update={
+            "agent_name": agent_name,
+            "agent_emoji": agent_emoji,
+            "agent_color": agent_color,
+            "agent_archived": agent_archived,
+            "user_email": user_email,
+            "user_name": user_name,
         },
     )
 
@@ -48,10 +70,22 @@ class ThreadService(BaseService[ThreadDB, ThreadRepository]):
         rows = await self.repository.list_for_user(user_id)
         return [_thread_with_agent(*row) for row in rows]
 
-    async def create_thread(self, data: ThreadCreate, user_id: UUID) -> ThreadResponse:
+    async def list_threads_for_agent(
+        self, agent_id: UUID
+    ) -> list[AgentThreadResponse]:
+        rows = await self.repository.list_for_agent(agent_id)
+        return [_agent_thread(*row) for row in rows]
+
+    async def create_thread(
+        self,
+        data: ThreadCreate,
+        user_id: UUID,
+        source: ThreadSource,
+    ) -> ThreadResponse:
         thread = ThreadDB(
             **data.model_dump(exclude_none=True),
             user_id=user_id,
+            source=source,
         )
         self.db.add(thread)
         await self.db.flush()
@@ -85,6 +119,7 @@ async def get_or_create_thread(
             model_id="deepseek-v4-flash",
             first_message_content=question,
             user_id=user_id,
+            source=ThreadSource.slack,
         )
         db.add(thread)
         await db.commit()

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.agents.models import AgentDB
+from app.threads.models import ThreadDB, ThreadSource
 
 
 def test_create_agent(client: TestClient, mock_db, editor_user):
@@ -304,4 +305,149 @@ def test_delete_agent_allows_workspace_admin(client: TestClient, mock_db, admin_
 def test_delete_agent_requires_auth(client: TestClient):
     """Test that DELETE /agents/{id} returns 401 without auth."""
     response = client.delete(f"/agents/{uuid4()}")
+    assert response.status_code == 401
+
+
+def _make_thread(*, agent_id, user_id, source=ThreadSource.web) -> ThreadDB:
+    return ThreadDB(
+        id=str(uuid4()),
+        agent_id=agent_id,
+        user_id=user_id,
+        first_message_content="hi",
+        source=source,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+def test_list_agent_threads_as_owner(client: TestClient, mock_db, current_user):
+    """An agent owner can list every thread for that agent."""
+    agent_id = uuid4()
+    agent = AgentDB(
+        id=agent_id,
+        name="Owned Agent",
+        instructions="...",
+        owner_id=current_user.id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    thread = _make_thread(
+        agent_id=agent_id,
+        user_id=uuid4(),
+        source=ThreadSource.slack,
+    )
+
+    def make_result(*, rows=None, scalars_list=None):
+        r = MagicMock()
+        r.all.return_value = rows or []
+        r.scalars.return_value.all.return_value = scalars_list or []
+        return r
+
+    mock_db.execute.side_effect = [
+        # get_agent: list_with_permissions returns the agent owned by current_user
+        make_result(rows=[(agent, None, None)]),
+        # get_agent: load_all_subagent_data
+        make_result(scalars_list=[]),
+        # ThreadRepository.list_for_agent
+        make_result(
+            rows=[
+                (
+                    thread,
+                    "Owned Agent",
+                    None,
+                    None,
+                    False,
+                    "viewer@test.com",
+                    "Viewer Name",
+                )
+            ]
+        ),
+    ]
+
+    response = client.get(f"/agents/{agent_id}/threads")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user_email"] == "viewer@test.com"
+    assert data[0]["source"] == ThreadSource.slack.value
+
+
+def test_list_agent_threads_forbidden_for_member(
+    client: TestClient, mock_db, current_user
+):
+    """A workspace member with no agent permission gets a 403."""
+    agent_id = uuid4()
+    other_owner = uuid4()
+    assert other_owner != current_user.id
+    agent = AgentDB(
+        id=agent_id,
+        name="Other agent",
+        instructions="...",
+        owner_id=other_owner,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    def make_result(*, rows=None, scalars_list=None):
+        r = MagicMock()
+        r.all.return_value = rows or []
+        r.scalars.return_value.all.return_value = scalars_list or []
+        return r
+
+    mock_db.execute.side_effect = [
+        # list_with_permissions returns the agent but no permission grant
+        make_result(rows=[(agent, None, None)]),
+        make_result(scalars_list=[]),
+    ]
+
+    response = client.get(f"/agents/{agent_id}/threads")
+    assert response.status_code == 403
+
+
+@pytest.mark.usefixtures("admin_user")
+def test_list_agent_threads_as_workspace_admin(client: TestClient, mock_db):
+    """Workspace admins see threads on any agent."""
+    agent_id = uuid4()
+    other_owner = uuid4()
+    agent = AgentDB(
+        id=agent_id,
+        name="Some agent",
+        instructions="...",
+        owner_id=other_owner,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    thread = _make_thread(agent_id=agent_id, user_id=other_owner)
+
+    def make_result(*, rows=None, scalars_list=None):
+        r = MagicMock()
+        r.all.return_value = rows or []
+        r.scalars.return_value.all.return_value = scalars_list or []
+        return r
+
+    mock_db.execute.side_effect = [
+        make_result(rows=[(agent, None, None)]),
+        make_result(scalars_list=[]),
+        make_result(
+            rows=[
+                (
+                    thread,
+                    "Some agent",
+                    None,
+                    None,
+                    False,
+                    "creator@test.com",
+                    "Creator",
+                )
+            ]
+        ),
+    ]
+
+    response = client.get(f"/agents/{agent_id}/threads")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+def test_list_agent_threads_requires_auth(client: TestClient):
+    response = client.get(f"/agents/{uuid4()}/threads")
     assert response.status_code == 401

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -2,9 +2,10 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
-from app.threads.models import ThreadDB
+from app.threads.models import ThreadDB, ThreadSource
 
 
 def test_create_thread(client: TestClient, mock_db, current_user):
@@ -36,6 +37,10 @@ def test_create_thread(client: TestClient, mock_db, current_user):
     assert "id" in data
     assert "created_at" in data
     assert "updated_at" in data
+    # TestClient defaults to no cookies/bearer, but get_current_user is
+    # overridden, so detect_auth_method falls through to "bearer" and the
+    # server tags the thread as API-created.
+    assert data["source"] == ThreadSource.api.value
 
 
 def test_create_thread_without_first_message(client: TestClient, mock_db, current_user):
@@ -99,14 +104,13 @@ def test_get_threads(client: TestClient, mock_db, current_user):
 
 
 @patch("app.threads.router.AsyncPostgresSaver.from_conn_string")
-def test_get_thread(mock_checkpointer, client: TestClient, mock_db):
-    """Test getting a single thread by ID."""
+def test_get_thread(mock_checkpointer, client: TestClient, mock_db, current_user):
+    """Owner can read their own thread."""
     thread_id = str(uuid4())
-    user_id = uuid4()
     agent_id = uuid4()
     thread = ThreadDB(
         id=thread_id,
-        user_id=user_id,
+        user_id=current_user.id,
         agent_id=agent_id,
         first_message_content="Test thread",
         created_at=datetime.now(),
@@ -114,12 +118,12 @@ def test_get_thread(mock_checkpointer, client: TestClient, mock_db):
     )
 
     mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
     mock_result.one_or_none.return_value = (thread, "Test Agent", "🤖", None, False)
     mock_db.execute.return_value = mock_result
 
-    # Mock the checkpointer context manager
     mock_saver_instance = AsyncMock()
-    mock_saver_instance.aget = AsyncMock(return_value=None)
+    mock_saver_instance.aget_tuple = AsyncMock(return_value=None)
     mock_checkpointer.return_value.__aenter__ = AsyncMock(
         return_value=mock_saver_instance
     )
@@ -132,13 +136,41 @@ def test_get_thread(mock_checkpointer, client: TestClient, mock_db):
     assert "messages" in data
     assert data["thread"]["id"] == thread_id
     assert data["messages"] == []
+    assert data["viewer_role"] is None
 
 
+@pytest.mark.usefixtures("current_user")
+def test_get_thread_forbidden_for_non_owner(client: TestClient, mock_db):
+    """A non-owner without admin access gets a 403."""
+    thread_id = str(uuid4())
+    agent_id = uuid4()
+    other_user_id = uuid4()
+    thread = ThreadDB(
+        id=thread_id,
+        user_id=other_user_id,
+        agent_id=agent_id,
+        first_message_content="Someone else's thread",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    # The agent permission lookup returns no rows for a regular member.
+    mock_result.all.return_value = []
+    mock_db.execute.return_value = mock_result
+
+    response = client.get(f"/threads/{thread_id}")
+    assert response.status_code in (403, 404)
+
+
+@pytest.mark.usefixtures("current_user")
 def test_get_thread_not_found(client: TestClient, mock_db):
     """Test getting a non-existent thread returns 404."""
     fake_id = uuid4()
 
     mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
     mock_result.one_or_none.return_value = None
     mock_db.execute.return_value = mock_result
 
@@ -148,14 +180,13 @@ def test_get_thread_not_found(client: TestClient, mock_db):
 
 
 @patch("app.threads.router.AsyncPostgresSaver.from_conn_string")
-def test_delete_thread(mock_checkpointer, client: TestClient, mock_db):
+def test_delete_thread(mock_checkpointer, client: TestClient, mock_db, current_user):
     """Test deleting a thread."""
     thread_id = str(uuid4())
-    user_id = uuid4()
     agent_id = uuid4()
     thread = ThreadDB(
         id=thread_id,
-        user_id=user_id,
+        user_id=current_user.id,
         agent_id=agent_id,
         first_message_content="Thread to delete",
         created_at=datetime.now(),
@@ -179,6 +210,7 @@ def test_delete_thread(mock_checkpointer, client: TestClient, mock_db):
     mock_db.delete.assert_called_once()
 
 
+@pytest.mark.usefixtures("current_user")
 @patch("app.threads.router.AsyncPostgresSaver.from_conn_string")
 def test_delete_thread_not_found(mock_checkpointer, client: TestClient, mock_db):
     """Test deleting a non-existent thread returns 404."""

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -56,7 +56,7 @@ import { type PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import ChatPromptInput from "../components/prompt-input";
-import { RefreshCcwIcon, CopyIcon, ArchiveIcon } from "lucide-react";
+import { RefreshCcwIcon, CopyIcon, ArchiveIcon, ShieldCheck } from "lucide-react";
 import {
 	useStream,
 	FetchStreamTransport,
@@ -356,6 +356,7 @@ const ChatPage = () => {
 	const hasInitialized = useRef(false);
 	const [threadModel, setThreadModel] = useState<string | undefined>(undefined);
 	const [agentArchived, setAgentArchived] = useState(false);
+	const [viewerRole, setViewerRole] = useState<"admin" | null>(null);
 	const [initialValues, setInitialValues] = useState<Record<
 		string,
 		unknown
@@ -661,6 +662,10 @@ const ChatPage = () => {
 
 			if (data.thread.agentArchived) {
 				setAgentArchived(true);
+			}
+
+			if (data.viewerRole === "admin") {
+				setViewerRole("admin");
 			}
 
 			if (data.interrupted) {
@@ -1015,7 +1020,17 @@ const ChatPage = () => {
 				<div className="pointer-events-none absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-background to-transparent z-10" />
 			</div>
 			<div className="w-full shrink-0 bg-background">
-				{agentArchived ? (
+				{viewerRole === "admin" ? (
+					<div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-6">
+						<div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
+							<ShieldCheck className="size-5 shrink-0 text-muted-foreground" />
+							<p className="text-sm text-muted-foreground">
+								Viewing as admin — this thread belongs to another user and is
+								read-only.
+							</p>
+						</div>
+					</div>
+				) : agentArchived ? (
 					<div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-6">
 						<div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
 							<ArchiveIcon className="size-5 shrink-0 text-muted-foreground" />

--- a/web/src/app/(protected)/agents/[id]/threads/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/threads/page.tsx
@@ -45,6 +45,7 @@ export default function AgentThreadsPage() {
 	const [threads, setThreads] = useState<AgentThread[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [forbiddenOpen, setForbiddenOpen] = useState(false);
+	const [hasError, setHasError] = useState(false);
 
 	useEffect(() => {
 		const fetch = async () => {
@@ -64,6 +65,7 @@ export default function AgentThreadsPage() {
 					setForbiddenOpen(true);
 				} else {
 					console.error("Error fetching agent threads:", error);
+					setHasError(true);
 				}
 			} finally {
 				setIsLoading(false);
@@ -113,7 +115,11 @@ export default function AgentThreadsPage() {
 						)}
 					</div>
 
-					{isLoading ? null : threads.length === 0 ? (
+					{isLoading ? null : hasError ? (
+						<div className="text-center py-16 text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium">
+							Failed to load threads. Please try again.
+						</div>
+					) : threads.length === 0 ? (
 						<div className="text-center py-16 text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium">
 							No threads yet for this agent.
 						</div>

--- a/web/src/app/(protected)/agents/[id]/threads/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/threads/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { api } from "@/lib/api/client";
+import { PageContainer } from "@/components/layout/page-container";
+import { AgentAvatar } from "@/components/ui/agent-avatar";
+import { ThreadSourceBadge } from "@/components/ui/thread-source-badge";
+import ForbiddenErrorDialog from "@/components/forbidden-error-dialog";
+import type { Agent } from "@/types/agents";
+import type { AgentThread } from "@/types/threads";
+
+function initials(name: string | null, email: string | null): string {
+	const source = name || email || "?";
+	const parts = source.trim().split(/\s+/);
+	if (parts.length >= 2) {
+		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+	}
+	return source.substring(0, 2).toUpperCase();
+}
+
+function formatDate(dateStr: string): string {
+	const diff = Date.now() - new Date(dateStr).getTime();
+	const minutes = Math.floor(diff / (1000 * 60));
+	if (minutes < 1) return "just now";
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	if (days < 7) return `${days}d ago`;
+	return new Date(dateStr).toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
+export default function AgentThreadsPage() {
+	const params = useParams();
+	const router = useRouter();
+	const agentId = params.id as string;
+	const [agent, setAgent] = useState<Agent | null>(null);
+	const [threads, setThreads] = useState<AgentThread[]>([]);
+	const [isLoading, setIsLoading] = useState(true);
+	const [forbiddenOpen, setForbiddenOpen] = useState(false);
+
+	useEffect(() => {
+		const fetch = async () => {
+			try {
+				const [agentRes, threadsRes] = await Promise.all([
+					api.get<Agent>(`/agents/${agentId}`),
+					api.get<AgentThread[]>(`/agents/${agentId}/threads`),
+				]);
+				setAgent(agentRes.data);
+				setThreads(threadsRes.data);
+			} catch (error: unknown) {
+				if (
+					error instanceof Object &&
+					"status" in error &&
+					(error.status === 403 || error.status === 401)
+				) {
+					setForbiddenOpen(true);
+				} else {
+					console.error("Error fetching agent threads:", error);
+				}
+			} finally {
+				setIsLoading(false);
+			}
+		};
+		fetch();
+	}, [agentId]);
+
+	return (
+		<PageContainer>
+			<ForbiddenErrorDialog
+				open={forbiddenOpen}
+				onOpenChange={(open) => {
+					setForbiddenOpen(open);
+					if (!open) router.push(`/agents/${agentId}`);
+				}}
+				title="Insufficient privileges"
+				message="You don't have permission to view this agent's threads."
+			/>
+
+			<div className="flex items-start gap-4 my-8">
+				<button
+					type="button"
+					onClick={() => router.push(`/agents/${agentId}`)}
+					className="shrink-0 w-10 h-10 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
+					aria-label="Back to agent"
+				>
+					<ArrowLeft className="w-[18px] h-[18px] text-[#6B7F76]" />
+				</button>
+
+				<div className="flex-1 min-w-0">
+					<div className="px-5 mb-7 flex items-center justify-between gap-4">
+						<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[28px] tracking-[-0.03em] text-[#111111] dark:text-white truncate">
+							Thread history
+						</h1>
+						{agent && (
+							<div className="flex items-center gap-2 shrink-0 min-w-0">
+								<AgentAvatar
+									color={agent.color}
+									emoji={agent.emoji}
+									size="sm"
+								/>
+								<h2 className="text-md font-bold truncate">{agent.name}</h2>
+							</div>
+						)}
+					</div>
+
+					{isLoading ? null : threads.length === 0 ? (
+						<div className="text-center py-16 text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium">
+							No threads yet for this agent.
+						</div>
+					) : (
+						<>
+							<div className="flex items-center py-3 pl-[76px] pr-5 mb-1 font-[family-name:var(--font-dm-sans)] animate-in fade-in duration-300">
+								<div className="w-[220px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+									User
+								</div>
+								<div className="w-[440px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+									First message
+								</div>
+								<div className="w-[120px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+									Source
+								</div>
+								<div className="w-[110px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+									Created
+								</div>
+							</div>
+
+							<div>
+								{threads.map((thread, i) => (
+									<Link
+										key={thread.id}
+										href={`/agents/${agentId}/chat/${thread.id}`}
+										className="group flex items-center py-3.5 px-5 rounded-[18px] mb-1 transition-all duration-200 hover:bg-[#F8FAF9] dark:hover:bg-white/5 hover:translate-x-1 animate-in fade-in slide-in-from-bottom-3"
+										style={{
+											animationDelay: `${i * 30}ms`,
+											animationFillMode: "both",
+										}}
+									>
+										<div className="shrink-0 w-[42px] h-[42px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[13.5px] font-bold text-[#6B7F76] dark:text-muted-foreground transition-transform duration-300 group-hover:scale-105">
+											{initials(thread.userName, thread.userEmail)}
+										</div>
+
+										<div className="w-[220px] shrink-0 min-w-0 ml-3.5 font-[family-name:var(--font-dm-sans)]">
+											<div className="text-[14px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
+												{thread.userName || "Unnamed"}
+											</div>
+											<div className="text-[12px] text-[#8FA89E] dark:text-muted-foreground font-medium truncate mt-0.5">
+												{thread.userEmail}
+											</div>
+										</div>
+
+										<div className="w-[440px] shrink-0 min-w-0 pr-4 font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#3F524B] dark:text-foreground/80 font-medium truncate">
+											{thread.firstMessageContent || (
+												<span className="italic text-[#A3B5AD]">
+													No message
+												</span>
+											)}
+										</div>
+
+										<div className="w-[120px] shrink-0">
+											<ThreadSourceBadge source={thread.source} />
+										</div>
+
+										<div className="w-[110px] shrink-0 font-[family-name:var(--font-dm-sans)] text-[13px] text-[#8FA89E] dark:text-muted-foreground font-medium">
+											{formatDate(thread.createdAt)}
+										</div>
+									</Link>
+								))}
+							</div>
+						</>
+					)}
+				</div>
+			</div>
+		</PageContainer>
+	);
+}

--- a/web/src/app/(protected)/agents/[id]/threads/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/threads/page.tsx
@@ -120,7 +120,7 @@ export default function AgentThreadsPage() {
 					) : (
 						<>
 							<div className="flex items-center py-3 pl-5 pr-5 mb-1 font-[family-name:var(--font-dm-sans)] animate-in fade-in duration-300">
-								<div className="w-[440px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+								<div className="flex-1 min-w-0 pr-4 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
 									First message
 								</div>
 								<div className="w-[120px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
@@ -142,7 +142,7 @@ export default function AgentThreadsPage() {
 											animationFillMode: "both",
 										}}
 									>
-										<div className="w-[440px] shrink-0 min-w-0 pr-4 font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#3F524B] dark:text-foreground/80 font-medium truncate">
+										<div className="flex-1 min-w-0 pr-4 font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#3F524B] dark:text-foreground/80 font-medium truncate">
 											{thread.firstMessageContent || (
 												<span className="italic text-[#A3B5AD]">
 													No message

--- a/web/src/app/(protected)/agents/[id]/threads/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/threads/page.tsx
@@ -69,7 +69,7 @@ export default function AgentThreadsPage() {
 				setIsLoading(false);
 			}
 		};
-		fetch();
+		void fetch();
 	}, [agentId]);
 
 	return (
@@ -87,7 +87,9 @@ export default function AgentThreadsPage() {
 			<div className="flex items-start gap-4 my-8">
 				<button
 					type="button"
-					onClick={() => router.push(`/agents/${agentId}`)}
+					onClick={() => {
+						router.push(`/agents/${agentId}`);
+					}}
 					className="shrink-0 w-10 h-10 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
 					aria-label="Back to agent"
 				>

--- a/web/src/app/(protected)/agents/[id]/threads/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/threads/page.tsx
@@ -119,10 +119,7 @@ export default function AgentThreadsPage() {
 						</div>
 					) : (
 						<>
-							<div className="flex items-center py-3 pl-[76px] pr-5 mb-1 font-[family-name:var(--font-dm-sans)] animate-in fade-in duration-300">
-								<div className="w-[220px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
-									User
-								</div>
+							<div className="flex items-center py-3 pl-5 pr-5 mb-1 font-[family-name:var(--font-dm-sans)] animate-in fade-in duration-300">
 								<div className="w-[440px] shrink-0 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
 									First message
 								</div>
@@ -145,19 +142,6 @@ export default function AgentThreadsPage() {
 											animationFillMode: "both",
 										}}
 									>
-										<div className="shrink-0 w-[42px] h-[42px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[13.5px] font-bold text-[#6B7F76] dark:text-muted-foreground transition-transform duration-300 group-hover:scale-105">
-											{initials(thread.userName, thread.userEmail)}
-										</div>
-
-										<div className="w-[220px] shrink-0 min-w-0 ml-3.5 font-[family-name:var(--font-dm-sans)]">
-											<div className="text-[14px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
-												{thread.userName || "Unnamed"}
-											</div>
-											<div className="text-[12px] text-[#8FA89E] dark:text-muted-foreground font-medium truncate mt-0.5">
-												{thread.userEmail}
-											</div>
-										</div>
-
 										<div className="w-[440px] shrink-0 min-w-0 pr-4 font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#3F524B] dark:text-foreground/80 font-medium truncate">
 											{thread.firstMessageContent || (
 												<span className="italic text-[#A3B5AD]">

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import EmojiPicker, { EmojiClickData, Theme } from "emoji-picker-react";
 import { AGENT_COLORS, agentColorBackground } from "@/lib/colors";
 import { useTheme } from "next-themes";
-import { ShieldCheck, ArrowRight, ArchiveIcon } from "lucide-react";
+import { ShieldCheck, ArrowRight, ArchiveIcon, History } from "lucide-react";
 import { Agent } from "@/types/agents";
 import AgentToolList from "../[id]/components/agent-tool-list";
 import AgentSubagentList from "../[id]/components/agent-subagent-list";
@@ -100,6 +100,14 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 	const handleManagePermissions = () => {
 		setPermissionsOpen(true);
 	};
+
+	const handleViewThreads = () => {
+		router.push(`/agents/${agent.id}/threads`);
+	};
+
+	const canManageAgent =
+		liveAgent.currentUserPermission === "owner" ||
+		liveAgent.currentUserPermission === "admin";
 
 	const handleDeleteAgent = async () => {
 		if (
@@ -261,8 +269,13 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 					{/* More menu */}
 					<SageDropdownMenu
 						items={[
-							{ label: "Manage permissions", icon: <ShieldCheck />, onClick: handleManagePermissions },
-							{ separator: true },
+							...(canManageAgent
+								? [
+									{ label: "View thread history", icon: <History />, onClick: handleViewThreads },
+									{ label: "Manage permissions", icon: <ShieldCheck />, onClick: handleManagePermissions },
+									{ separator: true as const },
+								]
+								: []),
 							{ label: "Archive agent", icon: <ArchiveIcon />, destructive: true, onClick: handleDeleteAgent },
 						]}
 					/>

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -182,7 +182,7 @@ export function AppSidebar() {
 																: thread.agentName}
 														</div>
 													</div>
-													{thread.id.includes(".") && (
+													{thread.source === "slack" && (
 														<Image
 															src="https://storage.googleapis.com/choose-assets/slack.png"
 															alt="Slack"

--- a/web/src/components/ui/thread-source-badge.tsx
+++ b/web/src/components/ui/thread-source-badge.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image";
+import { Globe, Plug } from "lucide-react";
+import type { ThreadSource } from "@/types/threads";
+
+const SLACK_ICON_SRC =
+	"https://storage.googleapis.com/choose-assets/slack.png";
+
+const LABELS: Record<ThreadSource, string> = {
+	web: "In-app",
+	slack: "Slack",
+	api: "External",
+};
+
+interface ThreadSourceBadgeProps {
+	source: ThreadSource;
+	withLabel?: boolean;
+	className?: string;
+}
+
+export function ThreadSourceBadge({
+	source,
+	withLabel = true,
+	className = "",
+}: ThreadSourceBadgeProps) {
+	const label = LABELS[source];
+	const icon =
+		source === "slack" ? (
+			<Image
+				src={SLACK_ICON_SRC}
+				alt="Slack"
+				height={14}
+				width={14}
+				className="h-3.5 w-3.5 shrink-0"
+			/>
+		) : source === "web" ? (
+			<Globe className="h-3.5 w-3.5 shrink-0 text-[#A3B5AD] dark:text-muted-foreground" />
+		) : (
+			<Plug className="h-3.5 w-3.5 shrink-0 text-[#A3B5AD] dark:text-muted-foreground" />
+		);
+	return (
+		<span
+			className={`inline-flex items-center gap-1.5 text-[12px] font-medium text-[#6E7C76] dark:text-muted-foreground ${className}`}
+			title={`Thread initiated from ${label}`}
+		>
+			{icon}
+			{withLabel && <span>{label}</span>}
+		</span>
+	);
+}

--- a/web/src/components/ui/thread-source-badge.tsx
+++ b/web/src/components/ui/thread-source-badge.tsx
@@ -5,11 +5,16 @@ import type { ThreadSource } from "@/types/threads";
 const SLACK_ICON_SRC =
 	"https://storage.googleapis.com/choose-assets/slack.png";
 
-const LABELS: Record<ThreadSource, string> = {
-	web: "In-app",
-	slack: "Slack",
-	api: "External",
-};
+function getLabel(source: ThreadSource): string {
+	switch (source) {
+		case "web":
+			return "In-app";
+		case "slack":
+			return "Slack";
+		case "api":
+			return "External";
+	}
+}
 
 interface ThreadSourceBadgeProps {
 	source: ThreadSource;
@@ -22,7 +27,7 @@ export function ThreadSourceBadge({
 	withLabel = true,
 	className = "",
 }: ThreadSourceBadgeProps) {
-	const label = LABELS[source];
+	const label = getLabel(source);
 	const icon =
 		source === "slack" ? (
 			<Image

--- a/web/src/types/threads.ts
+++ b/web/src/types/threads.ts
@@ -1,10 +1,21 @@
+export type ThreadSource = "web" | "slack" | "api";
+
+export type ViewerRole = "admin";
+
 export interface Thread {
 	id: string;
 	agentId: string;
+	userId: string;
 	firstMessageContent: string;
 	agentName: string | null;
 	agentEmoji: string | null;
 	agentColor: string | null;
 	agentArchived: boolean;
+	source: ThreadSource;
 	createdAt: string;
+}
+
+export interface AgentThread extends Thread {
+	userEmail: string | null;
+	userName: string | null;
 }


### PR DESCRIPTION
## Summary

- Adds a per-agent **Thread history** page (`/agents/[id]/threads`) so workspace admins, agent owners, and agent-level admins can audit conversations across users. Gated through the existing `_resolve_permission` so admin views require `owner`/`admin`.
- Introduces a real **thread source** column (`web` / `slack` / `api`) with an Alembic backfill, replacing the fragile `thread.id.includes(".")` heuristic. The user sidebar now excludes non-first-party (`api`) threads so external API consumers don't pollute the personal list.
- Hardens `GET /threads/{id}` (was unauthenticated) — checks ownership, falls through to workspace/agent admin, returns `viewer_role` so the chat page can render a read-only banner when viewing as admin. `stream`/`invoke`/`delete` reject non-owners.

## Surface changes
- **Backend**: `ThreadSource` enum, `Thread.source` column, `AgentThreadResponse` with user info, new repository methods (`list_for_agent`, filtered `list_for_user`), `detect_auth_method` helper for cookie-vs-bearer detection.
- **Frontend**: `ThreadSourceBadge` component, dropdown entry on the agent page, new admin threads list (left-justified columns, agent header inline), read-only banner in the chat page.
- **Migration**: `c9a4f1d83b27_add_source_to_threads.py` — adds column, backfills (`id LIKE '%.%'` → `slack`, else `web`), sets `NOT NULL` with default `web`.

## Test plan

- [ ] `cd backend && uv run alembic upgrade head` succeeds; existing Slack threads (id contains `.`) end up with `source='slack'` and the rest with `source='web'`. Downgrade + re-upgrade is clean.
- [ ] Create a thread via the in-app chat → `source='web'`. Trigger a Slack agent → `source='slack'`. Hit `POST /threads` with a PAT bearer → `source='api'`.
- [ ] Sidebar shows the `web` + `slack` threads but not the `api` thread; Slack icon shows only on `source='slack'` threads.
- [ ] As a non-admin without an agent grant, "View thread history" is hidden in the dropdown; hitting `/agents/{id}/threads` directly returns 403.
- [ ] As workspace admin or agent admin: list loads with user, first message, source badge, timestamp; clicking a row opens the chat in read-only mode (banner + prompt input hidden).
- [ ] `cd backend && uv run pytest tests/threads tests/agents` is green; ruff clean on `app/` and the new test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin/owner-only agent thread history page and a real thread source (`web`/`slack`/`api`) to clean up user lists and improve auditing. Enforces thread access (owners can run/delete; admins view read-only) and aligns auth-method detection with `get_current_user` so API-created threads are labeled correctly.

- **New Features**
  - Thread history at `/agents/[id]/threads` for workspace admins, agent owners, and agent-level admins.
  - `ThreadSource` stored on `Thread`; sidebar shows only first‑party (`web`, `slack`) threads.
  - `GET /agents/{id}/threads` returns threads with user info and source; gated to owner/admin.
  - `GET /threads/{id}` checks access and returns `viewer_role`; `stream`/`invoke`/`delete` are owners‑only.
  - Thread creation sets `source` from auth method (`cookie` → `web`, bearer token → `api`); detection now matches `get_current_user`. Slack auto‑created threads set `source='slack'`.
  - Frontend: `ThreadSourceBadge`, read‑only admin banner in chat, “View thread history” menu for owner/admin, sidebar uses `thread.source`, small UI fixes.

- **Migration**
  - Alembic `c9a4f1d83b27_add_source_to_threads.py`: adds `threads.source`, backfills (`id LIKE '%.%'` → `slack`, else `web`), sets NOT NULL with default `web`.
  - Run `alembic upgrade head`.

<sup>Written for commit e0be0c60ed8ed87af7fe42e31c578da3a3a904e4. Summary will update on new commits. <a href="https://cubic.dev/pr/keurcien/auxilia/pull/94?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

