### PR TITLE
fix: surface GraphRecursionError as a resumable AI message

### DIFF
--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -1,8 +1,10 @@
 import logging
 from dataclasses import dataclass
+from uuid import uuid4
 
 from deepagents import create_deep_agent
 from deepagents.backends import StateBackend
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgentMiddleware
 from langchain.agents import create_agent
 from langchain.agents.middleware import (
@@ -17,13 +19,18 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.core.service import AgentService
 from app.agents.schemas import AgentResponse
 from app.agents.settings import agent_settings
-from app.agents.stream import LangGraphStreamAdapter, SlackStreamAdapter
+from app.agents.stream import (
+    LangGraphStreamAdapter,
+    SlackStreamAdapter,
+    encode_synthetic_ai_message_sse,
+)
 from app.agents.tool_errors import ToolErrorMiddleware
 from app.agents.toolset import Toolset, sanitize_tool_name
 from app.database import get_psycopg_conn_string
@@ -34,6 +41,12 @@ from app.threads.models import ThreadDB
 
 
 logger = logging.getLogger(__name__)
+
+
+RECURSION_LIMIT_MESSAGE = (
+    "I reached my step limit for this turn. Send any follow-up message "
+    "(e.g. \"continue\") and I'll pick up where I left off."
+)
 
 
 async def get_regeneration_checkpoint_id(agent, config: dict) -> str | None:
@@ -162,8 +175,12 @@ class AgentRuntime:
             provider.name, thread.model_id, provider.api_key
         )
 
