### PR TITLE
refactor: extract shared helpers in runtime, stream, and Slack paths

### DIFF
--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from uuid import uuid4
 
@@ -18,7 +19,6 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
-from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,7 +33,8 @@ from app.agents.stream import (
 )
 from app.agents.tool_errors import ToolErrorMiddleware
 from app.agents.toolset import Toolset, sanitize_tool_name
-from app.database import get_psycopg_conn_string
+from app.database import get_checkpointer
+from app.exceptions import ValidationError
 from app.integrations.langfuse.callback import langfuse_callback_handler
 from app.model_providers.catalog import LLM_PROVIDERS, MODELS, ChatModelFactory
 from app.sandbox.settings import sandbox_settings
@@ -168,9 +169,16 @@ class AgentRuntime:
 
         agent = await Agent.resolve(thread.agent_id, db, user_id, is_parent=True)
 
-        model_entry = next(m for m in MODELS if m.name == thread.model_id)
-        provider = next(p for p in LLM_PROVIDERS if p.name ==
-                        model_entry.provider)
+        model_entry = next((m for m in MODELS if m.name == thread.model_id), None)
+        if model_entry is None:
+            raise ValidationError(f"Unknown model: {thread.model_id}")
+        provider = next(
+            (p for p in LLM_PROVIDERS if p.name == model_entry.provider), None
+        )
+        if provider is None:
+            raise ValidationError(
+                f"Unknown provider {model_entry.provider!r} for model {thread.model_id}"
+            )
         model = ChatModelFactory().create(
             provider.name, thread.model_id, provider.api_key
         )
@@ -252,6 +260,34 @@ class AgentRuntime:
                 config["configurable"]["checkpoint_id"] = checkpoint_id
         return config
 
