### PR TITLE
fix: preserve subagents when parent agent has code execution

### DIFF
--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -74,11 +74,27 @@ class Agent:
         return cls(config=config, toolset=toolset)
 
     def compile(self, model) -> CompiledSubAgent:
-        """Compile into a CompiledSubAgent runnable (for subagent use)."""
-        return CompiledSubAgent(
-            name=sanitize_tool_name(self.config.name),
-            description=f"{self.config.name}: {self.config.description or self.config.name}",
-            runnable=create_agent(
+        """Compile into a CompiledSubAgent runnable (for subagent use).
+
+        Subagent-level HITL is intentionally not wired here: CompiledSubAgent
+        runnables don't inherit the parent's checkpointer, and HumanInTheLoopMiddleware
+        needs one. Approval gates on subagent tools are silently dropped today.
+        """
+        if self.config.sandbox and sandbox_settings.enabled:
+            from app.sandbox.lazy import LazySandboxBackend
+            from app.sandbox.tools import create_sandbox_tools
+
+            lazy_backend = LazySandboxBackend()
+            sandbox_tools = create_sandbox_tools(lazy_backend)
+            runnable = create_deep_agent(
+                model=model,
+                tools=[*self.toolset.all, *sandbox_tools],
+                system_prompt=self.config.instructions or "",
+                backend=lazy_backend,
+                middleware=[ToolErrorMiddleware()],
+            )
+        else:
+            runnable = create_agent(
                 model=model,
                 tools=self.toolset.all,
                 system_prompt=SystemMessage(
@@ -86,7 +102,12 @@ class Agent:
                         {"type": "text", "text": self.config.instructions or ""}
                     ]
                 ),
-            ),
+            )
+
+        return CompiledSubAgent(
+            name=sanitize_tool_name(self.config.name),
+            description=f"{self.config.name}: {self.config.description or self.config.name}",
+            runnable=runnable,
         )
 
 
@@ -98,12 +119,14 @@ class AgentRuntime:
         model,
         middleware: list,
         callbacks: list,
+        subagents: list[Agent],
     ):
         self.thread = thread
         self.agent = agent
         self.model = model
         self.middleware = middleware
         self.callbacks = callbacks
+        self.subagents = subagents
 
     @property
     def metadata(self) -> dict:
@@ -149,16 +172,10 @@ class AgentRuntime:
             )
         ]
 
-        subagents = []
+        subagents: list[Agent] = []
         if agent.config.subagents:
             for sub in agent.config.subagents:
                 subagents.append(await Agent.resolve(sub.id, db, user_id))
-
-        if subagents:
-            compiled = [s.compile(model) for s in subagents]
-            middleware.append(
-                SubAgentMiddleware(backend=StateBackend, subagents=compiled)
-            )
 
         callbacks = (
             [langfuse_callback_handler] if langfuse_callback_handler is not None else []
@@ -170,18 +187,27 @@ class AgentRuntime:
             model=model,
             middleware=middleware,
             callbacks=callbacks,
+            subagents=subagents,
         )
 
     def _build_agent(self, checkpointer):
         """Build the LangGraph agent (deep or standard) with the given checkpointer."""
         if self.agent.config.sandbox and sandbox_settings.enabled:
             return self._build_deep_agent(checkpointer)
+
+        middleware = list(self.middleware)
+        if self.subagents:
+            compiled = [s.compile(self.model) for s in self.subagents]
+            middleware.append(
+                SubAgentMiddleware(backend=StateBackend, subagents=compiled)
+            )
+
         return create_agent(
             model=self.model,
             tools=self.agent.toolset.all,
             system_prompt=SystemMessage(self.agent.config.instructions),
             checkpointer=checkpointer,
-            middleware=self.middleware,
+            middleware=middleware,
         )
 
     def _resolve_input(self, input: dict | None, command: dict | None):
@@ -285,13 +311,17 @@ class AgentRuntime:
         lazy_backend = LazySandboxBackend()
         sandbox_tools = create_sandbox_tools(lazy_backend)
 
+        compiled_subagents = (
+            [s.compile(self.model) for s in self.subagents] if self.subagents else None
+        )
+
         return create_deep_agent(
             model=self.model,
             tools=[*self.agent.toolset.all, *sandbox_tools],
             system_prompt=self.agent.config.instructions or "",
             backend=lazy_backend,
-            interrupt_on=self.agent.toolset.interrupt_on,
-            middleware=[ToolErrorMiddleware()],
+            middleware=[*self.middleware, ToolErrorMiddleware()],
+            subagents=compiled_subagents,
             checkpointer=checkpointer,
         )
 


### PR DESCRIPTION
## Summary
- `_build_deep_agent` previously dropped `self.middleware` (which carried `SubAgentMiddleware`) and didn't pass `subagents=` to `create_deep_agent` — so a coordinator with `sandbox=True` silently lost all of its subagents at runtime.
- Lift subagents onto `AgentRuntime` itself instead of encoding them inside the middleware list. Mount `SubAgentMiddleware` explicitly on the non-sandbox path; pass `subagents=` + the full middleware stack on the sandbox path (and drop the now-redundant `interrupt_on=` kwarg — `HumanInTheLoopMiddleware` is already in `self.middleware`).
- Honor the subagent's own `sandbox` flag in `Agent.compile`: a subagent flagged for code execution now compiles via `create_deep_agent` with its own `LazySandboxBackend` and sandbox tools.

## Known limitations
- Subagent-level HITL (`needs_approval` tools on a subagent) is intentionally **not** wired in this PR. `CompiledSubAgent` runnables don't inherit the parent's checkpointer, and `HumanInTheLoopMiddleware` needs one to suspend. Approval gates on subagent tools are silently dropped today; follow-up will plumb a checkpointer through `Agent.compile`.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run pytest tests/agents/` — 126 passed
- [ ] Manual: create coordinator agent with `sandbox=True` + one subagent, send a message that requires delegation, verify the `task` tool fires and the subagent runs
- [ ] Manual: create a subagent with `sandbox=True`, attach it to a non-sandbox coordinator, verify code execution works inside the subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subagents disappearing when a coordinator runs with code execution (`sandbox=True`). Subagents are now preserved on both paths, and sandboxed subagents run with their own sandbox.

- **Bug Fixes**
  - Lift subagents onto `AgentRuntime`. Mount `SubAgentMiddleware` on the non-sandbox path; on the sandbox path pass `subagents=` and the full `middleware` stack to `create_deep_agent`.
  - Honor each subagent’s `sandbox` in `Agent.compile`: compile sandboxed subagents via `create_deep_agent` with `LazySandboxBackend` and sandbox tools. Removed redundant `interrupt_on`.

<sup>Written for commit 2520fd3d0ce90d5254a851b6f68de2736bf1aa99. Summary will update on new commits. <a href="https://cubic.dev/pr/keurcien/auxilia/pull/95?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