-        # Build middleware stack
+        # Build middleware stack.
+        # PatchToolCallsMiddleware runs first so that any dangling tool_calls
+        # left by a previous aborted turn (recursion limit, cancelled stream,
+        # etc.) get synthetic ToolMessage responses before the model sees them.
         middleware = [
+            PatchToolCallsMiddleware(),
             ToolCallLimitMiddleware(run_limit=(
                 agent_settings.recursion_limit - 1) // 2, exit_behavior="end"),
             HumanInTheLoopMiddleware(
@@ -275,8 +292,22 @@ class AgentRuntime:
                 )
                 adapter = LangGraphStreamAdapter(subgraphs=True)
 
-            async for chunk in adapter.stream(langchain_stream):
-                yield chunk
+            try:
+                async for chunk in adapter.stream(langchain_stream):
+                    yield chunk
+            except GraphRecursionError:
+                logger.info("Graph recursion limit reached; emitting synthetic AI message")
+                ai_msg = AIMessage(
+                    content=RECURSION_LIMIT_MESSAGE,
+                    id=str(uuid4()),
+                )
+                await agent.aupdate_state(config, {"messages": [ai_msg]})
+                if stream_adapter == "slack":
+                    yield {"type": "text", "content": ai_msg.content}
+                else:
+                    state = await agent.aget_state(config)
+                    for sse in encode_synthetic_ai_message_sse(ai_msg, state.values):
+                        yield sse
 
     async def invoke(
         self,
@@ -293,7 +324,16 @@ class AgentRuntime:
             agent_input = self._resolve_input(input, command)
             config = await self._resolve_config(agent, trigger, config_overrides)
 
-            result = await agent.ainvoke(agent_input, config=config)
+            try:
+                result = await agent.ainvoke(agent_input, config=config)
+            except GraphRecursionError:
+                logger.info("Graph recursion limit reached in invoke; appending synthetic AI message")
+                ai_msg = AIMessage(
+                    content=RECURSION_LIMIT_MESSAGE,
+                    id=str(uuid4()),
+                )
+                await agent.aupdate_state(config, {"messages": [ai_msg]})
+                return {"content": ai_msg.content}
 
             messages = result.get("messages", [])
             last = messages[-1] if messages else None

--- a/backend/app/agents/stream.py
+++ b/backend/app/agents/stream.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from langchain_ai_sdk_adapter import to_ui_message_stream
 from langchain_core.messages import BaseMessage
+from langgraph.errors import GraphRecursionError
 from langgraph.types import Overwrite
 
 
@@ -231,9 +232,31 @@ class LangGraphStreamAdapter:
                 elif mode == "updates":
                     yield self._serialize_updates_event(data, namespace)
 
+        except GraphRecursionError:
+            # Let the caller (runtime) catch this and surface a synthetic AI
+            # message; the checkpoint state is intact at this point so the
+            # next turn can pick up where we left off.
+            raise
         except Exception as e:
             logger.exception("Stream processing error")
             yield _encode_lg_sse("error", {"message": str(e), "status_code": 500})
+
+
+def encode_synthetic_ai_message_sse(
+    message: BaseMessage, state_values: dict[str, Any]
+) -> list[str]:
+    """SSE chunks that surface a synthetic AI message after the stream stopped.
+
+    Used when the graph aborts mid-run (e.g. recursion limit) and the runtime
+    persists a fallback assistant turn — these chunks make the JS SDK render
+    it without a special-case code path.
+    """
+    serialized = _serialize_lc_message(message)
+    return [
+        _encode_lg_sse("messages", [serialized, {}]),
+        _encode_lg_sse("updates", {"agent": {"messages": [serialized]}}),
+        _encode_lg_sse("values", _serialize_state(state_values)),
+    ]
 
 
 class SlackStreamAdapter:
@@ -256,6 +279,9 @@ class SlackStreamAdapter:
             async for chunk in to_ui_message_stream(langchain_stream):
                 for event in self._process(chunk):
                     yield event
+        except GraphRecursionError:
+            # Surfaced by the runtime as a synthetic AI message text event.
+            raise
         except Exception as e:
             body = getattr(e, "body", None)
             msg = (body.get("message") if isinstance(body, dict) else None) or str(e)


### PR DESCRIPTION
## Summary
- When LangGraph's recursion limit fires, the chat now shows a friendly AI reply (\"I reached my step limit for this turn… send any follow-up message and I'll pick up where I left off\") instead of a generic red error. The message is persisted in the checkpoint so it survives a refresh.
- Added `PatchToolCallsMiddleware` at the top of the middleware stack — fixes the provider 400 (\"An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'\") that happened when the recursion limit fired *between* an assistant tool-call message and its tool responses.
- `runs/invoke` no longer 500s on recursion limit either; it returns `{\"content\": \"…\"}` like a normal completion.

## How it works
1. Graph hits `recursion_limit` mid-run → `GraphRecursionError` is raised after the last checkpoint is written.
2. Both stream adapters re-raise it; the runtime catches it, appends an `AIMessage` to state via `agent.aupdate_state(...)`, and streams the synthetic turn through the active adapter (LangGraph SSE / Slack / invoke JSON).
3. On the user's next message, `PatchToolCallsMiddleware` runs in `before_agent` and inserts a synthetic `ToolMessage(\"…was cancelled — another message came in before it could be completed\")` for any dangling `tool_call_id`, so the model sees a well-formed history.

No frontend changes — the synthetic AI message renders like any other reply.

## Test plan
- [ ] Set a low `recursion_limit` (e.g. via env) on an agent with tools, ask a question that triggers many steps, confirm the synthetic AI message appears in chat and persists on refresh.
- [ ] In the same scenario, send \"continue\" — confirm the run resumes without a provider 400.
- [ ] Cancel a stream mid tool call, send a new message, confirm `PatchToolCallsMiddleware` patches the dangling call.
- [ ] `POST /threads/{id}/runs/invoke` with a thread known to exceed the limit returns 200 with a `content` field, not 500.
- [ ] Slack invocation: trigger a recursion limit in a Slack thread, confirm the friendly text is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a friendly, resumable assistant reply when the `langgraph` recursion limit is hit, and keep threads valid by patching dangling tool calls. Also prevents `runs/invoke` from 500ing by returning a normal content payload.

- Bug Fixes
  - On recursion limit, the runtime appends a friendly assistant message to state (persisted) and streams it via SSE/`Slack`/invoke JSON.
  - Added `PatchToolCallsMiddleware` at the top of the stack to synthesize a `ToolMessage` for any pending `tool_call_id`, avoiding provider 400s on the next turn.
  - `POST /threads/{id}/runs/invoke` now returns 200 with `{"content": ...}` instead of 500 when the limit is reached.

<sup>Written for commit 411b06b56329529957f507c009c7594a8fad1f3d. Summary will update on new commits. <a href="https://cubic.dev/pr/keurcien/auxilia/pull/97?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