+    @asynccontextmanager
+    async def _setup(
+        self,
+        input: dict | None,
+        command: dict | None,
+        trigger: str | None,
+        config_overrides: dict | None,
+    ):
+        """Open a checkpointer scope and yield (agent, agent_input, config).
+
+        Shared scaffolding for `stream` and `invoke`: opens the AsyncPostgresSaver,
+        builds the LangGraph agent against it, and resolves the request input and
+        run config in one place.
+        """
+        async with get_checkpointer() as checkpointer:
+            agent = self._build_agent(checkpointer)
+            agent_input = self._resolve_input(input, command)
+            config = await self._resolve_config(agent, trigger, config_overrides)
+            yield agent, agent_input, config
+
+    async def _persist_recursion_fallback(self, agent, config) -> AIMessage:
+        """Persist a synthetic AI message after a GraphRecursionError so the
+        next turn can pick up where we left off. Returns the message."""
+        logger.info("Graph recursion limit reached; persisting synthetic AI message")
+        ai_msg = AIMessage(content=RECURSION_LIMIT_MESSAGE, id=str(uuid4()))
+        await agent.aupdate_state(config, {"messages": [ai_msg]})
+        return ai_msg
+
     async def stream(
         self,
         input: dict | None = None,
@@ -269,13 +305,11 @@ class AgentRuntime:
             config_overrides: Optional config dict with configurable overrides.
             stream_adapter: Which stream adapter to use ("langgraph" or "slack").
         """
-        async with AsyncPostgresSaver.from_conn_string(
-            get_psycopg_conn_string()
-        ) as checkpointer:
-            agent = self._build_agent(checkpointer)
-            stream_input = self._resolve_input(input, command)
-            config = await self._resolve_config(agent, trigger, config_overrides)
-
+        async with self._setup(input, command, trigger, config_overrides) as (
+            agent,
+            stream_input,
+            config,
+        ):
             if stream_adapter == "slack":
                 langchain_stream = agent.astream(
                     stream_input,
@@ -296,12 +330,7 @@ class AgentRuntime:
                 async for chunk in adapter.stream(langchain_stream):
                     yield chunk
             except GraphRecursionError:
-                logger.info("Graph recursion limit reached; emitting synthetic AI message")
-                ai_msg = AIMessage(
-                    content=RECURSION_LIMIT_MESSAGE,
-                    id=str(uuid4()),
-                )
-                await agent.aupdate_state(config, {"messages": [ai_msg]})
+                ai_msg = await self._persist_recursion_fallback(agent, config)
                 if stream_adapter == "slack":
                     yield {"type": "text", "content": ai_msg.content}
                 else:
@@ -317,22 +346,15 @@ class AgentRuntime:
         config_overrides: dict | None = None,
     ) -> dict:
         """Run the agent to completion and return the text of the last AI message."""
-        async with AsyncPostgresSaver.from_conn_string(
-            get_psycopg_conn_string()
-        ) as checkpointer:
-            agent = self._build_agent(checkpointer)
-            agent_input = self._resolve_input(input, command)
-            config = await self._resolve_config(agent, trigger, config_overrides)
-
+        async with self._setup(input, command, trigger, config_overrides) as (
+            agent,
+            agent_input,
+            config,
+        ):
             try:
                 result = await agent.ainvoke(agent_input, config=config)
             except GraphRecursionError:
-                logger.info("Graph recursion limit reached in invoke; appending synthetic AI message")
-                ai_msg = AIMessage(
-                    content=RECURSION_LIMIT_MESSAGE,
-                    id=str(uuid4()),
-                )
-                await agent.aupdate_state(config, {"messages": [ai_msg]})
+                ai_msg = await self._persist_recursion_fallback(agent, config)
                 return {"content": ai_msg.content}
 
             messages = result.get("messages", [])

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -235,12 +235,12 @@ class AgentRuntime:
             middleware=middleware,
         )
 
-    def _resolve_input(self, input: dict | None, command: dict | None):
+    def _resolve_input(self, agent_input: dict | None, command: dict | None):
         """Resolve raw input/command dicts into the value to pass to the agent."""
         if command is not None:
             return Command(resume=command.get("resume"))
         lc_messages = _dicts_to_lc_messages(
-            input.get("messages", []) if input else []
+            agent_input.get("messages", []) if agent_input else []
         )
         return {"messages": lc_messages}
 
@@ -263,12 +263,12 @@ class AgentRuntime:
     @asynccontextmanager
     async def _setup(
         self,
-        input: dict | None,
+        agent_input: dict | None,
         command: dict | None,
         trigger: str | None,
         config_overrides: dict | None,
     ):
-        """Open a checkpointer scope and yield (agent, agent_input, config).
+        """Open a checkpointer scope and yield (agent, resolved_input, config).
 
         Shared scaffolding for `stream` and `invoke`: opens the AsyncPostgresSaver,
         builds the LangGraph agent against it, and resolves the request input and
@@ -276,9 +276,9 @@ class AgentRuntime:
         """
         async with get_checkpointer() as checkpointer:
             agent = self._build_agent(checkpointer)
-            agent_input = self._resolve_input(input, command)
+            resolved_input = self._resolve_input(agent_input, command)
             config = await self._resolve_config(agent, trigger, config_overrides)
-            yield agent, agent_input, config
+            yield agent, resolved_input, config
 
     async def _persist_recursion_fallback(self, agent, config) -> AIMessage:
         """Persist a synthetic AI message after a GraphRecursionError so the
@@ -290,7 +290,7 @@ class AgentRuntime:
 
     async def stream(
         self,
-        input: dict | None = None,
+        agent_input: dict | None = None,
         command: dict | None = None,
         trigger: str | None = None,
         config_overrides: dict | None = None,
@@ -299,13 +299,13 @@ class AgentRuntime:
         """Stream using the native LangGraph SSE protocol.
 
         Args:
-            input: Graph input dict (e.g. {"messages": [{"type": "human", ...}]}) or None for resume.
+            agent_input: Graph input dict (e.g. {"messages": [{"type": "human", ...}]}) or None for resume.
             command: LangGraph Command dict (e.g. {"resume": {...}}) for HITL resume.
             trigger: Optional trigger ("regenerate-message") for regeneration.
             config_overrides: Optional config dict with configurable overrides.
             stream_adapter: Which stream adapter to use ("langgraph" or "slack").
         """
-        async with self._setup(input, command, trigger, config_overrides) as (
+        async with self._setup(agent_input, command, trigger, config_overrides) as (
             agent,
             stream_input,
             config,
@@ -340,19 +340,19 @@ class AgentRuntime:
 
     async def invoke(
         self,
-        input: dict | None = None,
+        agent_input: dict | None = None,
         command: dict | None = None,
         trigger: str | None = None,
         config_overrides: dict | None = None,
     ) -> dict:
         """Run the agent to completion and return the text of the last AI message."""
-        async with self._setup(input, command, trigger, config_overrides) as (
+        async with self._setup(agent_input, command, trigger, config_overrides) as (
             agent,
-            agent_input,
+            resolved_input,
             config,
         ):
             try:
-                result = await agent.ainvoke(agent_input, config=config)
+                result = await agent.ainvoke(resolved_input, config=config)
             except GraphRecursionError:
                 ai_msg = await self._persist_recursion_fallback(agent, config)
                 return {"content": ai_msg.content}

--- a/backend/app/integrations/slack/blocks.py
+++ b/backend/app/integrations/slack/blocks.py
@@ -48,16 +48,33 @@ def _format_tool_input(obj: Any, indent: int = 0) -> str:
     return "  " * indent + str(obj)
 
 
+def _split_tool_name(tool_name: str) -> tuple[str, str]:
+    """Split a `prefix_suffix_parts` tool name into (prefix, suffix)."""
+    parts = tool_name.split("_")
+    return parts[0], "_".join(parts[1:])
+
+
+def format_tool_streamer_label(tool_name: str) -> str:
+    """Format a tool call as Slack markdown text for the streaming chat surface.
+
+    Returns a block with leading and trailing newlines so it slots cleanly into
+    a streamer that's appending chunks of markdown.
+    """
+    prefix, suffix = _split_tool_name(tool_name)
+    return f"\n\n:{prefix.lower()}:  **{prefix}**  ›  `{suffix}`\n\n"
+
+
 def _tool_context_block(tool_name: str) -> dict:
     """Build the context block header for a tool name."""
+    prefix, suffix = _split_tool_name(tool_name)
     return {
         "type": "context",
         "elements": [
             {
                 "type": "mrkdwn",
-                "text": f":{tool_name.split('_')[0]}:  *{tool_name.split('_')[0]}*  ›  `{'_'.join(tool_name.split('_')[1:])}`"
+                "text": f":{prefix}:  *{prefix}*  ›  `{suffix}`",
             }
-        ]
+        ],
     }
 
 

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -42,7 +42,7 @@ async def _stream_and_collect_approvals(
     agent_runtime: AgentRuntime,
     streamer,
     *,
-    input: dict | None = None,
+    agent_input: dict | None = None,
     command: dict | None = None,
 ) -> list[dict]:
     """Stream the agent response, forwarding text to the streamer.
@@ -53,7 +53,7 @@ async def _stream_and_collect_approvals(
     approval_requests: list[dict] = []
 
     async for ev in agent_runtime.stream(
-        input=input, command=command, stream_adapter="slack",
+        agent_input=agent_input, command=command, stream_adapter="slack",
     ):
         if ev["type"] == "text":
             await streamer.append(markdown_text=ev["content"])
@@ -79,7 +79,7 @@ async def _run_slack_turn(
     *,
     recipient_user_id: str,
     recipient_team_id: str | None = None,
-    input: dict | None = None,
+    agent_input: dict | None = None,
     command: dict | None = None,
 ) -> None:
     """Build the agent runtime, stream the response, and post follow-ups.
@@ -97,7 +97,7 @@ async def _run_slack_turn(
 
     agent_runtime = await AgentRuntime.build(thread=thread, db=db)
     approval_requests = await _stream_and_collect_approvals(
-        agent_runtime, streamer, input=input, command=command,
+        agent_runtime, streamer, agent_input=agent_input, command=command,
     )
 
     for req in approval_requests:
@@ -250,7 +250,7 @@ async def stream_agent_response(
         thread_ts=event.thread_ts or event.ts,
         recipient_user_id=event.user,
         recipient_team_id=team_id,
-        input={"messages": [{"type": "human", "content": question}]},
+        agent_input={"messages": [{"type": "human", "content": question}]},
     )
 
 

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -12,7 +12,10 @@ from app.agents.core.service import AgentService
 from app.agents.runtime import AgentRuntime
 from app.auth.settings import auth_settings
 from app.database import AsyncSessionLocal
-from app.integrations.slack.blocks import build_tool_approval_blocks
+from app.integrations.slack.blocks import (
+    build_tool_approval_blocks,
+    format_tool_streamer_label,
+)
 from app.integrations.slack.commands.chat import post_agent_picker
 from app.integrations.slack.models import SlackEvent, SlackInteractionPayload
 from app.integrations.slack.settings import slack_settings
@@ -55,8 +58,9 @@ async def _stream_and_collect_approvals(
         if ev["type"] == "text":
             await streamer.append(markdown_text=ev["content"])
         elif ev["type"] == "tool_start":
-            tool_name = ev["tool_name"]
-            await streamer.append(markdown_text=f"\n\n:{tool_name.split('_')[0].lower()}:  **{tool_name.split('_')[0]}**  ›  `{'_'.join(tool_name.split('_')[1:])}`\n\n")
+            await streamer.append(
+                markdown_text=format_tool_streamer_label(ev["tool_name"])
+            )
         elif ev["type"] == "tool_approval_request":
             approval_requests.append(ev)
         elif ev["type"] == "error":
@@ -64,6 +68,43 @@ async def _stream_and_collect_approvals(
 
     await streamer.stop()
     return approval_requests
+
+
+async def _run_slack_turn(
+    client: AsyncWebClient,
+    thread: ThreadDB,
+    db: AsyncSession,
+    channel_id: str,
+    thread_ts: str,
+    *,
+    recipient_user_id: str,
+    recipient_team_id: str | None = None,
+    input: dict | None = None,
+    command: dict | None = None,
+) -> None:
+    """Build the agent runtime, stream the response, and post follow-ups.
+
+    Shared by initial messages and HITL resume: opens the chat streamer,
+    runs the agent, then either posts approval blocks for any pending
+    tool calls or the auxilia link when the turn completes cleanly.
+    """
+    streamer = await client.chat_stream(
+        channel=channel_id,
+        thread_ts=thread_ts,
+        recipient_team_id=recipient_team_id,
+        recipient_user_id=recipient_user_id,
+    )
+
+    agent_runtime = await AgentRuntime.build(thread=thread, db=db)
+    approval_requests = await _stream_and_collect_approvals(
+        agent_runtime, streamer, input=input, command=command,
+    )
+
+    for req in approval_requests:
+        await post_tool_approval_block(client, channel_id, thread_ts, req)
+
+    if not approval_requests:
+        await _post_auxilia_link(client, channel_id, thread_ts, thread)
 
 
 async def _post_auxilia_link(
@@ -200,27 +241,17 @@ async def stream_agent_response(
     *,
     team_id: str | None = None,
 ) -> None:
-    """Build the agent runtime, stream the response, and close the streamer."""
-    streamer = await client.chat_stream(
-        channel=event.channel,
+    """Stream an initial agent response to a user message in a Slack thread."""
+    await _run_slack_turn(
+        client=client,
+        thread=thread,
+        db=db,
+        channel_id=event.channel,
         thread_ts=event.thread_ts or event.ts,
-        recipient_team_id=team_id,
         recipient_user_id=event.user,
-    )
-    thread_ts = event.thread_ts or event.ts
-
-    agent_runtime = await AgentRuntime.build(thread=thread, db=db)
-
-    approval_requests = await _stream_and_collect_approvals(
-        agent_runtime, streamer,
+        recipient_team_id=team_id,
         input={"messages": [{"type": "human", "content": question}]},
     )
-
-    for req in approval_requests:
-        await post_tool_approval_block(client, event.channel, thread_ts, req)
-
-    if not approval_requests:
-        await _post_auxilia_link(client, event.channel, thread_ts, thread)
 
 
 async def handle_assistant_thread_started(event: SlackEvent) -> None:
@@ -338,8 +369,7 @@ async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> No
     client = AsyncWebClient(token=slack_settings.slack_bot_token)
 
     # Look up the existing thread (created when the user picked an agent)
-    db = AsyncSessionLocal()
-    try:
+    async with AsyncSessionLocal() as db:
         thread = await db.get(ThreadDB, thread_ts)
 
         if not thread:
@@ -391,8 +421,6 @@ async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> No
         await stream_agent_response(
             thread, db, question, event, client, team_id=team_id,
         )
-    finally:
-        await db.close()
 
 
 async def handle_interaction(payload: SlackInteractionPayload) -> None:
@@ -469,8 +497,7 @@ async def _resume_agent(
     if not user:
         return
 
-    db = AsyncSessionLocal()
-    try:
+    async with AsyncSessionLocal() as db:
         thread = await db.get(ThreadDB, thread_ts)
         if not thread:
             return
@@ -479,23 +506,12 @@ async def _resume_agent(
             channel_id=channel_id, thread_ts=thread_ts, status="is typing...",
         )
 
-        agent_runtime = await AgentRuntime.build(thread=thread, db=db)
-
-        streamer = await client.chat_stream(
-            channel=channel_id,
+        await _run_slack_turn(
+            client=client,
+            thread=thread,
+            db=db,
+            channel_id=channel_id,
             thread_ts=thread_ts,
             recipient_user_id=slack_user_id,
-        )
-
-        approval_requests = await _stream_and_collect_approvals(
-            agent_runtime, streamer,
             command={"resume": {"decisions": [{"type": cmd} for cmd in commands]}},
         )
-
-        for req in approval_requests:
-            await post_tool_approval_block(client, channel_id, thread_ts, req)
-
-        if not approval_requests:
-            await _post_auxilia_link(client, channel_id, thread_ts, thread)
-    finally:
-        await db.close()

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -1,12 +1,11 @@
 from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import StreamingResponse
-from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 
 from app.agents.core.service import AgentService, get_agent_service
 from app.agents.runtime import AgentRuntime
 from app.agents.stream import _serialize_lc_message
 from app.auth.dependencies import detect_auth_method, get_current_user
-from app.database import get_db, get_psycopg_conn_string
+from app.database import get_checkpointer, get_db
 from app.exceptions import PermissionDeniedError
 from app.threads.models import ThreadDB, ThreadSource
 from app.threads.schemas import ThreadCreate, ThreadResponse, ViewerRole
@@ -16,6 +15,23 @@ from app.users.models import UserDB
 
 
 router = APIRouter(prefix="/threads", tags=["threads"])
+
+
+def _parse_run_config(
+    config: dict | None,
+) -> tuple[str | None, dict | None]:
+    """Pull `trigger` and `config_overrides` out of a /runs request body config.
+
+    Mutates the input dict: consumes `trigger` and `thread_id` from
+    `config["configurable"]`. Returns `(trigger, config_overrides)` where
+    `config_overrides` is the remaining config (or None if empty).
+    """
+    if not config or not config.get("configurable"):
+        return None, None
+    trigger = config["configurable"].pop("trigger", None)
+    config["configurable"].pop("thread_id", None)
+    config_overrides = config if config["configurable"] else None
+    return trigger, config_overrides
 
 
 async def _resolve_viewer_role(
@@ -50,9 +66,7 @@ async def read_thread(
     viewer_role = await _resolve_viewer_role(thread, current_user, agent_service)
     thread_read = await service.get_thread_with_agent(thread_id)
 
-    async with AsyncPostgresSaver.from_conn_string(
-        get_psycopg_conn_string()
-    ) as checkpointer:
+    async with get_checkpointer() as checkpointer:
         checkpoint_tuple = await checkpointer.aget_tuple(
             config={"configurable": {"thread_id": thread_id}}
         )
@@ -99,9 +113,7 @@ async def read_thread(
 @router.get("/{thread_id}/subagents/{tool_call_id}/state")
 async def get_subagent_state(thread_id: str, tool_call_id: str) -> dict:
     """Fetch a subagent's checkpoint state (its internal messages) by tool call ID."""
-    async with AsyncPostgresSaver.from_conn_string(
-        get_psycopg_conn_string()
-    ) as checkpointer:
+    async with get_checkpointer() as checkpointer:
         checkpoint = await checkpointer.aget(
             config={
                 "configurable": {
@@ -153,9 +165,7 @@ async def delete_thread(
     thread = await service.get_thread(thread_id)
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to delete this thread")
-    async with AsyncPostgresSaver.from_conn_string(
-        get_psycopg_conn_string()
-    ) as checkpointer:
+    async with get_checkpointer() as checkpointer:
         await checkpointer.adelete_thread(thread_id=thread_id)
 
     await service.delete_thread(thread_id)
@@ -177,16 +187,7 @@ async def run_stream(
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to run this thread")
     runtime = await AgentRuntime.build(thread=thread, db=db)
-
-    # Extract trigger from config.configurable if provided
-    trigger = None
-    config_overrides = None
-    if config and config.get("configurable"):
-        trigger = config["configurable"].pop("trigger", None)
-        # thread_id is already from the URL path, remove it from config
-        config["configurable"].pop("thread_id", None)
-        if config["configurable"]:
-            config_overrides = config
+    trigger, config_overrides = _parse_run_config(config)
 
     return StreamingResponse(
         runtime.stream(
@@ -220,14 +221,7 @@ async def run_invoke(
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to run this thread")
     runtime = await AgentRuntime.build(thread=thread, db=db)
-
-    trigger = None
-    config_overrides = None
-    if config and config.get("configurable"):
-        trigger = config["configurable"].pop("trigger", None)
-        config["configurable"].pop("thread_id", None)
-        if config["configurable"]:
-            config_overrides = config
+    trigger, config_overrides = _parse_run_config(config)
 
     return await runtime.invoke(
         input=input,

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -174,7 +174,7 @@ async def delete_thread(
 @router.post("/{thread_id}/runs/stream")
 async def run_stream(
     thread_id: str,
-    input: dict | None = Body(None, embed=True),
+    agent_input: dict | None = Body(None, embed=True, alias="input"),
     command: dict | None = Body(None, embed=True),
     config: dict | None = Body(None, embed=True),
     context: dict | None = Body(None, embed=True),  # noqa: ARG001
@@ -191,7 +191,7 @@ async def run_stream(
 
     return StreamingResponse(
         runtime.stream(
-            input=input,
+            agent_input=agent_input,
             command=command,
             trigger=trigger,
             config_overrides=config_overrides,
@@ -208,7 +208,7 @@ async def run_stream(
 @router.post("/{thread_id}/runs/invoke")
 async def run_invoke(
     thread_id: str,
-    input: dict | None = Body(None, embed=True),
+    agent_input: dict | None = Body(None, embed=True, alias="input"),
     command: dict | None = Body(None, embed=True),
     config: dict | None = Body(None, embed=True),
     context: dict | None = Body(None, embed=True),  # noqa: ARG001
@@ -224,7 +224,7 @@ async def run_invoke(
     trigger, config_overrides = _parse_run_config(config)
 
     return await runtime.invoke(
-        input=input,
+        agent_input=agent_input,
         command=command,
         trigger=trigger,
         config_overrides=config_overrides,

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -103,7 +103,7 @@ def test_get_threads(client: TestClient, mock_db, current_user):
     assert len(data) == 2
 
 
-@patch("app.threads.router.AsyncPostgresSaver.from_conn_string")
+@patch("app.threads.router.get_checkpointer")
 def test_get_thread(mock_checkpointer, client: TestClient, mock_db, current_user):
     """Owner can read their own thread."""
     thread_id = str(uuid4())
@@ -179,7 +179,7 @@ def test_get_thread_not_found(client: TestClient, mock_db):
     assert response.json()["detail"] == "Thread not found"
 
 
-@patch("app.threads.router.AsyncPostgresSaver.from_conn_string")
+@patch("app.threads.router.get_checkpointer")
 def test_delete_thread(mock_checkpointer, client: TestClient, mock_db, current_user):
     """Test deleting a thread."""
     thread_id = str(uuid4())
@@ -211,7 +211,7 @@ def test_delete_thread(mock_checkpointer, client: TestClient, mock_db, current_u
 
 
 @pytest.mark.usefixtures("current_user")
-@patch("app.threads.router.AsyncPostgresSaver.from_conn_string")
+@patch("app.threads.router.get_checkpointer")
 def test_delete_thread_not_found(mock_checkpointer, client: TestClient, mock_db):
     """Test deleting a non-existent thread returns 404."""
     fake_id = uuid4()


### PR DESCRIPTION
## Summary
Extract shared helpers across the agent execution path to remove duplication between `/runs/stream`, `/runs/invoke`, and the Slack handlers. No API or behavior changes — pure internal restructuring.

- **`runtime.py`** — new `_setup` async context manager + `_persist_recursion_fallback` collapse the boilerplate shared by `stream()` and `invoke()` (checkpointer scope, agent build, input/config resolution, recursion-limit fallback). `next(...)` model/provider lookup now raises `ValidationError` on miss.
- **`threads/router.py`** — `_parse_run_config` replaces the identical 7-line trigger/`config_overrides` block that lived in both `run_stream` and `run_invoke`. Three checkpointer call sites switched to the existing `get_checkpointer()` helper.
- **`slack/handlers.py`** — `_run_slack_turn` unifies the build-runtime + stream + post-followups flow shared by `stream_agent_response` (initial message) and `_resume_agent` (HITL resume). Manual `try/finally` session blocks became `async with AsyncSessionLocal()`.
- **`slack/blocks.py`** — `format_tool_streamer_label` + `_split_tool_name` centralize tool-name display, removing the inline f-string in `handlers.py`.

## Trade-off note
Net line count went up (~+49) because helper signatures + docstrings carry overhead. The gain is single-source-of-truth, not raw line reduction. If we want to claw back lines, the obvious candidate is inlining `stream_agent_response` into `handle_message` (the wrapper exists only to translate `event` fields into kwargs).

## Test plan
- [x] `ruff check` on touched files passes
- [x] `pytest` — 146 affected tests pass (one pre-existing failure in `tests/users/test_users_router.py::test_create_user_duplicate_email` is unrelated: 400 vs 409 mismatch on `main`)
- [x] Manual: web flow — send a message, confirm streaming text + tool calls render unchanged
- [x] Manual: HITL — trigger a tool with `interrupt_on`, confirm approve/reject still resumes the agent
- [x] Manual: recursion limit — confirm synthetic AI message persists and renders
- [x] Manual: Slack flow — send a message, confirm streaming + approval buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared helpers across the agent runtime, thread run paths, and Slack handlers to remove duplication. Renamed internal `input` params to `agent_input` (API still accepts "input"); unknown model/provider now raises a clear `ValidationError`.

- **Refactors**
  - Runtime: added `_setup` async context manager and `_persist_recursion_fallback` to unify `stream()`/`invoke()`; switched to `get_checkpointer()`; model/provider lookup now raises `ValidationError`.
  - Threads: introduced `_parse_run_config` to extract `trigger`/`config_overrides`; unified checkpointer usage via `get_checkpointer()` in read/delete/state endpoints; request bodies keep `"input"` via alias.
  - Slack handlers: added `_run_slack_turn` to share build + stream + post-followups for initial and resume flows; replaced manual `try/finally` with `async with AsyncSessionLocal()`.
  - Slack blocks: added `_split_tool_name` and `format_tool_streamer_label` to centralize tool-name formatting for streaming.

<sup>Written for commit 3ee083c74f73111d1263e1eb9d960574e33bce76. Summary will update on new commits. <a href="https://cubic.dev/pr/keurcien/auxilia/pull/98?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

