### PR TITLE
refactor: enforce CONVENTIONS.md naming across backend + frontend

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -2,3 +2,6 @@ engines:
   bandit:
     exclude_paths:
       - "backend/tests/**"
+  gitleaks:
+    exclude_paths:
+      - "backend/tests/**"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,7 +1,7 @@
+exclude_paths:
+  - "backend/tests/**"
+
 engines:
   bandit:
-    exclude_paths:
-      - "backend/tests/**"
-  gitleaks:
     exclude_paths:
       - "backend/tests/**"

--- a/backend/CONVENTIONS.md
+++ b/backend/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Backend Naming Conventions
 
-This document is the source of truth for how to name things in the FastAPI backend (`backend/`). It complements `CLAUDE.md`, which describes the *architecture* (router → service → repository → model). This one is about *names*.
+This document is the source of truth for how to name things in the FastAPI backend (`backend/`). It complements `CLAUDE.md`, which describes the _architecture_ (router → service → repository → model). This one is about _names_.
 
 If anything in this doc conflicts with code in the repo today, the code is wrong — see `CONVENTIONS_RENAMES.md` for the punch list of changes needed to bring the codebase into compliance.
 
@@ -12,14 +12,14 @@ If anything in this doc conflicts with code in the repo today, the code is wrong
 
 The bare noun is the concept. Specific classes always wear a suffix that says what stage / representation they are.
 
-| Concept | Suffix family |
-| --- | --- |
-| `User` | `UserDB`, `UserCreate`, `UserPatch`, `UserResponse` |
-| `Agent` | `AgentDB`, `AgentCreate`, `AgentCreateDB`, `AgentPatch`, `AgentResponse`, `ResolvedAgent`, `Agent` (the runnable — see §4) |
-| `Thread` | `ThreadDB`, `ThreadCreate`, `ThreadPatch`, `ThreadResponse` |
-| `MCPServer` | `MCPServerDB`, `MCPServerCreate`, `MCPServerPatch`, `MCPServerResponse` |
-| `Invite` | `InviteDB`, `InviteCreate`, `InviteCreateDB`, `InviteResponse` |
-| `PersonalAccessToken` (PAT) | `PersonalAccessTokenDB`, `PersonalAccessTokenCreate`, `PersonalAccessTokenCreateDB`, `PersonalAccessTokenResponse` |
+| Concept                     | Suffix family                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `User`                      | `UserDB`, `UserCreate`, `UserPatch`, `UserResponse`                                                                        |
+| `Agent`                     | `AgentDB`, `AgentCreate`, `AgentCreateDB`, `AgentPatch`, `AgentResponse`, `ResolvedAgent`, `Agent` (the runnable — see §4) |
+| `Thread`                    | `ThreadDB`, `ThreadCreate`, `ThreadPatch`, `ThreadResponse`                                                                |
+| `MCPServer`                 | `MCPServerDB`, `MCPServerCreate`, `MCPServerPatch`, `MCPServerResponse`                                                    |
+| `Invite`                    | `InviteDB`, `InviteCreate`, `InviteCreateDB`, `InviteResponse`                                                             |
+| `PersonalAccessToken` (PAT) | `PersonalAccessTokenDB`, `PersonalAccessTokenCreate`, `PersonalAccessTokenCreateDB`, `PersonalAccessTokenResponse`         |
 
 Rule: **never define a class with the bare noun** (`User`, `Thread`, `MCPServer`). The bare noun is reserved for prose. `Agent` is the deliberate exception — it names the runnable runtime class (§4).
 
@@ -29,23 +29,23 @@ A parent agent that orchestrates other agents is the **supervisor**. The orchest
 
 ### Class suffix catalogue
 
-| Suffix | Meaning | Used by |
-| --- | --- | --- |
-| `*DB` | SQLModel table (`table=True`) | `UserDB`, `AgentDB`, … |
-| `*Base` | Shared column set mixed into the table + create schema | `UserBase`, `AgentBase` |
-| `*Create` | Client-supplied create payload | `UserCreate`, `AgentCreate` |
-| `*CreateDB` | Server-side create payload — adds fields the client can't set (`owner_id`, `token_hash`, `expires_at`) | `AgentCreateDB`, `InviteCreateDB`, `PersonalAccessTokenCreateDB` |
-| `*Patch` | Partial update payload (all fields nullable, consumed with `model_dump(exclude_unset=True)`) | `UserPatch`, `AgentPatch` |
-| `*Response` | API response shape | `UserResponse`, `AgentResponse` |
-| `*Service` | Business logic class — owns the `db`, raises domain exceptions | `UserService`, `AgentService` |
-| `*Repository` | Data access class — one method per query shape | `UserRepository`, `AgentRepository` |
-| `*Settings` | `pydantic_settings.BaseSettings` config class | `AppSettings`, `AgentSettings` |
-| `*Factory` | Builds objects from inputs | `ChatModelFactory`, `MCPClientConfigFactory` |
-| `*Provider` | Provides a service or capability (OAuth, auth, …) | `WebOAuthClientProvider` |
-| `*Middleware` | LangChain middleware | `ToolErrorMiddleware`, `SubAgentMiddleware` |
-| `*Adapter` | Adapts one interface to another (e.g. stream protocols) | `LangGraphStreamAdapter`, `SlackStreamAdapter` |
-| `*Error` | Domain exception (see §8) | `NotFoundError`, `DomainValidationError` |
-| `*Mixin` | SQLModel column mixin | `UUIDMixin`, `TimestampMixin` |
+| Suffix        | Meaning                                                                                                | Used by                                                          |
+| ------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `*DB`         | SQLModel table (`table=True`)                                                                          | `UserDB`, `AgentDB`, …                                           |
+| `*Base`       | Shared column set mixed into the table + create schema                                                 | `UserBase`, `AgentBase`                                          |
+| `*Create`     | Client-supplied create payload                                                                         | `UserCreate`, `AgentCreate`                                      |
+| `*CreateDB`   | Server-side create payload — adds fields the client can't set (`owner_id`, `token_hash`, `expires_at`) | `AgentCreateDB`, `InviteCreateDB`, `PersonalAccessTokenCreateDB` |
+| `*Patch`      | Partial update payload (all fields nullable, consumed with `model_dump(exclude_unset=True)`)           | `UserPatch`, `AgentPatch`                                        |
+| `*Response`   | API response shape                                                                                     | `UserResponse`, `AgentResponse`                                  |
+| `*Service`    | Business logic class — owns the `db`, raises domain exceptions                                         | `UserService`, `AgentService`                                    |
+| `*Repository` | Data access class — one method per query shape                                                         | `UserRepository`, `AgentRepository`                              |
+| `*Settings`   | `pydantic_settings.BaseSettings` config class                                                          | `AppSettings`, `AgentSettings`                                   |
+| `*Factory`    | Builds objects from inputs                                                                             | `ChatModelFactory`, `MCPClientConfigFactory`                     |
+| `*Provider`   | Provides a service or capability (OAuth, auth, …)                                                      | `WebOAuthClientProvider`                                         |
+| `*Middleware` | LangChain middleware                                                                                   | `ToolErrorMiddleware`, `SubAgentMiddleware`                      |
+| `*Adapter`    | Adapts one interface to another (e.g. stream protocols)                                                | `LangGraphStreamAdapter`, `SlackStreamAdapter`                   |
+| `*Error`      | Domain exception (see §8)                                                                              | `NotFoundError`, `DomainValidationError`                         |
+| `*Mixin`      | SQLModel column mixin                                                                                  | `UUIDMixin`, `TimestampMixin`                                    |
 
 **Do not use**: `*Update` (we use `*Patch`), `*Schema`, `*Model`, `*DTO`, `*Payload`, `*Exception` (use `*Error`), `*Handler`, `*Manager`.
 
@@ -53,7 +53,7 @@ A parent agent that orchestrates other agents is the **supervisor**. The orchest
 
 ### Enum values
 
-Enum values are lowercase snake_case. Multi-word values use `_` (`always_allow`), compound technical terms stay as one word (`oauth2`, `api_key` — but write `api_key` consistently with `_` for any token-like compound).
+Enum values are lowercase snake*case. Multi-word values use `*` (`always*allow`), compound technical terms stay as one word (`oauth2`, `api_key`— but write`api_key`consistently with`*` for any token-like compound).
 
 Shared role values across enums are kept in sync. `PermissionLevel` (per-agent) and `WorkspaceRole` (per-workspace) both use `member` / `editor` / `admin` — never `user` for the lowest level.
 
@@ -65,14 +65,14 @@ This is the canonical verb for each kind of method/function. Any other verb mean
 
 ### Read
 
-| Operation | Verb | Returns | Example |
-| --- | --- | --- | --- |
-| Fetch one by PK | `get(id)` (base repo), `get_by_*` (by field) | `Entity \| None` (repo) | `repo.get(user_id)`, `repo.get_by_email(email)` |
-| Fetch one or raise 404 | `get_or_404(id)` | `Entity` (raises `NotFoundError`) | `service.get_or_404(id)` |
-| Fetch by credential (token, hash, ...) | `get_by_token`, `get_by_hash`, … | `Entity \| None` | `repo.get_by_token(plaintext)` |
-| Fetch many | `list(...)`, `list_for_*`, `list_with_*`, `list_pending` | `list[Entity]` | `repo.list()`, `repo.list_for_user(user_id)` |
-| Count | `count_*` | `int` | `service.count_users()` |
-| Fetch-or-create | `get_or_create_*` | `(Entity, bool)` or `Entity` | `service.get_or_create_thread(...)` |
+| Operation                              | Verb                                                     | Returns                           | Example                                         |
+| -------------------------------------- | -------------------------------------------------------- | --------------------------------- | ----------------------------------------------- |
+| Fetch one by PK                        | `get(id)` (base repo), `get_by_*` (by field)             | `Entity \| None` (repo)           | `repo.get(user_id)`, `repo.get_by_email(email)` |
+| Fetch one or raise 404                 | `get_or_404(id)`                                         | `Entity` (raises `NotFoundError`) | `service.get_or_404(id)`                        |
+| Fetch by credential (token, hash, ...) | `get_by_token`, `get_by_hash`, …                         | `Entity \| None`                  | `repo.get_by_token(plaintext)`                  |
+| Fetch many                             | `list(...)`, `list_for_*`, `list_with_*`, `list_pending` | `list[Entity]`                    | `repo.list()`, `repo.list_for_user(user_id)`    |
+| Count                                  | `count_*`                                                | `int`                             | `service.count_users()`                         |
+| Fetch-or-create                        | `get_or_create_*`                                        | `(Entity, bool)` or `Entity`      | `service.get_or_create_thread(...)`             |
 
 **Reserved — do not use**: `load_*`, `fetch_*`, `resolve_*` (for DB lookups), `find_*`, `query_*`, `retrieve_*`, `select_*`.
 
@@ -80,23 +80,23 @@ This is the canonical verb for each kind of method/function. Any other verb mean
 
 ### Create / update / delete
 
-| Operation | Verb | Notes |
-| --- | --- | --- |
-| Create | `create(...)`, `create_*` | Adds row(s); raises `AlreadyExistsError` on conflict |
-| Update (partial) | `update(...)`, `update_*` | Consumes `*Patch`; uses `model_dump(exclude_unset=True)` |
-| Upsert | `create_or_update(...)`, `create_or_update_*` | Spelled out — never hidden behind `save_*` or `set_*` |
-| Delete (hard) | `delete(...)`, `delete_*` | Row removed |
-| Delete many | `delete_all_for_*` | E.g. `delete_all_for_agent(agent_id)` |
-| Replace a collection | `set_*` (e.g. `set_permissions`) | Bulk-replace semantics, *not* an upsert of single rows |
-| Soft delete (invite-status flip) | `revoke(...)` | Invite-specific; transitions `pending → revoked` |
-| Soft delete (agent flag) | `archive(...)` | Agent-specific; sets `is_archived = True` |
-| Wipe + keep row | `reset_*` (e.g. `reset_server`) | Clears credentials/state, row stays |
+| Operation                        | Verb                                          | Notes                                                    |
+| -------------------------------- | --------------------------------------------- | -------------------------------------------------------- |
+| Create                           | `create(...)`, `create_*`                     | Adds row(s); raises `AlreadyExistsError` on conflict     |
+| Update (partial)                 | `update(...)`, `update_*`                     | Consumes `*Patch`; uses `model_dump(exclude_unset=True)` |
+| Upsert                           | `create_or_update(...)`, `create_or_update_*` | Spelled out — never hidden behind `save_*` or `set_*`    |
+| Delete (hard)                    | `delete(...)`, `delete_*`                     | Row removed                                              |
+| Delete many                      | `delete_all_for_*`                            | E.g. `delete_all_for_agent(agent_id)`                    |
+| Replace a collection             | `set_*` (e.g. `set_permissions`)              | Bulk-replace semantics, _not_ an upsert of single rows   |
+| Soft delete (invite-status flip) | `revoke(...)`                                 | Invite-specific; transitions `pending → revoked`         |
+| Soft delete (agent flag)         | `archive(...)`                                | Agent-specific; sets `is_archived = True`                |
+| Wipe + keep row                  | `reset_*` (e.g. `reset_server`)               | Clears credentials/state, row stays                      |
 
 **Reserved — do not use**: `save_*`, `store_*`, `persist_*` (use `create` / `update` / `create_or_update`), `remove_*` / `destroy_*` (use `delete`), `modify_*` / `edit_*` / `change_*` (use `update`), `make_*` (use `build_*`), `add_*` (use `create_*`).
 
 ### Service methods drop the entity noun
 
-Repositories and services already name their entity through the class name. Methods do *not* repeat it.
+Repositories and services already name their entity through the class name. Methods do _not_ repeat it.
 
 ```python
 # GOOD
@@ -119,25 +119,25 @@ Relationship and filter qualifiers stay (`list_for_user`, `list_for_supervisor`,
 
 ### Predicates and assertions
 
-| Shape | Verb | Returns | Example |
-| --- | --- | --- | --- |
-| Pure bool — state | `is_*` | `bool` | `is_archived`, `is_sandboxed`, `is_subagent` |
-| Pure bool — possession | `has_*` | `bool` | `has_subagents`, `has_permission` |
-| Pure bool — capability | `can_*` | `bool` | `can_edit` |
-| Assert / guard | `_ensure_*` (private) | `None` or the asserted object; raises on failure | `_ensure_email_available`, `_ensure_server` |
-| I/O probe (network call, returns diagnostics) | `probe_*` | `dict` / status payload | `probe_connectivity`, `probe_mcp_server` |
-| Structured status | `describe_*` or `get_*_status` | `dict` | `describe_readiness`, `get_oauth_status` |
+| Shape                                         | Verb                           | Returns                                          | Example                                      |
+| --------------------------------------------- | ------------------------------ | ------------------------------------------------ | -------------------------------------------- |
+| Pure bool — state                             | `is_*`                         | `bool`                                           | `is_archived`, `is_sandboxed`, `is_subagent` |
+| Pure bool — possession                        | `has_*`                        | `bool`                                           | `has_subagents`, `has_permission`            |
+| Pure bool — capability                        | `can_*`                        | `bool`                                           | `can_edit`                                   |
+| Assert / guard                                | `_ensure_*` (private)          | `None` or the asserted object; raises on failure | `_ensure_email_available`, `_ensure_server`  |
+| I/O probe (network call, returns diagnostics) | `probe_*`                      | `dict` / status payload                          | `probe_connectivity`, `probe_mcp_server`     |
+| Structured status                             | `describe_*` or `get_*_status` | `dict`                                           | `describe_readiness`, `get_oauth_status`     |
 
 **Reserved — do not use**: `check_*` (ambiguous between predicate, assertion, and probe — pick one of the above), `validate_*` (use `_ensure_*` or `is_*`), `verify_*`, `_require_*` (use `_ensure_*`).
 
 ### Constructors of new artifacts
 
-| Operation | Verb | Notes |
-| --- | --- | --- |
-| Deterministic compose | `build_*` | `build_invite_url`, `build_oauth_client_metadata`, `build_jwt_for_user`. Pure function-y. |
-| Entropy / cryptographic | `_generate_*` (private) | `_generate_token` — anything that calls `secrets.token_*` or pulls randomness. |
-| DB lookup + hydrate (factory) | `resolve(...)` (classmethod) | `ResolvedAgent.resolve(agent_id, db, user_id)`, `Toolset.resolve(...)` |
-| Orchestrate multiple resolves | `build(...)` (classmethod) | `Agent.build(thread, db)` — composes multiple `resolve` calls + middleware/callbacks |
+| Operation                     | Verb                         | Notes                                                                                     |
+| ----------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
+| Deterministic compose         | `build_*`                    | `build_invite_url`, `build_oauth_client_metadata`, `build_jwt_for_user`. Pure function-y. |
+| Entropy / cryptographic       | `_generate_*` (private)      | `_generate_token` — anything that calls `secrets.token_*` or pulls randomness.            |
+| DB lookup + hydrate (factory) | `resolve(...)` (classmethod) | `ResolvedAgent.resolve(agent_id, db, user_id)`, `Toolset.resolve(...)`                    |
+| Orchestrate multiple resolves | `build(...)` (classmethod)   | `Agent.build(thread, db)` — composes multiple `resolve` calls + middleware/callbacks      |
 
 **Reserved — do not use**: `make_*`, `_issue_*` (use `build_*`), `new_*`, `from_*` (use `resolve` / `build`; future `from_spec(dict)` is allowed as a deliberate exception).
 
@@ -178,10 +178,10 @@ A router never instantiates a repository directly; only services do.
 
 Because agents have a persistent-store side and a runtime-execution side, two classes exist:
 
-| Class | What it holds | Methods | Typical caller |
-| --- | --- | --- | --- |
-| `ResolvedAgent` (in `app/agents/runtime.py`) | `config: AgentResponse` + `toolset: Toolset` | `.resolve(...)` (classmethod factory), `.compile(model)` | Internal: subagent compilation, `Agent.build()` |
-| `Agent` (in `app/agents/runtime.py`) | `thread`, `model`, `middleware`, `callbacks`, the resolved parent agent, `list[ResolvedAgent]` subagents | `.build(thread, db)` (classmethod factory), `.invoke(...)`, `.stream(...)` | Public: routers, integrations |
+| Class                                        | What it holds                                                                                            | Methods                                                                    | Typical caller                                  |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------- |
+| `ResolvedAgent` (in `app/agents/runtime.py`) | `config: AgentResponse` + `toolset: Toolset`                                                             | `.resolve(...)` (classmethod factory), `.compile(model)`                   | Internal: subagent compilation, `Agent.build()` |
+| `Agent` (in `app/agents/runtime.py`)         | `thread`, `model`, `middleware`, `callbacks`, the resolved parent agent, `list[ResolvedAgent]` subagents | `.build(thread, db)` (classmethod factory), `.invoke(...)`, `.stream(...)` | Public: routers, integrations                   |
 
 Public API reads:
 
@@ -210,7 +210,7 @@ Do not introduce `from_*` factory names unless you're deliberately exposing a Py
 
 - **Default**: `{entity}_id` (`user_id`, `agent_id`, `mcp_server_id`, `thread_id`).
 - **Semantic noun role**: `{role}_id` (`owner_id`, `supervisor_id`, `subagent_id`).
-- **Verb-form (past participle) role**: no suffix (`created_by`, `invited_by`). This is the *only* time an FK column doesn't end in `_id`.
+- **Verb-form (past participle) role**: no suffix (`created_by`, `invited_by`). This is the _only_ time an FK column doesn't end in `_id`.
 
 Rule of thumb: ask "is the column a noun describing the relationship, or a past-tense verb describing how the row came to be?" Nouns get `_id`; verbs don't.
 
@@ -262,19 +262,19 @@ Column name is the plural of the contents (`tools` for a list of tool descriptor
 
 ### Path parameters
 
-Always prefixed (see §4): `{user_id}`, `{agent_id}`, `{server_id}`. Consistency *within a single router* is mandatory.
+Always prefixed (see §4): `{user_id}`, `{agent_id}`, `{server_id}`. Consistency _within a single router_ is mandatory.
 
 ### Verbs in paths
 
 Allowed only when CRUD doesn't fit. When allowed, the verb segment is kebab-case:
 
-| When allowed | Examples |
-| --- | --- |
-| State transition that isn't a PATCH | `POST /agents/{agent_id}/mcp-servers/{server_id}/sync-tools` |
-| Non-idempotent action | `POST /mcp-servers/{server_id}/reset`, `POST /invites/accept` |
-| Streaming / RPC | `POST /threads/{thread_id}/runs/stream`, `POST /threads/{thread_id}/runs/invoke` |
-| Predicate (mirrors an `is_*` helper) | `GET /agents/{agent_id}/is-ready`, `GET /mcp-servers/{server_id}/is-connected` |
-| Auth-flow verbs at root | `POST /auth/signin`, `POST /auth/signout`, `POST /auth/setup` |
+| When allowed                         | Examples                                                                         |
+| ------------------------------------ | -------------------------------------------------------------------------------- |
+| State transition that isn't a PATCH  | `POST /agents/{agent_id}/mcp-servers/{server_id}/sync-tools`                     |
+| Non-idempotent action                | `POST /mcp-servers/{server_id}/reset`, `POST /invites/accept`                    |
+| Streaming / RPC                      | `POST /threads/{thread_id}/runs/stream`, `POST /threads/{thread_id}/runs/invoke` |
+| Predicate (mirrors an `is_*` helper) | `GET /agents/{agent_id}/is-ready`, `GET /mcp-servers/{server_id}/is-connected`   |
+| Auth-flow verbs at root              | `POST /auth/signin`, `POST /auth/signout`, `POST /auth/setup`                    |
 
 Otherwise, stick to CRUD on the resource.
 
@@ -317,10 +317,10 @@ Trailing slashes match what's already in the router. If the router defines `POST
 
 Two acceptable styles, chosen by what's in the file:
 
-| Style | When | Examples |
-| --- | --- | --- |
-| **Verb / abstract noun** | The file is a collection of pure helper functions on a topic | `serialization.py`, `encryption.py`, `connectivity.py` |
-| **Concrete noun** (often a class name in lowercase) | The file is centered on one class | `toolset.py` (`Toolset`), `runtime.py` (`Agent`, `ResolvedAgent`), `factory.py` (`*Factory`), `repository.py`, `service.py`, `router.py`, `models.py`, `schemas.py` |
+| Style                                               | When                                                         | Examples                                                                                                                                                            |
+| --------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Verb / abstract noun**                            | The file is a collection of pure helper functions on a topic | `serialization.py`, `encryption.py`, `connectivity.py`                                                                                                              |
+| **Concrete noun** (often a class name in lowercase) | The file is centered on one class                            | `toolset.py` (`Toolset`), `runtime.py` (`Agent`, `ResolvedAgent`), `factory.py` (`*Factory`), `repository.py`, `service.py`, `router.py`, `models.py`, `schemas.py` |
 
 Don't create `utils.py` catch-alls. If a helper has a topic, name the file after the topic.
 
@@ -337,17 +337,17 @@ All domain exceptions:
 
 Current map:
 
-| Exception | HTTP status |
-| --- | --- |
-| `NotFoundError` | 404 |
-| `AlreadyExistsError` | 400 |
-| `DomainValidationError` | 400 |
-| `PermissionDeniedError` | 403 |
-| `InvalidCredentialsError` | 401 |
-| `NoInviteError` | 302 (special — redirect in the OAuth callback router) |
-| `DomainError` (base) | 500 |
+| Exception                 | HTTP status                                           |
+| ------------------------- | ----------------------------------------------------- |
+| `NotFoundError`           | 404                                                   |
+| `AlreadyExistsError`      | 400                                                   |
+| `DomainValidationError`   | 400                                                   |
+| `PermissionDeniedError`   | 403                                                   |
+| `InvalidCredentialsError` | 401                                                   |
+| `NoInviteError`           | 302 (special — redirect in the OAuth callback router) |
+| `DomainError` (base)      | 500                                                   |
 
-`DomainValidationError` — not `ValidationError`. Pydantic's `ValidationError` exists for *parse-time* failures at the HTTP boundary; ours is for *business-rule* violations inside services. The `Domain` prefix removes the import-time ambiguity.
+`DomainValidationError` — not `ValidationError`. Pydantic's `ValidationError` exists for _parse-time_ failures at the HTTP boundary; ours is for _business-rule_ violations inside services. The `Domain` prefix removes the import-time ambiguity.
 
 Routers never catch domain exceptions — the global handler does the HTTP translation. The only acceptable router-level `try/except` is when a different HTTP shape is needed (e.g. the OAuth callback catching `NoInviteError` to emit a 302 redirect).
 
@@ -357,30 +357,30 @@ Routers never catch domain exceptions — the global handler does the HTTP trans
 
 A "don't" list, with the corrected version:
 
-| Don't | Do |
-| --- | --- |
-| `def get_users(...)` returning a list | `def list(...)` (and on the repo, `list_*`) |
-| `def get_for_agent(...)` returning a list | `def list_for_agent(...)` |
-| `def load_subagents(...)` | `def list_subagents(...)` |
-| `def validate_invite(token)` returning the invite | `def get_by_token(token)` + `is_*` / `_ensure_*` if needed |
-| `def resolve_token(plaintext)` (in PAT) | `def get_by_token(plaintext)` |
-| `def get_user_by_email(...)` on `UserService` | `def get_by_email(...)` |
-| `def save_api_key(...)` (silent upsert) | `def create_or_update_api_key(...)` |
-| `def check_ready(...)` returning a dict | `def describe_readiness(...)` (or `is_ready` if bool) |
-| `def check_connectivity(...)` | `def probe_connectivity(...)` |
-| `def _require_server(...)` | `def _ensure_server(...)` |
-| `def _issue_token(user)` | `def build_jwt_for_user(user)` |
-| `sandbox: bool` column | `is_sandboxed: bool` |
-| `hashed_password: str` column | `password_hash: str` |
-| `coordinator_id` FK | `supervisor_id` |
-| `PermissionLevel.user` | `PermissionLevel.member` |
-| `ValidationError` (custom) | `DomainValidationError` |
-| `class Agent` for the runtime dataclass + `class AgentRuntime` for the runner | `class ResolvedAgent` + `class Agent` (runner) |
-| `{mcp_server_id}` and `{server_id}` in the same router | `{server_id}` consistently |
-| Handler `create_invite_endpoint(...)` | Handler `create_invite(...)` |
-| Handler `get_user_by_email_route(...)` | Handler `get_user_by_email(...)` |
-| `_endpoint` / `_route` suffix on any handler | No suffix |
-| `utils.py` catch-all module | Topic-named file (`encryption.py`, `serialization.py`, …) |
+| Don't                                                                         | Do                                                         |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `def get_users(...)` returning a list                                         | `def list(...)` (and on the repo, `list_*`)                |
+| `def get_for_agent(...)` returning a list                                     | `def list_for_agent(...)`                                  |
+| `def load_subagents(...)`                                                     | `def list_subagents(...)`                                  |
+| `def validate_invite(token)` returning the invite                             | `def get_by_token(token)` + `is_*` / `_ensure_*` if needed |
+| `def resolve_token(plaintext)` (in PAT)                                       | `def get_by_token(plaintext)`                              |
+| `def get_user_by_email(...)` on `UserService`                                 | `def get_by_email(...)`                                    |
+| `def save_api_key(...)` (silent upsert)                                       | `def create_or_update_api_key(...)`                        |
+| `def check_ready(...)` returning a dict                                       | `def describe_readiness(...)` (or `is_ready` if bool)      |
+| `def check_connectivity(...)`                                                 | `def probe_connectivity(...)`                              |
+| `def _require_server(...)`                                                    | `def _ensure_server(...)`                                  |
+| `def _issue_token(user)`                                                      | `def build_jwt_for_user(user)`                             |
+| `sandbox: bool` column                                                        | `is_sandboxed: bool`                                       |
+| `hashed_password: str` column                                                 | `password_hash: str`                                       |
+| `coordinator_id` FK                                                           | `supervisor_id`                                            |
+| `PermissionLevel.user`                                                        | `PermissionLevel.member`                                   |
+| `ValidationError` (custom)                                                    | `DomainValidationError`                                    |
+| `class Agent` for the runtime dataclass + `class AgentRuntime` for the runner | `class ResolvedAgent` + `class Agent` (runner)             |
+| `{mcp_server_id}` and `{server_id}` in the same router                        | `{server_id}` consistently                                 |
+| Handler `create_invite_endpoint(...)`                                         | Handler `create_invite(...)`                               |
+| Handler `get_user_by_email_route(...)`                                        | Handler `get_user_by_email(...)`                           |
+| `_endpoint` / `_route` suffix on any handler                                  | No suffix                                                  |
+| `utils.py` catch-all module                                                   | Topic-named file (`encryption.py`, `serialization.py`, …)  |
 
 ---
 

--- a/backend/alembic/versions/b1c2d3e4f5a6_rename_users_hashed_password.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_rename_users_hashed_password.py
@@ -1,0 +1,25 @@
+"""rename users.hashed_password to password_hash
+
+Revision ID: b1c2d3e4f5a6
+Revises: c9a4f1d83b27
+Create Date: 2026-05-22 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1c2d3e4f5a6'
+down_revision: Union[str, Sequence[str], None] = 'c9a4f1d83b27'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('users', 'hashed_password', new_column_name='password_hash')
+
+
+def downgrade() -> None:
+    op.alter_column('users', 'password_hash', new_column_name='hashed_password')

--- a/backend/alembic/versions/c2d3e4f5a6b7_rename_agents_sandbox_to_has_code_interpreter.py
+++ b/backend/alembic/versions/c2d3e4f5a6b7_rename_agents_sandbox_to_has_code_interpreter.py
@@ -1,0 +1,25 @@
+"""rename agents.sandbox to has_code_interpreter
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-05-22 10:01:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c2d3e4f5a6b7'
+down_revision: Union[str, Sequence[str], None] = 'b1c2d3e4f5a6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column('agents', 'sandbox', new_column_name='has_code_interpreter')
+
+
+def downgrade() -> None:
+    op.alter_column('agents', 'has_code_interpreter', new_column_name='sandbox')

--- a/backend/alembic/versions/d3e4f5a6b7c8_rename_subagent_coordinator_to_supervisor.py
+++ b/backend/alembic/versions/d3e4f5a6b7c8_rename_subagent_coordinator_to_supervisor.py
@@ -1,0 +1,45 @@
+"""rename agent_subagents.coordinator_id to supervisor_id
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-05-22 10:02:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd3e4f5a6b7c8'
+down_revision: Union[str, Sequence[str], None] = 'c2d3e4f5a6b7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'agent_subagents', 'coordinator_id', new_column_name='supervisor_id'
+    )
+    op.execute(
+        'ALTER INDEX ix_agent_subagents_coordinator_id '
+        'RENAME TO ix_agent_subagents_supervisor_id'
+    )
+    op.execute(
+        'ALTER INDEX ix_agent_subagents_coordinator_subagent '
+        'RENAME TO ix_agent_subagents_supervisor_subagent'
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        'ALTER INDEX ix_agent_subagents_supervisor_subagent '
+        'RENAME TO ix_agent_subagents_coordinator_subagent'
+    )
+    op.execute(
+        'ALTER INDEX ix_agent_subagents_supervisor_id '
+        'RENAME TO ix_agent_subagents_coordinator_id'
+    )
+    op.alter_column(
+        'agent_subagents', 'supervisor_id', new_column_name='coordinator_id'
+    )

--- a/backend/alembic/versions/e4f5a6b7c8d9_rename_permission_user_to_member.py
+++ b/backend/alembic/versions/e4f5a6b7c8d9_rename_permission_user_to_member.py
@@ -1,0 +1,27 @@
+"""rename PermissionLevel enum value 'user' to 'member'
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-05-22 10:03:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e4f5a6b7c8d9'
+down_revision: Union[str, Sequence[str], None] = 'd3e4f5a6b7c8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Postgres 10+ supports renaming an enum value in place; existing rows
+    # referencing the old value are updated automatically.
+    op.execute("ALTER TYPE permissionlevel RENAME VALUE 'user' TO 'member'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE permissionlevel RENAME VALUE 'member' TO 'user'")

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
 from uuid import UUID
@@ -22,7 +24,7 @@ from app.agents.subagents.service import SubagentService
 from app.database import get_db
 from app.exceptions import NotFoundError, PermissionDeniedError
 from app.mcp.servers.models import MCPServerDB
-from app.mcp.utils import check_mcp_server_connected
+from app.mcp.utils import probe_mcp_server
 from app.service import BaseService
 from app.users.models import WorkspaceRole
 
@@ -62,7 +64,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         (
             subagents_map,
             is_subagent_ids,
-        ) = await self.subagent_service.load_all_subagent_data(agent_ids)
+        ) = await self.subagent_service.list_all_subagent_data(agent_ids)
         return [
             AgentResponse(
                 **agent.model_dump(),
@@ -100,10 +102,10 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                     permissions_map[agent.id] = permission.value
         return agents_map, mcp_map, permissions_map
 
-    async def create_agent(self, data: AgentCreateDB) -> AgentDB:
+    async def create(self, data: AgentCreateDB) -> AgentDB:
         return await self.repository.create(data)
 
-    async def get_agent(
+    async def get(
         self,
         agent_id: UUID,
         user_id: UUID | None = None,
@@ -129,7 +131,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         )
         return responses[0]
 
-    async def list_agents(
+    async def list(
         self,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
@@ -146,21 +148,21 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             user_role,
         )
 
-    async def update_agent(
+    async def update(
         self,
         agent_id: UUID,
         data: AgentPatch,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
     ) -> AgentResponse:
-        existing = await self.get_agent(agent_id, user_id=user_id, user_role=user_role)
+        existing = await self.get(agent_id, user_id=user_id, user_role=user_role)
         if existing.current_user_permission not in ("owner", "admin", "editor"):
             raise PermissionDeniedError("Not authorized to edit this agent")
         agent = await self.get_or_404(agent_id)
         await self.repository.update(agent, data)
-        return await self.get_agent(agent_id, user_id=user_id, user_role=user_role)
+        return await self.get(agent_id, user_id=user_id, user_role=user_role)
 
-    async def delete_agent(
+    async def delete(
         self,
         agent_id: UUID,
         user_id: UUID | None = None,
@@ -180,8 +182,8 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     ) -> list[AgentUserPermissionDB]:
         return await self.repository.set_permissions(agent_id, permissions)
 
-    async def check_ready(self, agent_id: UUID, user_id: str) -> dict:
-        agent = await self.get_agent(agent_id, include_archived=True)
+    async def describe_readiness(self, agent_id: UUID, user_id: str) -> dict:
+        agent = await self.get(agent_id, include_archived=True)
 
         if not agent.mcp_servers:
             return {"ready": True, "disconnected_servers": [], "status": "ready"}
@@ -202,7 +204,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
 
         disconnected: list[str] = []
         for server in servers:
-            if not await check_mcp_server_connected(server, user_id):
+            if not await probe_mcp_server(server, user_id):
                 disconnected.append(str(server.id))
 
         return {

--- a/backend/app/agents/mcp_servers/service.py
+++ b/backend/app/agents/mcp_servers/service.py
@@ -9,7 +9,7 @@ from app.agents.models import AgentMCPServerBase, AgentMCPServerDB
 from app.agents.schemas import AgentMCPServerCreate, AgentMCPServerPatch
 from app.database import get_db
 from app.exceptions import NotFoundError
-from app.mcp.client.connectivity import check_oauth_connected
+from app.mcp.client.connectivity import is_oauth_connected
 from app.mcp.servers.models import MCPAuthType, MCPServerDB
 from app.mcp.servers.repository import MCPServerRepository
 from app.mcp.servers.service import connect_to_server
@@ -28,13 +28,13 @@ class AgentMCPServerService(
         super().__init__(db, AgentMCPServerRepository(db))
         self._servers = MCPServerRepository(db)
 
-    async def _require_server(self, server_id: UUID) -> MCPServerDB:
+    async def _ensure_server(self, server_id: UUID) -> MCPServerDB:
         server = await self._servers.get(server_id)
         if not server:
             raise NotFoundError("MCP server not found")
         return server
 
-    async def _fetch_and_save_tools(
+    async def _sync_tools(
         self,
         db_link: AgentMCPServerDB,
         mcp_server: MCPServerDB,
@@ -56,7 +56,7 @@ class AgentMCPServerService(
         data: AgentMCPServerCreate,
         user_id: str,
     ) -> AgentMCPServerDB:
-        mcp_server = await self._require_server(server_id)
+        mcp_server = await self._ensure_server(server_id)
 
         existing = await self.repository.get(agent_id, server_id)
         if existing:
@@ -80,10 +80,10 @@ class AgentMCPServerService(
             MCPAuthType.api_key,
         ) or (
             mcp_server.auth_type == MCPAuthType.oauth2
-            and await check_oauth_connected(mcp_server, user_id)
+            and await is_oauth_connected(mcp_server, user_id)
         )
         if should_fetch:
-            await self._fetch_and_save_tools(db_link, mcp_server, user_id)
+            await self._sync_tools(db_link, mcp_server, user_id)
 
         return db_link
 
@@ -109,11 +109,11 @@ class AgentMCPServerService(
     async def sync_tools(
         self, agent_id: UUID, server_id: UUID, user_id: str
     ) -> AgentMCPServerDB:
-        mcp_server = await self._require_server(server_id)
+        mcp_server = await self._ensure_server(server_id)
         link = await self.repository.get(agent_id, server_id)
         if not link:
             raise NotFoundError(self.not_found_message)
-        await self._fetch_and_save_tools(link, mcp_server, user_id)
+        await self._sync_tools(link, mcp_server, user_id)
         return link
 
 

--- a/backend/app/agents/models.py
+++ b/backend/app/agents/models.py
@@ -20,7 +20,7 @@ ALLOWED_COLORS = {
 
 
 class PermissionLevel(str, Enum):
-    user = "user"
+    member = "member"
     editor = "editor"
     admin = "admin"
 
@@ -61,7 +61,7 @@ class AgentDB(AgentBase, BaseDBModel, table=True):
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
-    sandbox: bool = Field(
+    has_code_interpreter: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
@@ -82,11 +82,11 @@ class AgentSubagentDB(BaseDBModel, table=True):
     __tablename__ = "agent_subagents"
     __table_args__ = (
         UniqueConstraint(
-            "coordinator_id",
+            "supervisor_id",
             "subagent_id",
             name="uq_agent_subagent",
         ),
     )
 
-    coordinator_id: UUID = Field(foreign_key="agents.id", nullable=False)
+    supervisor_id: UUID = Field(foreign_key="agents.id", nullable=False)
     subagent_id: UUID = Field(foreign_key="agents.id", nullable=False)

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -40,7 +40,7 @@ async def create_agent(
     current_user: UserDB = Depends(require_editor),
     service: AgentService = Depends(get_agent_service),
 ) -> AgentResponse:
-    return await service.create_agent(
+    return await service.create(
         AgentCreateDB(**data.model_dump(), owner_id=current_user.id)
     )
 
@@ -50,7 +50,7 @@ async def get_agents(
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> list[AgentResponse]:
-    return await service.list_agents(
+    return await service.list(
         user_id=current_user.id, user_role=current_user.role
     )
 
@@ -61,7 +61,7 @@ async def get_agent(
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> AgentResponse:
-    return await service.get_agent(
+    return await service.get(
         agent_id,
         user_id=current_user.id,
         user_role=current_user.role,
@@ -75,7 +75,7 @@ async def update_agent(
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> AgentResponse:
-    return await service.update_agent(
+    return await service.update(
         agent_id, agent_update, user_id=current_user.id, user_role=current_user.role
     )
 
@@ -86,7 +86,7 @@ async def delete_agent(
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> None:
-    await service.delete_agent(
+    await service.delete(
         agent_id, user_id=current_user.id, user_role=current_user.role
     )
 
@@ -174,7 +174,7 @@ async def create_subagent(
     _: UserDB = Depends(require_admin),
     service: SubagentService = Depends(get_subagent_service),
 ) -> AgentSubagentResponse:
-    return await service.create(agent_id, subagent_id)
+    return await service.create_or_update(agent_id, subagent_id)
 
 
 @router.delete("/{agent_id}/subagents/{subagent_id}", status_code=204)
@@ -193,7 +193,7 @@ async def is_ready(
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ):
-    return await service.check_ready(agent_id, str(current_user.id))
+    return await service.describe_readiness(agent_id, str(current_user.id))
 
 
 @router.get("/{agent_id}/threads", response_model=list[AgentThreadResponse])
@@ -205,9 +205,9 @@ async def list_agent_threads(
 ) -> list[AgentThreadResponse]:
     """List all threads for an agent across users. Restricted to agent owners
     and admins (workspace or agent-level)."""
-    agent = await agent_service.get_agent(
+    agent = await agent_service.get(
         agent_id, user_id=current_user.id, user_role=current_user.role
     )
     if agent.current_user_permission not in ("owner", "admin"):
         raise PermissionDeniedError("Not authorized to view this agent's threads")
-    return await thread_service.list_threads_for_agent(agent_id)
+    return await thread_service.list_for_agent(agent_id)

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -34,7 +34,7 @@ from app.agents.stream import (
 from app.agents.tool_errors import ToolErrorMiddleware
 from app.agents.toolset import Toolset, sanitize_tool_name
 from app.database import get_checkpointer
-from app.exceptions import ValidationError
+from app.exceptions import DomainValidationError
 from app.integrations.langfuse.callback import langfuse_callback_handler
 from app.model_providers.catalog import LLM_PROVIDERS, MODELS, ChatModelFactory
 from app.sandbox.settings import sandbox_settings
@@ -66,7 +66,7 @@ async def get_regeneration_checkpoint_id(agent, config: dict) -> str | None:
 
 
 @dataclass
-class Agent:
+class ResolvedAgent:
     """An agent config with its resolved toolset. Used for both parent and subagents."""
 
     config: AgentResponse
@@ -80,8 +80,8 @@ class Agent:
         user_id: str,
         *,
         is_parent: bool = False,
-    ) -> "Agent":
-        config = await AgentService(db).get_agent(agent_id, include_archived=True)
+    ) -> "ResolvedAgent":
+        config = await AgentService(db).get(agent_id, include_archived=True)
         toolset = await Toolset.resolve(config.mcp_servers, db, user_id)
         if is_parent:
             toolset.apply_ui_metadata()
@@ -94,7 +94,7 @@ class Agent:
         runnables don't inherit the parent's checkpointer, and HumanInTheLoopMiddleware
         needs one. Approval gates on subagent tools are silently dropped today.
         """
-        if self.config.sandbox and sandbox_settings.enabled:
+        if self.config.has_code_interpreter and sandbox_settings.enabled:
             from app.sandbox.lazy import LazySandboxBackend
             from app.sandbox.tools import create_sandbox_tools
 
@@ -125,15 +125,15 @@ class Agent:
         )
 
 
-class AgentRuntime:
+class Agent:
     def __init__(
         self,
         thread: ThreadDB,
-        agent: Agent,
+        agent: ResolvedAgent,
         model,
         middleware: list,
         callbacks: list,
-        subagents: list[Agent],
+        subagents: list[ResolvedAgent],
     ):
         self.thread = thread
         self.agent = agent
@@ -164,19 +164,19 @@ class AgentRuntime:
         cls,
         thread: ThreadDB,
         db: AsyncSession,
-    ) -> "AgentRuntime":
+    ) -> "Agent":
         user_id = str(thread.user_id)
 
-        agent = await Agent.resolve(thread.agent_id, db, user_id, is_parent=True)
+        agent = await ResolvedAgent.resolve(thread.agent_id, db, user_id, is_parent=True)
 
         model_entry = next((m for m in MODELS if m.name == thread.model_id), None)
         if model_entry is None:
-            raise ValidationError(f"Unknown model: {thread.model_id}")
+            raise DomainValidationError(f"Unknown model: {thread.model_id}")
         provider = next(
             (p for p in LLM_PROVIDERS if p.name == model_entry.provider), None
         )
         if provider is None:
-            raise ValidationError(
+            raise DomainValidationError(
                 f"Unknown provider {model_entry.provider!r} for model {thread.model_id}"
             )
         model = ChatModelFactory().create(
@@ -197,10 +197,10 @@ class AgentRuntime:
             )
         ]
 
-        subagents: list[Agent] = []
+        subagents: list[ResolvedAgent] = []
         if agent.config.subagents:
             for sub in agent.config.subagents:
-                subagents.append(await Agent.resolve(sub.id, db, user_id))
+                subagents.append(await ResolvedAgent.resolve(sub.id, db, user_id))
 
         callbacks = (
             [langfuse_callback_handler] if langfuse_callback_handler is not None else []
@@ -217,7 +217,7 @@ class AgentRuntime:
 
     def _build_agent(self, checkpointer):
         """Build the LangGraph agent (deep or standard) with the given checkpointer."""
-        if self.agent.config.sandbox and sandbox_settings.enabled:
+        if self.agent.config.has_code_interpreter and sandbox_settings.enabled:
             return self._build_deep_agent(checkpointer)
 
         middleware = list(self.middleware)

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -17,7 +17,7 @@ class AgentCreate(SQLModel):
     instructions: str
     emoji: str | None = None
     color: str | None = None
-    sandbox: bool = False
+    has_code_interpreter: bool = False
 
     @field_validator("color")
     @classmethod
@@ -33,7 +33,7 @@ class AgentCreateDB(SQLModel):
     owner_id: UUID
     emoji: str | None = None
     color: str | None = None
-    sandbox: bool = False
+    has_code_interpreter: bool = False
 
     @field_validator("color")
     @classmethod
@@ -49,7 +49,7 @@ class AgentPatch(SQLModel):
     emoji: str | None = None
     color: str | None = None
     description: str | None = None
-    sandbox: bool | None = None
+    has_code_interpreter: bool | None = None
 
     @field_validator("color")
     @classmethod
@@ -85,7 +85,7 @@ class AgentPermissionCreate(SQLModel):
 
 class AgentSubagentResponse(SQLModel):
     id: UUID
-    coordinator_id: UUID
+    supervisor_id: UUID
     subagent_id: UUID
     created_at: datetime
     updated_at: datetime
@@ -107,7 +107,7 @@ class AgentResponse(SQLModel):
     emoji: str | None
     color: str | None
     description: str | None
-    sandbox: bool
+    has_code_interpreter: bool
     created_at: datetime
     updated_at: datetime
     mcp_servers: list[AgentMCPServerResponse] | None = None

--- a/backend/app/agents/subagents/repository.py
+++ b/backend/app/agents/subagents/repository.py
@@ -12,25 +12,25 @@ class SubagentRepository:
         self.db = db
 
     async def get(
-        self, coordinator_id: UUID, subagent_id: UUID
+        self, supervisor_id: UUID, subagent_id: UUID
     ) -> AgentSubagentDB | None:
         stmt = select(AgentSubagentDB).where(
-            AgentSubagentDB.coordinator_id == coordinator_id,
+            AgentSubagentDB.supervisor_id == supervisor_id,
             AgentSubagentDB.subagent_id == subagent_id,
         )
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def get_for_coordinator(
-        self, coordinator_id: UUID
+    async def list_for_supervisor(
+        self, supervisor_id: UUID
     ) -> list[AgentSubagentDB]:
         stmt = select(AgentSubagentDB).where(
-            AgentSubagentDB.coordinator_id == coordinator_id
+            AgentSubagentDB.supervisor_id == supervisor_id
         )
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 
-    async def get_coordinator(
+    async def get_supervisor(
         self, subagent_id: UUID
     ) -> AgentSubagentDB | None:
         stmt = (
@@ -44,7 +44,7 @@ class SubagentRepository:
     async def has_subagents(self, agent_id: UUID) -> bool:
         stmt = (
             select(AgentSubagentDB.id)
-            .where(AgentSubagentDB.coordinator_id == agent_id)
+            .where(AgentSubagentDB.supervisor_id == agent_id)
             .limit(1)
         )
         result = await self.db.execute(stmt)
@@ -59,11 +59,14 @@ class SubagentRepository:
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none() is not None
 
-    async def create(
-        self, coordinator_id: UUID, subagent_id: UUID
+    async def create_or_update(
+        self, supervisor_id: UUID, subagent_id: UUID
     ) -> AgentSubagentDB:
+        existing = await self.get(supervisor_id, subagent_id)
+        if existing:
+            return existing
         link = AgentSubagentDB(
-            coordinator_id=coordinator_id,
+            supervisor_id=supervisor_id,
             subagent_id=subagent_id,
         )
         self.db.add(link)
@@ -78,7 +81,7 @@ class SubagentRepository:
     async def delete_all_for_agent(self, agent_id: UUID) -> None:
         stmt = select(AgentSubagentDB).where(
             or_(
-                AgentSubagentDB.coordinator_id == agent_id,
+                AgentSubagentDB.supervisor_id == agent_id,
                 AgentSubagentDB.subagent_id == agent_id,
             )
         )

--- a/backend/app/agents/subagents/service.py
+++ b/backend/app/agents/subagents/service.py
@@ -9,7 +9,7 @@ from app.agents.models import AgentDB, AgentSubagentDB
 from app.agents.schemas import SubagentResponse
 from app.agents.subagents.repository import SubagentRepository
 from app.database import get_db
-from app.exceptions import NotFoundError, ValidationError
+from app.exceptions import DomainValidationError, NotFoundError
 
 
 def _to_response(agent: AgentDB) -> SubagentResponse:
@@ -26,19 +26,19 @@ class SubagentService:
         self.db = db
         self.repository = SubagentRepository(db)
 
-    async def _load_agents(self, ids: list[UUID]) -> dict[UUID, AgentDB]:
+    async def _list_agents(self, ids: list[UUID]) -> dict[UUID, AgentDB]:
         if not ids:
             return {}
         result = await self.db.execute(select(AgentDB).where(AgentDB.id.in_(ids)))
         return {agent.id: agent for agent in result.scalars().all()}
 
-    async def load_subagents(self, agent_id: UUID) -> list[SubagentResponse]:
-        links = await self.repository.get_for_coordinator(agent_id)
+    async def list_subagents(self, agent_id: UUID) -> list[SubagentResponse]:
+        links = await self.repository.list_for_supervisor(agent_id)
         sub_ids = [b.subagent_id for b in links]
-        agents = await self._load_agents(sub_ids)
+        agents = await self._list_agents(sub_ids)
         return [_to_response(agents[sid]) for sid in sub_ids if sid in agents]
 
-    async def load_all_subagent_data(
+    async def list_all_subagent_data(
         self, agent_ids: list[UUID]
     ) -> tuple[dict[UUID, list[SubagentResponse]], set[UUID]]:
         if not agent_ids:
@@ -46,68 +46,64 @@ class SubagentService:
 
         result = await self.db.execute(
             select(AgentSubagentDB).where(
-                AgentSubagentDB.coordinator_id.in_(agent_ids)
+                AgentSubagentDB.supervisor_id.in_(agent_ids)
                 | AgentSubagentDB.subagent_id.in_(agent_ids)
             )
         )
         all_links = list(result.scalars().all())
 
-        referenced_ids = {b.coordinator_id for b in all_links} | {
+        referenced_ids = {b.supervisor_id for b in all_links} | {
             b.subagent_id for b in all_links
         }
-        agent_lookup = await self._load_agents(list(referenced_ids))
+        agent_lookup = await self._list_agents(list(referenced_ids))
 
         subagents_map: dict[UUID, list[SubagentResponse]] = defaultdict(list)
         is_subagent_ids: set[UUID] = set()
         agent_ids_set = set(agent_ids)
 
         for link in all_links:
-            if link.coordinator_id in agent_ids_set:
+            if link.supervisor_id in agent_ids_set:
                 sub = agent_lookup.get(link.subagent_id)
                 if sub:
-                    subagents_map[link.coordinator_id].append(_to_response(sub))
+                    subagents_map[link.supervisor_id].append(_to_response(sub))
             if link.subagent_id in agent_ids_set:
                 is_subagent_ids.add(link.subagent_id)
 
         return subagents_map, is_subagent_ids
 
-    async def create(
-        self, coordinator_id: UUID, subagent_id: UUID
+    async def create_or_update(
+        self, supervisor_id: UUID, subagent_id: UUID
     ) -> AgentSubagentDB:
-        if coordinator_id == subagent_id:
-            raise ValidationError("Cannot add an agent as its own subagent")
+        if supervisor_id == subagent_id:
+            raise DomainValidationError("Cannot add an agent as its own subagent")
 
         # Local import avoids AgentService → SubagentService circular import.
         from app.agents.core.repository import AgentRepository
 
         agent_repo = AgentRepository(self.db)
 
-        coordinator = await agent_repo.get(coordinator_id)
-        if not coordinator or coordinator.is_archived:
-            raise NotFoundError("Coordinator agent not found")
+        supervisor = await agent_repo.get(supervisor_id)
+        if not supervisor or supervisor.is_archived:
+            raise NotFoundError("Supervisor agent not found")
 
         subagent = await agent_repo.get(subagent_id)
         if not subagent or subagent.is_archived:
             raise NotFoundError("Subagent not found")
 
         if await self.repository.has_subagents(subagent_id):
-            raise ValidationError(
+            raise DomainValidationError(
                 "This agent already has subagents and cannot be used as a subagent"
             )
 
-        if await self.repository.is_subagent(coordinator_id):
-            raise ValidationError(
+        if await self.repository.is_subagent(supervisor_id):
+            raise DomainValidationError(
                 "This agent is already used as a subagent and cannot have subagents"
             )
 
-        existing = await self.repository.get(coordinator_id, subagent_id)
-        if existing:
-            return existing
+        return await self.repository.create_or_update(supervisor_id, subagent_id)
 
-        return await self.repository.create(coordinator_id, subagent_id)
-
-    async def delete(self, coordinator_id: UUID, subagent_id: UUID) -> None:
-        link = await self.repository.get(coordinator_id, subagent_id)
+    async def delete(self, supervisor_id: UUID, subagent_id: UUID) -> None:
+        link = await self.repository.get(supervisor_id, subagent_id)
         if not link:
             raise NotFoundError("Subagent not found")
         await self.repository.delete(link)

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -39,7 +39,7 @@ async def _resolve_from_bearer(
     """Resolve a Bearer token to a user — supports PATs and JWTs."""
     if token.startswith(TOKEN_PREFIX):
         repo = PersonalAccessTokenRepository(db)
-        pat = await repo.resolve_token(token)
+        pat = await repo.get_by_token(token)
         if pat is None:
             return None
         return await _resolve_user_by_id(db, pat.user_id)

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -12,13 +12,9 @@ from app.auth.schemas import (
     SigninRequest,
     SignupRequest,
 )
-from app.auth.service import (
-    AuthService,
-    InvalidCredentialsError,
-    NoInviteError,
-    get_auth_service,
-)
+from app.auth.service import AuthService, get_auth_service
 from app.auth.settings import auth_settings
+from app.exceptions import NoInviteError
 from app.invites.service import InviteService, get_invite_service
 from app.users.models import UserDB
 from app.users.schemas import UserResponse
@@ -92,13 +88,7 @@ async def signin(
     signin_data: SigninRequest,
     service: AuthService = Depends(get_auth_service),
 ) -> JSONResponse:
-    try:
-        user, token = await service.signin(signin_data)
-    except InvalidCredentialsError as e:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=e.detail,
-        ) from e
+    user, token = await service.signin(signin_data)
     return _auth_response(user, token)
 
 
@@ -123,7 +113,7 @@ async def get_invite_info(
     token: str,
     service: InviteService = Depends(get_invite_service),
 ) -> InviteInfoResponse:
-    invite = await service.validate_invite(token)
+    invite = await service.get_by_token(token)
     if not invite:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -16,20 +16,14 @@ from app.database import get_db
 from app.exceptions import (
     AlreadyExistsError,
     DomainError,
+    DomainValidationError,
+    InvalidCredentialsError,
+    NoInviteError,
     PermissionDeniedError,
-    ValidationError,
 )
 from app.invites.models import InviteStatus
 from app.invites.service import InviteService
 from app.users.models import OAuthAccountDB, UserDB, WorkspaceRole
-
-
-class InvalidCredentialsError(DomainError):
-    """Signin failed (wrong email/password, or password auth disabled)."""
-
-
-class NoInviteError(DomainError):
-    """OAuth signup attempted with no matching invite."""
 
 
 class AuthService:
@@ -41,28 +35,29 @@ class AuthService:
         result = await self.db.execute(select(func.count()).select_from(UserDB))
         return result.scalar_one()
 
-    def _require_password_auth(self) -> None:
+    def _ensure_password_auth(self) -> None:
         if not auth_settings.password_enabled:
             raise PermissionDeniedError("Password authentication is disabled")
 
-    def _issue_token(self, user: UserDB) -> tuple[UserDB, str]:
+    def build_jwt_for_user(self, user: UserDB) -> tuple[UserDB, str]:
         return user, create_access_token(user.id)
 
-    async def _email_exists(self, email: str) -> bool:
+    async def _ensure_email_available(self, email: str) -> None:
         result = await self.db.execute(select(UserDB).where(UserDB.email == email))
-        return result.scalar_one_or_none() is not None
+        if result.scalar_one_or_none() is not None:
+            raise AlreadyExistsError("Email already registered")
 
     async def signin(self, data: SigninRequest) -> tuple[UserDB, str]:
-        self._require_password_auth()
+        self._ensure_password_auth()
         result = await self.db.execute(
             select(UserDB).where(UserDB.email == data.email)
         )
         user = result.scalar_one_or_none()
-        if user is None or user.hashed_password is None:
+        if user is None or user.password_hash is None:
             raise InvalidCredentialsError("Invalid email or password")
-        if not verify_password(data.password, user.hashed_password):
+        if not verify_password(data.password, user.password_hash):
             raise InvalidCredentialsError("Invalid email or password")
-        return self._issue_token(user)
+        return self.build_jwt_for_user(user)
 
     async def setup(self, data: SignupRequest) -> tuple[UserDB, str]:
         if await self.count_users() > 0:
@@ -70,26 +65,25 @@ class AuthService:
         user = UserDB(
             email=data.email,
             name=data.name,
-            hashed_password=get_password_hash(data.password),
+            password_hash=get_password_hash(data.password),
             role=WorkspaceRole.admin,
         )
         self.db.add(user)
         await self.db.flush()
         await self.db.refresh(user)
-        return self._issue_token(user)
+        return self.build_jwt_for_user(user)
 
     async def accept_invite(self, data: InviteAcceptRequest) -> tuple[UserDB, str]:
-        self._require_password_auth()
-        invite = await self.invites.validate_invite(data.token)
+        self._ensure_password_auth()
+        invite = await self.invites.get_by_token(data.token)
         if not invite:
-            raise ValidationError("Invalid or expired invite")
-        if await self._email_exists(invite.email):
-            raise AlreadyExistsError("Email already registered")
+            raise DomainValidationError("Invalid or expired invite")
+        await self._ensure_email_available(invite.email)
 
         user = UserDB(
             email=invite.email,
             name=data.name,
-            hashed_password=get_password_hash(data.password),
+            password_hash=get_password_hash(data.password),
             role=WorkspaceRole(invite.role),
         )
         self.db.add(user)
@@ -97,7 +91,7 @@ class AuthService:
         self.db.add(invite)
         await self.db.flush()
         await self.db.refresh(user)
-        return self._issue_token(user)
+        return self.build_jwt_for_user(user)
 
     async def google_signin_or_link(
         self,
@@ -130,7 +124,7 @@ class AuthService:
             user = result.scalar_one_or_none()
             if not user:
                 raise DomainError("Linked user not found")
-            return self._issue_token(user)
+            return self.build_jwt_for_user(user)
 
         result = await self.db.execute(select(UserDB).where(UserDB.email == email))
         user = result.scalar_one_or_none()
@@ -140,11 +134,11 @@ class AuthService:
                 provider="google", sub_id=google_sub, user_id=user.id,
             ))
             await self.db.flush()
-            return self._issue_token(user)
+            return self.build_jwt_for_user(user)
 
         invite = None
         if invite_token:
-            invite = await self.invites.validate_invite(invite_token)
+            invite = await self.invites.get_by_token(invite_token)
         if not invite:
             invite = await self.invites.get_pending_by_email(email)
         if not invite:
@@ -165,7 +159,7 @@ class AuthService:
         self.db.add(invite)
         await self.db.flush()
         await self.db.refresh(user)
-        return self._issue_token(user)
+        return self.build_jwt_for_user(user)
 
 
 def get_auth_service(db: AsyncSession = Depends(get_db)) -> AuthService:

--- a/backend/app/auth/tokens/repository.py
+++ b/backend/app/auth/tokens/repository.py
@@ -21,7 +21,7 @@ class PersonalAccessTokenRepository(BaseRepository[PersonalAccessTokenDB]):
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 
-    async def resolve_token(self, plaintext: str) -> PersonalAccessTokenDB | None:
+    async def get_by_token(self, plaintext: str) -> PersonalAccessTokenDB | None:
         """Find the PAT matching a plaintext token by prefix, then verify hash."""
         prefix = plaintext[:12]
         stmt = select(PersonalAccessTokenDB).where(

--- a/backend/app/auth/tokens/router.py
+++ b/backend/app/auth/tokens/router.py
@@ -21,7 +21,7 @@ async def create_token(
     current_user: UserDB = Depends(require_admin),
     service: PersonalAccessTokenService = Depends(get_pat_service),
 ) -> PersonalAccessTokenCreatedResponse:
-    pat, plaintext = await service.create_token(current_user.id, data.name)
+    pat, plaintext = await service.create(current_user.id, data.name)
     return PersonalAccessTokenCreatedResponse(
         id=pat.id,
         name=pat.name,
@@ -36,7 +36,7 @@ async def list_tokens(
     current_user: UserDB = Depends(require_admin),
     service: PersonalAccessTokenService = Depends(get_pat_service),
 ) -> list[PersonalAccessTokenResponse]:
-    pats = await service.list_tokens(current_user.id)
+    pats = await service.list(current_user.id)
     return [PersonalAccessTokenResponse.model_validate(pat) for pat in pats]
 
 
@@ -46,4 +46,4 @@ async def delete_token(
     current_user: UserDB = Depends(require_admin),
     service: PersonalAccessTokenService = Depends(get_pat_service),
 ) -> None:
-    await service.delete_token(token_id, current_user.id)
+    await service.delete(token_id, current_user.id)

--- a/backend/app/auth/tokens/service.py
+++ b/backend/app/auth/tokens/service.py
@@ -33,7 +33,7 @@ class PersonalAccessTokenService(
         token_hash = get_password_hash(plaintext)
         return plaintext, token_hash, prefix
 
-    async def create_token(
+    async def create(
         self, user_id: UUID, name: str
     ) -> tuple[PersonalAccessTokenDB, str]:
         plaintext, token_hash, prefix = self._generate_token()
@@ -46,17 +46,17 @@ class PersonalAccessTokenService(
         pat = await self.repository.create(data)
         return pat, plaintext
 
-    async def list_tokens(self, user_id: UUID) -> list[PersonalAccessTokenDB]:
+    async def list(self, user_id: UUID) -> list[PersonalAccessTokenDB]:
         return await self.repository.list_by_user(user_id)
 
-    async def delete_token(self, token_id: UUID, user_id: UUID) -> None:
+    async def delete(self, token_id: UUID, user_id: UUID) -> None:
         pat = await self.get_or_404(token_id)
         if pat.user_id != user_id:
             raise NotFoundError(self.not_found_message)
         await self.repository.delete(pat)
 
-    async def resolve_token(self, plaintext: str) -> PersonalAccessTokenDB | None:
-        return await self.repository.resolve_token(plaintext)
+    async def get_by_token(self, plaintext: str) -> PersonalAccessTokenDB | None:
+        return await self.repository.get_by_token(plaintext)
 
 
 def get_pat_service(db: AsyncSession = Depends(get_db)) -> PersonalAccessTokenService:

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -14,9 +14,17 @@ class AlreadyExistsError(DomainError):
     pass
 
 
-class ValidationError(DomainError):
-    pass
+class DomainValidationError(DomainError):
+    """Business-rule violation. Distinct from Pydantic's parse-time ValidationError."""
 
 
 class PermissionDeniedError(DomainError):
     pass
+
+
+class InvalidCredentialsError(DomainError):
+    """Signin failed (wrong email/password, or password auth disabled)."""
+
+
+class NoInviteError(DomainError):
+    """OAuth signup attempted with no matching invite."""

--- a/backend/app/integrations/slack/commands/chat.py
+++ b/backend/app/integrations/slack/commands/chat.py
@@ -8,7 +8,7 @@ from app.database import AsyncSessionLocal
 from app.integrations.slack.models import SlackInteractionPayload
 from app.integrations.slack.settings import slack_settings
 from app.integrations.slack.utils import get_user_info
-from app.threads.service import get_or_create_thread
+from app.threads.service import ThreadService
 from app.users.models import WorkspaceRole
 from app.users.repository import UserRepository
 
@@ -63,7 +63,7 @@ async def post_agent_picker(
     db: AsyncSession, user_id: str, user_role: WorkspaceRole | None = None,
 ) -> None:
     """Post an agent picker in the thread."""
-    all_agents = await AgentService(db).list_agents(user_id=user_id, user_role=user_role)
+    all_agents = await AgentService(db).list(user_id=user_id, user_role=user_role)
     agents = [a for a in all_agents if a.current_user_permission is not None]
     if not agents:
         return
@@ -121,12 +121,14 @@ async def handle_agent_selection(payload: SlackInteractionPayload) -> None:
     # Create the thread bound to this agent.
     # first_message_content is left None here; it will be set (and the Slack
     # thread title updated) when the user sends their first real message.
-    await get_or_create_thread(
-        ts=thread_ts,
-        agent_id=str(agent.id),
-        question=None,
-        user_id=str(user.id),
-    )
+    async with AsyncSessionLocal() as db:
+        await ThreadService(db).get_or_create(
+            ts=thread_ts,
+            agent_id=str(agent.id),
+            question=None,
+            user_id=str(user.id),
+        )
+        await db.commit()
 
     # Replace the picker message with a confirmation
     client = AsyncWebClient(token=slack_settings.slack_bot_token)

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.agents.core.service import AgentService
-from app.agents.runtime import AgentRuntime
+from app.agents.runtime import Agent
 from app.auth.settings import auth_settings
 from app.database import AsyncSessionLocal
 from app.integrations.slack.blocks import (
@@ -21,7 +21,7 @@ from app.integrations.slack.models import SlackEvent, SlackInteractionPayload
 from app.integrations.slack.settings import slack_settings
 from app.integrations.slack.utils import get_user_info, resolve_user
 from app.mcp.servers.models import MCPServerDB
-from app.mcp.utils import check_mcp_server_connected
+from app.mcp.utils import probe_mcp_server
 from app.threads.models import ThreadDB
 from app.users.repository import UserRepository
 
@@ -39,7 +39,7 @@ async def post_tool_approval_block(
 
 
 async def _stream_and_collect_approvals(
-    agent_runtime: AgentRuntime,
+    agent: Agent,
     streamer,
     *,
     agent_input: dict | None = None,
@@ -52,7 +52,7 @@ async def _stream_and_collect_approvals(
     """
     approval_requests: list[dict] = []
 
-    async for ev in agent_runtime.stream(
+    async for ev in agent.stream(
         agent_input=agent_input, command=command, stream_adapter="slack",
     ):
         if ev["type"] == "text":
@@ -95,9 +95,9 @@ async def _run_slack_turn(
         recipient_user_id=recipient_user_id,
     )
 
-    agent_runtime = await AgentRuntime.build(thread=thread, db=db)
+    agent = await Agent.build(thread=thread, db=db)
     approval_requests = await _stream_and_collect_approvals(
-        agent_runtime, streamer, agent_input=agent_input, command=command,
+        agent, streamer, agent_input=agent_input, command=command,
     )
 
     for req in approval_requests:
@@ -292,7 +292,7 @@ async def handle_assistant_thread_started(event: SlackEvent) -> None:
         return
 
     async with AsyncSessionLocal() as db:
-        all_agents = await AgentService(db).list_agents(user_id=user.id, user_role=user.role)
+        all_agents = await AgentService(db).list(user_id=user.id, user_role=user.role)
     agents = [a for a in all_agents if a.current_user_permission is not None]
 
     if not agents:
@@ -333,7 +333,7 @@ async def _is_agent_ready(agent_id: str, user_id: str, db: AsyncSession) -> bool
     """Mirror the /is-ready endpoint: return True only when all bound MCP servers
     are connected for this user."""
     from uuid import UUID
-    agent = await AgentService(db).get_agent(UUID(agent_id))
+    agent = await AgentService(db).get(UUID(agent_id))
 
     if not agent.mcp_servers:
         return True
@@ -347,7 +347,7 @@ async def _is_agent_ready(agent_id: str, user_id: str, db: AsyncSession) -> bool
     servers = result.scalars().all()
 
     for server in servers:
-        if not await check_mcp_server_connected(server, user_id):
+        if not await probe_mcp_server(server, user_id):
             return False
 
     return True

--- a/backend/app/invites/router.py
+++ b/backend/app/invites/router.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends
 
 from app.auth.dependencies import require_admin
 from app.exceptions import NotFoundError
-from app.invites.models import InviteDB
 from app.invites.schemas import InviteCreate, InviteResponse
 from app.invites.service import InviteService, get_invite_service
 from app.users.models import UserDB
@@ -13,38 +12,19 @@ from app.users.models import UserDB
 router = APIRouter(prefix="/invites", tags=["invites"])
 
 
-def _invite_to_read(
-    invite: InviteDB,
-    service: InviteService,
-    include_url: bool = False,
-    invited_by_name: str | None = None,
-) -> InviteResponse:
-    return InviteResponse(
-        id=invite.id,
-        email=invite.email,
-        role=invite.role,
-        status=invite.status.value,
-        invite_url=service.build_invite_url(invite.token) if include_url else None,
-        invited_by=invite.invited_by,
-        invited_by_name=invited_by_name,
-        expires_at=invite.expires_at,
-        created_at=invite.created_at,
-    )
-
-
 @router.post("/", response_model=InviteResponse, status_code=201)
-async def create_invite_endpoint(
+async def create_invite(
     data: InviteCreate,
     current_user: UserDB = Depends(require_admin),
     service: InviteService = Depends(get_invite_service),
 ) -> InviteResponse:
     """Create an invite for a new user. Admin only."""
-    invite = await service.create_invite(
+    invite = await service.create(
         email=data.email,
         role=data.role.value,
         invited_by=current_user.id,
     )
-    return _invite_to_read(invite, service, include_url=True)
+    return service._to_response(invite, include_url=True)
 
 
 @router.get("/", response_model=list[InviteResponse])
@@ -55,7 +35,7 @@ async def list_invites(
     """List pending invites. Admin only."""
     invites_with_inviters = await service.list_pending_with_inviters()
     return [
-        _invite_to_read(inv, service, include_url=True, invited_by_name=name)
+        service._to_response(inv, include_url=True, invited_by_name=name)
         for inv, name in invites_with_inviters
     ]
 

--- a/backend/app/invites/service.py
+++ b/backend/app/invites/service.py
@@ -11,6 +11,7 @@ from app.database import get_db
 from app.exceptions import AlreadyExistsError
 from app.invites.models import InviteCreateDB, InviteDB, InviteStatus
 from app.invites.repository import InviteRepository
+from app.invites.schemas import InviteResponse
 from app.service import BaseService
 from app.users.models import UserDB
 
@@ -24,6 +25,24 @@ class InviteService(BaseService[InviteDB, InviteRepository]):
     def build_invite_url(self, token: str) -> str:
         return f"{auth_settings.FRONTEND_URL}/invite/{token}"
 
+    def _to_response(
+        self,
+        invite: InviteDB,
+        include_url: bool = False,
+        invited_by_name: str | None = None,
+    ) -> InviteResponse:
+        return InviteResponse(
+            id=invite.id,
+            email=invite.email,
+            role=invite.role,
+            status=invite.status.value,
+            invite_url=self.build_invite_url(invite.token) if include_url else None,
+            invited_by=invite.invited_by,
+            invited_by_name=invited_by_name,
+            expires_at=invite.expires_at,
+            created_at=invite.created_at,
+        )
+
     @staticmethod
     def _is_usable(invite: InviteDB | None) -> bool:
         return (
@@ -32,7 +51,7 @@ class InviteService(BaseService[InviteDB, InviteRepository]):
             and invite.expires_at >= datetime.now(UTC)
         )
 
-    async def create_invite(self, email: str, role: str, invited_by: UUID) -> InviteDB:
+    async def create(self, email: str, role: str, invited_by: UUID) -> InviteDB:
         """Create a new invite, revoking any existing pending invite for the same email."""
         result = await self.db.execute(select(UserDB).where(UserDB.email == email))
         if result.scalar_one_or_none():
@@ -47,7 +66,7 @@ class InviteService(BaseService[InviteDB, InviteRepository]):
         )
         return await self.repository.create(data)
 
-    async def validate_invite(self, token: str) -> InviteDB | None:
+    async def get_by_token(self, token: str) -> InviteDB | None:
         invite = await self.repository.get_by_token(token)
         return invite if self._is_usable(invite) else None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,9 +15,10 @@ from app.auth.tokens.router import router as tokens_router
 from app.exceptions import (
     AlreadyExistsError,
     DomainError,
+    DomainValidationError,
+    InvalidCredentialsError,
     NotFoundError,
     PermissionDeniedError,
-    ValidationError,
 )
 from app.integrations.slack.router import router as slack_router
 from app.invites.router import router as invites_router
@@ -89,17 +90,26 @@ async def not_found_handler(_request: Request, exc: NotFoundError):
 
 @app.exception_handler(AlreadyExistsError)
 async def already_exists_handler(_request: Request, exc: AlreadyExistsError):
-    return JSONResponse(status_code=409, content={"detail": exc.detail})
+    return JSONResponse(status_code=400, content={"detail": exc.detail})
 
 
-@app.exception_handler(ValidationError)
-async def validation_error_handler(_request: Request, exc: ValidationError):
+@app.exception_handler(DomainValidationError)
+async def domain_validation_error_handler(
+    _request: Request, exc: DomainValidationError
+):
     return JSONResponse(status_code=400, content={"detail": exc.detail})
 
 
 @app.exception_handler(PermissionDeniedError)
 async def permission_denied_handler(_request: Request, exc: PermissionDeniedError):
     return JSONResponse(status_code=403, content={"detail": exc.detail})
+
+
+@app.exception_handler(InvalidCredentialsError)
+async def invalid_credentials_handler(
+    _request: Request, exc: InvalidCredentialsError
+):
+    return JSONResponse(status_code=401, content={"detail": exc.detail})
 
 
 @app.exception_handler(DomainError)

--- a/backend/app/mcp/apps/router.py
+++ b/backend/app/mcp/apps/router.py
@@ -1,14 +1,17 @@
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import SQLModel, select
+from sqlmodel import SQLModel
 
 from app.auth.dependencies import get_current_user
 from app.database import get_db
-from app.mcp.servers.models import MCPServerDB
-from app.mcp.servers.service import connect_to_server
+from app.mcp.servers.service import (
+    MCPServerService,
+    connect_to_server,
+    get_mcp_server_service,
+)
 from app.users.models import UserDB
 
 
@@ -24,22 +27,15 @@ class MCPAppCallToolRequest(SQLModel):
     arguments: dict[str, Any] | None = None
 
 
-async def get_server_or_404(server_id: UUID, db: AsyncSession) -> MCPServerDB:
-    result = await db.execute(select(MCPServerDB).where(MCPServerDB.id == server_id))
-    server = result.scalar_one_or_none()
-    if not server:
-        raise HTTPException(status_code=404, detail="MCP server not found")
-    return server
-
-
 @router.post("/mcp-servers/{server_id}/app/read-resource")
 async def read_mcp_app_resource(
     server_id: UUID,
     body: MCPAppReadResourceRequest,
     db: AsyncSession = Depends(get_db),
     current_user: UserDB = Depends(get_current_user),
+    service: MCPServerService = Depends(get_mcp_server_service),
 ):
-    mcp_server = await get_server_or_404(server_id, db)
+    mcp_server = await service.get_or_404(server_id)
     async with connect_to_server(mcp_server, str(current_user.id), db) as (session, _):
         return await session.read_resource(body.uri)
 
@@ -50,7 +46,8 @@ async def call_mcp_app_tool(
     body: MCPAppCallToolRequest,
     db: AsyncSession = Depends(get_db),
     current_user: UserDB = Depends(get_current_user),
+    service: MCPServerService = Depends(get_mcp_server_service),
 ):
-    mcp_server = await get_server_or_404(server_id, db)
+    mcp_server = await service.get_or_404(server_id)
     async with connect_to_server(mcp_server, str(current_user.id), db) as (session, _):
         return await session.call_tool(body.tool_name, body.arguments)

--- a/backend/app/mcp/client/connectivity.py
+++ b/backend/app/mcp/client/connectivity.py
@@ -8,13 +8,13 @@ call sites.
 from app.mcp.client.auth import WebOAuthClientProvider, build_oauth_client_metadata
 from app.mcp.client.storage import TokenStorageFactory
 from app.mcp.servers.models import MCPAuthType, MCPServerDB
-from app.mcp.utils import check_mcp_server_connected
+from app.mcp.utils import probe_mcp_server
 
 
-async def check_oauth_connected(server: MCPServerDB, user_id: str) -> bool:
+async def is_oauth_connected(server: MCPServerDB, user_id: str) -> bool:
     """Return True when an OAuth MCP server has stored tokens for the user.
 
-    Does **not** attempt a refresh. Use :func:`check_connectivity_with_refresh`
+    Does **not** attempt a refresh. Use :func:`probe_connectivity_with_refresh`
     for probes where an expired-but-refreshable token should still count as
     connected.
     """
@@ -30,17 +30,17 @@ async def check_oauth_connected(server: MCPServerDB, user_id: str) -> bool:
     return tokens is not None
 
 
-async def check_connectivity(server: MCPServerDB, user_id: str) -> bool:
+async def probe_connectivity(server: MCPServerDB, user_id: str) -> bool:
     """Lightweight probe: servers without auth are always connected, OAuth
     servers count as connected if a token exists (no refresh attempted)."""
     if server.auth_type in (MCPAuthType.none, MCPAuthType.api_key):
         return True
-    return await check_oauth_connected(server, user_id)
+    return await is_oauth_connected(server, user_id)
 
 
-async def check_connectivity_with_refresh(
+async def probe_connectivity_with_refresh(
     server: MCPServerDB, user_id: str
 ) -> bool:
     """Probe that also attempts a token refresh when the stored token is
-    expired. Delegates to :func:`app.mcp.utils.check_mcp_server_connected`."""
-    return await check_mcp_server_connected(server, user_id)
+    expired. Delegates to :func:`app.mcp.utils.probe_mcp_server`."""
+    return await probe_mcp_server(server, user_id)

--- a/backend/app/mcp/servers/repository.py
+++ b/backend/app/mcp/servers/repository.py
@@ -46,12 +46,22 @@ class MCPServerRepository(BaseRepository[MCPServerDB]):
 
     async def create_or_update_api_key(self, server_id: UUID, api_key: str) -> None:
         encrypted_key = encrypt_api_key(api_key)
-        api_key_record = MCPServerAPIKeyDB(
-            mcp_server_id=server_id,
-            key_encrypted=encrypted_key,
-            created_by=None,
+        stmt = select(MCPServerAPIKeyDB).where(
+            MCPServerAPIKeyDB.mcp_server_id == server_id
         )
-        self.db.add(api_key_record)
+        result = await self.db.execute(stmt)
+        api_key_record = result.scalar_one_or_none()
+        if api_key_record:
+            api_key_record.key_encrypted = encrypted_key
+        else:
+            self.db.add(
+                MCPServerAPIKeyDB(
+                    mcp_server_id=server_id,
+                    key_encrypted=encrypted_key,
+                    created_by=None,
+                )
+            )
+        await self.db.flush()
 
     async def get_oauth_credentials(self, server_id: UUID) -> MCPServerOAuthCredentialsDB | None:
         stmt = select(MCPServerOAuthCredentialsDB).where(
@@ -68,14 +78,22 @@ class MCPServerRepository(BaseRepository[MCPServerDB]):
         auth_method: str | None,
     ) -> None:
         encrypted_secret = encrypt_api_key(client_secret)
-        oauth_credentials = MCPServerOAuthCredentialsDB(
-            mcp_server_id=server_id,
-            client_id=client_id,
-            client_secret_encrypted=encrypted_secret,
-            token_endpoint_auth_method=auth_method,
-            created_by=None,
-        )
-        self.db.add(oauth_credentials)
+        oauth_credentials = await self.get_oauth_credentials(server_id)
+        if oauth_credentials:
+            oauth_credentials.client_id = client_id
+            oauth_credentials.client_secret_encrypted = encrypted_secret
+            oauth_credentials.token_endpoint_auth_method = auth_method
+        else:
+            self.db.add(
+                MCPServerOAuthCredentialsDB(
+                    mcp_server_id=server_id,
+                    client_id=client_id,
+                    client_secret_encrypted=encrypted_secret,
+                    token_endpoint_auth_method=auth_method,
+                    created_by=None,
+                )
+            )
+        await self.db.flush()
 
     async def list_official(self) -> list[tuple[OfficialMCPServerDB, bool]]:
         stmt = (

--- a/backend/app/mcp/servers/repository.py
+++ b/backend/app/mcp/servers/repository.py
@@ -44,7 +44,7 @@ class MCPServerRepository(BaseRepository[MCPServerDB]):
             return decrypt_api_key(api_key_record.key_encrypted)
         return None
 
-    async def save_api_key(self, server_id: UUID, api_key: str) -> None:
+    async def create_or_update_api_key(self, server_id: UUID, api_key: str) -> None:
         encrypted_key = encrypt_api_key(api_key)
         api_key_record = MCPServerAPIKeyDB(
             mcp_server_id=server_id,
@@ -60,7 +60,7 @@ class MCPServerRepository(BaseRepository[MCPServerDB]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def save_oauth_credentials(
+    async def create_or_update_oauth_credentials(
         self,
         server_id: UUID,
         client_id: str,

--- a/backend/app/mcp/servers/router.py
+++ b/backend/app/mcp/servers/router.py
@@ -7,8 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.dependencies import get_current_user, require_admin
 from app.database import get_db
 from app.mcp.client.connectivity import (
-    check_connectivity,
-    check_connectivity_with_refresh,
+    probe_connectivity,
+    probe_connectivity_with_refresh,
 )
 from app.mcp.servers.models import MCPServerDB
 from app.mcp.servers.schemas import (
@@ -25,10 +25,10 @@ router = APIRouter(prefix="/mcp-servers", tags=["mcp-servers"])
 
 
 async def get_mcp_server_dependency(
-    mcp_server_id: UUID,
+    server_id: UUID,
     service: MCPServerService = Depends(get_mcp_server_service),
 ) -> MCPServerDB:
-    return await service.get_server(mcp_server_id)
+    return await service.get(server_id)
 
 
 @router.post("/", response_model=MCPServerResponse, status_code=201)
@@ -37,7 +37,7 @@ async def create_mcp_server(
     _current_user: UserDB = Depends(require_admin),
     service: MCPServerService = Depends(get_mcp_server_service),
 ) -> MCPServerResponse:
-    return await service.create_server(server)
+    return await service.create(server)
 
 
 @router.get("/", response_model=list[MCPServerResponse])
@@ -45,7 +45,7 @@ async def get_mcp_servers(
     _current_user: UserDB = Depends(get_current_user),
     service: MCPServerService = Depends(get_mcp_server_service),
 ) -> list[MCPServerResponse]:
-    return await service.list_servers()
+    return await service.list()
 
 
 @router.get("/official", response_model=list[OfficialMCPServerResponse])
@@ -53,7 +53,7 @@ async def get_official_mcp_servers(
     _current_user: UserDB = Depends(get_current_user),
     service: MCPServerService = Depends(get_mcp_server_service),
 ) -> list[OfficialMCPServerResponse]:
-    return await service.list_official_servers()
+    return await service.list_official()
 
 
 @router.get("/{server_id}", response_model=MCPServerResponse)
@@ -62,7 +62,7 @@ async def get_mcp_server(
     _current_user: UserDB = Depends(get_current_user),
     service: MCPServerService = Depends(get_mcp_server_service),
 ) -> MCPServerResponse:
-    return await service.get_server(server_id)
+    return await service.get(server_id)
 
 
 @router.patch("/{server_id}", response_model=MCPServerResponse)
@@ -72,7 +72,7 @@ async def update_mcp_server(
     _current_user: UserDB = Depends(require_admin),
     service: MCPServerService = Depends(get_mcp_server_service),
 ) -> MCPServerResponse:
-    return await service.update_server(server_id, server_update)
+    return await service.update(server_id, server_update)
 
 
 @router.delete("/{server_id}", status_code=204)
@@ -81,7 +81,7 @@ async def delete_mcp_server(
     _current_user: UserDB = Depends(require_admin),
     service: MCPServerService = Depends(get_mcp_server_service),
 ) -> None:
-    await service.delete_server(server_id)
+    await service.delete(server_id)
 
 
 @router.post("/{server_id}/reset", status_code=200)
@@ -94,7 +94,7 @@ async def reset_mcp_server(
 
     Clears all per-user OAuth tokens, client info, and metadata from Redis.
     """
-    return await service.reset_server(server_id)
+    return await service.reset(server_id)
 
 
 @router.get("/oauth/callback")
@@ -107,7 +107,7 @@ async def oauth_callback(
     return JSONResponse(status_code=200, content=result)
 
 
-@router.get("/{mcp_server_id}/list-tools")
+@router.get("/{server_id}/list-tools")
 async def list_tools(
     mcp_server: MCPServerDB = Depends(get_mcp_server_dependency),
     current_user: UserDB = Depends(get_current_user),
@@ -122,21 +122,21 @@ async def list_tools(
     return await MCPServerService(db).list_tools(mcp_server, str(current_user.id))
 
 
-@router.get("/{mcp_server_id}/is-connected")
+@router.get("/{server_id}/is-connected")
 async def is_connected(
     mcp_server: MCPServerDB = Depends(get_mcp_server_dependency),
     current_user: UserDB = Depends(get_current_user),
 ):
-    connected = await check_connectivity(mcp_server, str(current_user.id))
+    connected = await probe_connectivity(mcp_server, str(current_user.id))
     return {"connected": connected}
 
 
-@router.get("/{mcp_server_id}/is-connected-v2")
+@router.get("/{server_id}/is-connected-v2")
 async def is_connected_v2(
     mcp_server: MCPServerDB = Depends(get_mcp_server_dependency),
     current_user: UserDB = Depends(get_current_user),
 ):
-    connected = await check_connectivity_with_refresh(
+    connected = await probe_connectivity_with_refresh(
         mcp_server, str(current_user.id)
     )
     return {"connected": connected}

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from contextlib import asynccontextmanager
 from uuid import UUID
@@ -9,7 +11,7 @@ from mcp.shared.auth import OAuthClientInformationFull
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.exceptions import DomainError, NotFoundError, ValidationError
+from app.exceptions import DomainError, DomainValidationError, NotFoundError
 from app.mcp.client.auth import WebOAuthClientProvider, build_oauth_client_metadata
 from app.mcp.client.storage import TokenStorageFactory
 from app.mcp.servers.encryption import decrypt_value as decrypt_api_key
@@ -29,21 +31,21 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
     def __init__(self, db: AsyncSession):
         super().__init__(db, MCPServerRepository(db))
 
-    async def create_server(self, data: MCPServerCreate) -> MCPServerDB:
+    async def create(self, data: MCPServerCreate) -> MCPServerDB:
         if data.auth_type == MCPAuthType.api_key and not data.api_key:
-            raise ValidationError("API key is required when auth_type is 'api_key'")
+            raise DomainValidationError("API key is required when auth_type is 'api_key'")
 
         db_server = await self.repository.create(data)
 
         if data.auth_type == MCPAuthType.api_key and data.api_key:
-            await self.repository.save_api_key(db_server.id, data.api_key)
+            await self.repository.create_or_update_api_key(db_server.id, data.api_key)
 
         if (
             data.auth_type == MCPAuthType.oauth2
             and data.oauth_client_id
             and data.oauth_client_secret
         ):
-            await self.repository.save_oauth_credentials(
+            await self.repository.create_or_update_oauth_credentials(
                 db_server.id,
                 data.oauth_client_id,
                 data.oauth_client_secret,
@@ -52,29 +54,29 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
 
         return db_server
 
-    async def get_server(self, server_id: UUID) -> MCPServerDB:
+    async def get(self, server_id: UUID) -> MCPServerDB:
         return await self.get_or_404(server_id)
 
-    async def list_servers(self) -> list[MCPServerDB]:
+    async def list(self) -> list[MCPServerDB]:
         return await self.repository.list()
 
-    async def update_server(self, server_id: UUID, data: MCPServerPatch) -> MCPServerDB:
+    async def update(self, server_id: UUID, data: MCPServerPatch) -> MCPServerDB:
         server = await self.get_or_404(server_id)
         return await self.repository.update(server, data)
 
-    async def delete_server(self, server_id: UUID) -> None:
+    async def delete(self, server_id: UUID) -> None:
         server = await self.get_or_404(server_id)
         await self.repository.delete(server)
 
-    async def list_official_servers(self) -> list[OfficialMCPServerResponse]:
+    async def list_official(self) -> list[OfficialMCPServerResponse]:
         rows = await self.repository.list_official()
         return [
             OfficialMCPServerResponse(**row[0].model_dump(), is_installed=row[1])
             for row in rows
         ]
 
-    async def reset_server(self, server_id: UUID) -> dict:
-        await self.get_server(server_id)
+    async def reset(self, server_id: UUID) -> dict:
+        await self.get(server_id)
         factory = TokenStorageFactory()
         deleted = await factory.clear_server_data(str(server_id))
         return {"deleted_keys": deleted}
@@ -84,7 +86,7 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
         result = await storage_factory.get_storage_from_state(state)
 
         if not result:
-            raise ValidationError("Invalid or expired OAuth state")
+            raise DomainValidationError("Invalid or expired OAuth state")
 
         storage, state_data = result
 

--- a/backend/app/mcp/utils.py
+++ b/backend/app/mcp/utils.py
@@ -7,7 +7,7 @@ from app.mcp.client.storage import TokenStorageFactory
 from app.mcp.servers.models import MCPAuthType, MCPServerDB
 
 
-async def check_mcp_server_connected(
+async def probe_mcp_server(
     mcp_server: MCPServerDB,
     user_id: str,
 ) -> bool:

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import StreamingResponse
 
 from app.agents.core.service import AgentService, get_agent_service
-from app.agents.runtime import AgentRuntime
+from app.agents.runtime import Agent
 from app.agents.stream import _serialize_lc_message
 from app.auth.dependencies import detect_auth_method, get_current_user
 from app.database import get_checkpointer, get_db
@@ -47,7 +47,7 @@ async def _resolve_viewer_role(
     """
     if thread.user_id == current_user.id:
         return None
-    agent = await agent_service.get_agent(
+    agent = await agent_service.get(
         thread.agent_id, user_id=current_user.id, user_role=current_user.role
     )
     if agent.current_user_permission in ("owner", "admin"):
@@ -62,9 +62,9 @@ async def read_thread(
     service: ThreadService = Depends(get_thread_service),
     agent_service: AgentService = Depends(get_agent_service),
 ) -> dict:
-    thread = await service.get_thread(thread_id)
+    thread = await service.get(thread_id)
     viewer_role = await _resolve_viewer_role(thread, current_user, agent_service)
-    thread_read = await service.get_thread_with_agent(thread_id)
+    thread_read = await service.get_with_agent(thread_id)
 
     async with get_checkpointer() as checkpointer:
         checkpoint_tuple = await checkpointer.aget_tuple(
@@ -138,7 +138,7 @@ async def get_threads(
     current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
 ) -> list[ThreadResponse]:
-    return await service.list_threads(current_user.id)
+    return await service.list(current_user.id)
 
 
 @router.post("/")
@@ -153,7 +153,7 @@ async def create_thread(
         if detect_auth_method(request, current_user) == "cookie"
         else ThreadSource.api
     )
-    return await service.create_thread(thread_data, current_user.id, source)
+    return await service.create(thread_data, current_user.id, source)
 
 
 @router.delete("/{thread_id}", status_code=204)
@@ -162,13 +162,13 @@ async def delete_thread(
     current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
 ) -> None:
-    thread = await service.get_thread(thread_id)
+    thread = await service.get(thread_id)
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to delete this thread")
     async with get_checkpointer() as checkpointer:
         await checkpointer.adelete_thread(thread_id=thread_id)
 
-    await service.delete_thread(thread_id)
+    await service.delete(thread_id)
 
 
 @router.post("/{thread_id}/runs/stream")
@@ -183,14 +183,14 @@ async def run_stream(
     db=Depends(get_db),
 ):
     """LangGraph native streaming endpoint for @langchain/langgraph-sdk useStream."""
-    thread = await service.get_thread(thread_id)
+    thread = await service.get(thread_id)
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to run this thread")
-    runtime = await AgentRuntime.build(thread=thread, db=db)
+    agent = await Agent.build(thread=thread, db=db)
     trigger, config_overrides = _parse_run_config(config)
 
     return StreamingResponse(
-        runtime.stream(
+        agent.stream(
             agent_input=agent_input,
             command=command,
             trigger=trigger,
@@ -217,13 +217,13 @@ async def run_invoke(
     db=Depends(get_db),
 ):
     """Non-streaming invoke endpoint. Returns the final agent response as JSON."""
-    thread = await service.get_thread(thread_id)
+    thread = await service.get(thread_id)
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to run this thread")
-    runtime = await AgentRuntime.build(thread=thread, db=db)
+    agent = await Agent.build(thread=thread, db=db)
     trigger, config_overrides = _parse_run_config(config)
 
-    return await runtime.invoke(
+    return await agent.invoke(
         agent_input=agent_input,
         command=command,
         trigger=trigger,

--- a/backend/app/threads/service.py
+++ b/backend/app/threads/service.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from uuid import UUID
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import AsyncSessionLocal, get_db
+from app.database import get_db
 from app.exceptions import NotFoundError
 from app.service import BaseService
 from app.threads.models import ThreadDB, ThreadSource
@@ -57,26 +59,26 @@ class ThreadService(BaseService[ThreadDB, ThreadRepository]):
     def __init__(self, db: AsyncSession):
         super().__init__(db, ThreadRepository(db))
 
-    async def get_thread(self, thread_id: str) -> ThreadDB:
+    async def get(self, thread_id: str) -> ThreadDB:
         return await self.get_or_404(thread_id)
 
-    async def get_thread_with_agent(self, thread_id: str) -> ThreadResponse:
+    async def get_with_agent(self, thread_id: str) -> ThreadResponse:
         row = await self.repository.get_with_agent(thread_id)
         if not row:
             raise NotFoundError(self.not_found_message)
         return _thread_with_agent(*row)
 
-    async def list_threads(self, user_id: UUID) -> list[ThreadResponse]:
+    async def list(self, user_id: UUID) -> list[ThreadResponse]:
         rows = await self.repository.list_for_user(user_id)
         return [_thread_with_agent(*row) for row in rows]
 
-    async def list_threads_for_agent(
+    async def list_for_agent(
         self, agent_id: UUID
     ) -> list[AgentThreadResponse]:
         rows = await self.repository.list_for_agent(agent_id)
         return [_agent_thread(*row) for row in rows]
 
-    async def create_thread(
+    async def create(
         self,
         data: ThreadCreate,
         user_id: UUID,
@@ -92,36 +94,37 @@ class ThreadService(BaseService[ThreadDB, ThreadRepository]):
         await self.db.refresh(thread)
         return ThreadResponse.model_validate(thread)
 
-    async def delete_thread(self, thread_id: str) -> ThreadDB:
+    async def delete(self, thread_id: str) -> ThreadDB:
         thread = await self.get_or_404(thread_id)
         await self.db.delete(thread)
+        return thread
+
+    async def get_or_create(
+        self,
+        ts: str,
+        agent_id: str,
+        question: str | None,
+        user_id: str,
+    ) -> ThreadDB:
+        """Return the existing thread or create a new Slack-sourced thread.
+
+        Caller (Slack handler) owns the session lifecycle and the final commit.
+        """
+        thread = await self.db.get(ThreadDB, ts)
+        if thread is None:
+            thread = ThreadDB(
+                id=ts,
+                agent_id=agent_id,
+                model_id="deepseek-v4-flash",
+                first_message_content=question,
+                user_id=user_id,
+                source=ThreadSource.slack,
+            )
+            self.db.add(thread)
+            await self.db.flush()
+            await self.db.refresh(thread)
         return thread
 
 
 def get_thread_service(db: AsyncSession = Depends(get_db)) -> ThreadService:
     return ThreadService(db)
-
-
-async def get_or_create_thread(
-    ts: str, agent_id: str, question: str, user_id: str,
-) -> tuple[ThreadDB, AsyncSession]:
-    """Slack-side helper: open a dedicated session and return/persist the thread.
-
-    Uses its own session because Slack event handlers don't run inside a FastAPI
-    request, so they can't rely on the request-scoped ``get_db``.
-    """
-    db = AsyncSessionLocal()
-    thread = await db.get(ThreadDB, ts)
-    if thread is None:
-        thread = ThreadDB(
-            id=ts,
-            agent_id=agent_id,
-            model_id="deepseek-v4-flash",
-            first_message_content=question,
-            user_id=user_id,
-            source=ThreadSource.slack,
-        )
-        db.add(thread)
-        await db.commit()
-        await db.refresh(thread)
-    return thread, db

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -15,7 +15,7 @@ class WorkspaceRole(str, Enum):
 class UserBase(SQLModel):
     name: str | None = Field(default=None, max_length=255)
     email: str | None = Field(default=None, max_length=255, unique=True, index=True)
-    hashed_password: str | None = Field(default=None)
+    password_hash: str | None = Field(default=None)
     role: WorkspaceRole = Field(default=WorkspaceRole.member, nullable=False)
 
 

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -17,7 +17,7 @@ async def create_user(
     _: UserDB = Depends(require_admin),
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
-    return await service.create_user(user)
+    return await service.create(user)
 
 
 @router.get("/", response_model=list[UserResponse])
@@ -25,7 +25,7 @@ async def get_users(
     role: WorkspaceRole | None = None,
     service: UserService = Depends(get_user_service),
 ) -> list[UserResponse]:
-    return await service.list_users(role=role)
+    return await service.list(role=role)
 
 
 @router.get("/{user_id}", response_model=UserResponse)
@@ -33,15 +33,15 @@ async def get_user(
     user_id: UUID,
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
-    return await service.get_user(user_id)
+    return await service.get(user_id)
 
 
 @router.get("/email/{email}", response_model=UserResponse)
-async def get_user_by_email_route(
+async def get_user_by_email(
     email: str,
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
-    return await service.get_user_by_email(email)
+    return await service.get_by_email(email)
 
 
 @router.patch("/{user_id}", response_model=UserResponse)
@@ -50,7 +50,7 @@ async def update_user(
     user_update: UserPatch,
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
-    return await service.update_user(user_id, user_update)
+    return await service.update(user_id, user_update)
 
 
 @router.patch("/{user_id}/role", response_model=UserResponse)
@@ -59,7 +59,7 @@ async def update_user_role(
     role_update: UserRolePatch,
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
-    return await service.update_user_role(user_id, role_update)
+    return await service.update_role(user_id, role_update)
 
 
 @router.delete("/{user_id}", status_code=204)
@@ -68,4 +68,4 @@ async def delete_user(
     _: UserDB = Depends(require_admin),
     service: UserService = Depends(get_user_service),
 ) -> None:
-    await service.delete_user(user_id)
+    await service.delete(user_id)

--- a/backend/app/users/schemas.py
+++ b/backend/app/users/schemas.py
@@ -9,14 +9,14 @@ from app.users.models import OAuthAccountBase, WorkspaceRole
 class UserCreate(SQLModel):
     name: str | None = Field(default=None, max_length=255)
     email: str | None = Field(default=None, max_length=255)
-    hashed_password: str | None = None
+    password_hash: str | None = None
     role: WorkspaceRole = WorkspaceRole.member
 
 
 class UserPatch(SQLModel):
     name: str | None = Field(default=None, max_length=255)
     email: str | None = Field(default=None, max_length=255)
-    hashed_password: str | None = None
+    password_hash: str | None = None
 
 
 class UserRolePatch(SQLModel):

--- a/backend/app/users/service.py
+++ b/backend/app/users/service.py
@@ -21,24 +21,24 @@ class UserService(BaseService[UserDB, UserRepository]):
         if await self.repository.get_by_email(email):
             raise AlreadyExistsError("Email already registered")
 
-    async def create_user(self, data: UserCreate) -> UserDB:
+    async def create(self, data: UserCreate) -> UserDB:
         if data.email:
             await self._ensure_email_available(data.email)
         return await self.repository.create(data)
 
-    async def get_user(self, user_id: UUID) -> UserDB:
+    async def get(self, user_id: UUID) -> UserDB:
         return await self.get_or_404(user_id)
 
-    async def get_user_by_email(self, email: str) -> UserDB:
+    async def get_by_email(self, email: str) -> UserDB:
         user = await self.repository.get_by_email(email)
         if not user:
             raise NotFoundError(self.not_found_message)
         return user
 
-    async def list_users(self, role: WorkspaceRole | None = None) -> list[UserDB]:
+    async def list(self, role: WorkspaceRole | None = None) -> list[UserDB]:
         return await self.repository.list(role=role)
 
-    async def update_user(self, user_id: UUID, data: UserPatch) -> UserDB:
+    async def update(self, user_id: UUID, data: UserPatch) -> UserDB:
         user = await self.get_or_404(user_id)
         update_data = data.model_dump(exclude_unset=True)
         new_email = update_data.get("email")
@@ -46,11 +46,11 @@ class UserService(BaseService[UserDB, UserRepository]):
             await self._ensure_email_available(new_email)
         return await self.repository.update(user, data)
 
-    async def update_user_role(self, user_id: UUID, data: UserRolePatch) -> UserDB:
+    async def update_role(self, user_id: UUID, data: UserRolePatch) -> UserDB:
         user = await self.get_or_404(user_id)
         return await self.repository.update(user, data)
 
-    async def delete_user(self, user_id: UUID) -> None:
+    async def delete(self, user_id: UUID) -> None:
         user = await self.get_or_404(user_id)
         await self.repository.delete(user)
 

--- a/backend/tests/agents/core/test_repository.py
+++ b/backend/tests/agents/core/test_repository.py
@@ -48,7 +48,7 @@ def make_permission(agent_id=None, **kwargs):
         id=uuid4(),
         agent_id=agent_id or uuid4(),
         user_id=uuid4(),
-        permission=PermissionLevel.user,
+        permission=PermissionLevel.member,
         created_at=datetime.now(),
         updated_at=datetime.now(),
     )
@@ -306,7 +306,7 @@ async def test_set_permissions_refreshes_each_new_permission(repo, mock_db):
     mock_db.execute.return_value = mock_result
 
     writes = [
-        AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.user),
+        AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.member),
         AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.editor),
     ]
     result = await repo.set_permissions(agent_id, writes)

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -155,10 +155,10 @@ def test_update_agent(client: TestClient, mock_db, current_user):
 
     mock_db.execute.side_effect = [
         make_result(rows=[(agent, None)]),  # get_agent (auth): list_with_permissions
-        make_result(scalars_list=[]),  # get_agent (auth): load_all_subagent_data
+        make_result(scalars_list=[]),  # get_agent (auth): list_all_subagent_data
         make_result(scalar=agent),  # get_or_404: repository.get
         make_result(rows=[(agent, None)]),  # get_agent (return): list_with_permissions
-        make_result(scalars_list=[]),  # get_agent (return): load_all_subagent_data
+        make_result(scalars_list=[]),  # get_agent (return): list_all_subagent_data
     ]
 
     update_data = {
@@ -214,7 +214,7 @@ def test_update_agent_forbidden_for_non_owner(
 
     mock_db.execute.side_effect = [
         make_result(rows=[(agent, None, None)]),  # list_with_permissions: no grant
-        make_result(scalars_list=[]),  # load_all_subagent_data
+        make_result(scalars_list=[]),  # list_all_subagent_data
     ]
 
     response = client.patch(f"/agents/{agent_id}", json={"name": "Pwned"})
@@ -346,7 +346,7 @@ def test_list_agent_threads_as_owner(client: TestClient, mock_db, current_user):
     mock_db.execute.side_effect = [
         # get_agent: list_with_permissions returns the agent owned by current_user
         make_result(rows=[(agent, None, None)]),
-        # get_agent: load_all_subagent_data
+        # get_agent: list_all_subagent_data
         make_result(scalars_list=[]),
         # ThreadRepository.list_for_agent
         make_result(

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -49,8 +49,8 @@ def mock_repo():
 @pytest.fixture
 def mock_subagent_service():
     svc = MagicMock()
-    svc.load_subagents = AsyncMock(return_value=[])
-    svc.load_all_subagent_data = AsyncMock(return_value=({}, set()))
+    svc.list_subagents = AsyncMock(return_value=[])
+    svc.list_all_subagent_data = AsyncMock(return_value=({}, set()))
     svc.delete_all_for_agent = AsyncMock()
     svc.repository = MagicMock()
     svc.repository.is_subagent = AsyncMock(return_value=False)
@@ -108,7 +108,7 @@ async def test_create_agent_delegates_to_repository(service, mock_repo):
     mock_repo.create.return_value = agent
     data = AgentCreateDB(name="X", instructions="Y", owner_id=uuid4())
 
-    result = await service.create_agent(data)
+    result = await service.create(data)
 
     mock_repo.create.assert_awaited_once_with(data)
     assert result is agent
@@ -123,7 +123,7 @@ async def test_get_agent_returns_agent_read(service, mock_repo):
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.get_agent(agent.id)
+    result = await service.get(agent.id)
 
     assert isinstance(result, AgentResponse)
     assert result.id == agent.id
@@ -136,7 +136,7 @@ async def test_get_agent_raises_404_when_not_found(service, mock_repo):
     mock_repo.list_with_permissions.return_value = []
 
     with pytest.raises(NotFoundError) as exc_info:
-        await service.get_agent(uuid4())
+        await service.get(uuid4())
 
     assert exc_info.value.detail == "Agent not found"
 
@@ -146,7 +146,7 @@ async def test_get_agent_sets_owner_permission(service, mock_repo):
     agent = make_agent(owner_id=owner_id)
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.get_agent(agent.id, user_id=owner_id)
+    result = await service.get(agent.id, user_id=owner_id)
 
     assert result.current_user_permission == "owner"
 
@@ -155,7 +155,7 @@ async def test_get_agent_sets_admin_permission(service, mock_repo):
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.get_agent(agent.id, user_role=WorkspaceRole.admin)
+    result = await service.get(agent.id, user_role=WorkspaceRole.admin)
 
     assert result.current_user_permission == "admin"
 
@@ -174,7 +174,7 @@ async def test_get_agent_includes_mcp_servers_from_bindings(service, mock_repo):
     )
     mock_repo.list_with_permissions.return_value = [(agent, binding)]
 
-    result = await service.get_agent(agent.id)
+    result = await service.get(agent.id)
 
     assert len(result.mcp_servers) == 1
     assert result.mcp_servers[0].mcp_server_id == server_id
@@ -185,7 +185,7 @@ async def test_get_agent_skips_null_bindings(service, mock_repo):
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.get_agent(agent.id)
+    result = await service.get(agent.id)
 
     assert result.mcp_servers == []
 
@@ -198,7 +198,7 @@ async def test_get_agent_skips_null_bindings(service, mock_repo):
 async def test_list_agents_returns_empty_when_no_agents(service, mock_repo):
     mock_repo.list_with_permissions.return_value = []
 
-    result = await service.list_agents()
+    result = await service.list()
 
     assert result == []
 
@@ -207,7 +207,7 @@ async def test_list_agents_returns_one_per_agent(service, mock_repo):
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.list_agents()
+    result = await service.list()
 
     assert len(result) == 1
     assert result[0].id == agent.id
@@ -236,7 +236,7 @@ async def test_list_agents_deduplicates_multiple_bindings_per_agent(service, moc
         (agent, binding2),
     ]
 
-    result = await service.list_agents(user_role=WorkspaceRole.admin)
+    result = await service.list(user_role=WorkspaceRole.admin)
 
     assert len(result) == 1
     assert len(result[0].mcp_servers) == 2
@@ -247,7 +247,7 @@ async def test_list_agents_owner_gets_owner_permission(service, mock_repo):
     agent = make_agent(owner_id=owner_id)
     mock_repo.list_with_permissions.return_value = [(agent, None, None)]
 
-    result = await service.list_agents(user_id=owner_id, user_role=WorkspaceRole.member)
+    result = await service.list(user_id=owner_id, user_role=WorkspaceRole.member)
 
     assert result[0].current_user_permission == "owner"
 
@@ -256,7 +256,7 @@ async def test_list_agents_admin_gets_admin_permission(service, mock_repo):
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.list_agents(user_role=WorkspaceRole.admin)
+    result = await service.list(user_role=WorkspaceRole.admin)
 
     assert result[0].current_user_permission == "admin"
 
@@ -268,7 +268,7 @@ async def test_list_agents_granted_permission_from_row(service, mock_repo):
         (agent, None, PermissionLevel.editor)
     ]
 
-    result = await service.list_agents(
+    result = await service.list(
         user_id=non_owner_id, user_role=WorkspaceRole.member
     )
 
@@ -280,7 +280,7 @@ async def test_list_agents_no_permission_when_not_granted(service, mock_repo):
     non_owner_id = uuid4()
     mock_repo.list_with_permissions.return_value = [(agent, None, None)]
 
-    result = await service.list_agents(
+    result = await service.list(
         user_id=non_owner_id, user_role=WorkspaceRole.member
     )
 
@@ -293,7 +293,7 @@ async def test_list_agents_no_user_returns_agents_with_no_permission(
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.list_agents()
+    result = await service.list()
 
     assert result[0].current_user_permission is None
 
@@ -308,7 +308,7 @@ async def test_update_agent_delegates_to_repository(service, mock_repo):
     mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.update_agent(
+    result = await service.update(
         agent.id, AgentPatch(name="Updated"), user_id=agent.owner_id
     )
 
@@ -327,7 +327,7 @@ async def test_update_agent_passes_only_set_fields(service, mock_repo):
     mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    await service.update_agent(
+    await service.update(
         agent.id, AgentPatch(name="New Name"), user_id=agent.owner_id
     )
 
@@ -340,7 +340,7 @@ async def test_update_agent_raises_404_when_not_found(service, mock_repo):
     mock_repo.list_with_permissions.return_value = []
 
     with pytest.raises(NotFoundError) as exc_info:
-        await service.update_agent(uuid4(), AgentPatch(name="X"))
+        await service.update(uuid4(), AgentPatch(name="X"))
 
     assert exc_info.value.detail == "Agent not found"
     mock_repo.update.assert_not_called()
@@ -351,7 +351,7 @@ async def test_update_agent_raises_403_when_no_permission(service, mock_repo):
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     with pytest.raises(PermissionDeniedError):
-        await service.update_agent(agent.id, AgentPatch(name="X"), user_id=uuid4())
+        await service.update(agent.id, AgentPatch(name="X"), user_id=uuid4())
 
     mock_repo.get.assert_not_called()
     mock_repo.update.assert_not_called()
@@ -362,7 +362,7 @@ async def test_update_agent_allows_workspace_admin(service, mock_repo):
     mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    await service.update_agent(
+    await service.update(
         agent.id,
         AgentPatch(name="Renamed"),
         user_id=uuid4(),
@@ -383,7 +383,7 @@ async def test_delete_agent_delegates_to_repository(
     agent = make_agent()
     mock_repo.get.return_value = agent
 
-    await service.delete_agent(agent.id, user_id=agent.owner_id)
+    await service.delete(agent.id, user_id=agent.owner_id)
 
     mock_repo.get.assert_awaited_once_with(agent.id)
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
@@ -394,7 +394,7 @@ async def test_delete_agent_raises_404_when_not_found(service, mock_repo):
     mock_repo.get.return_value = None
 
     with pytest.raises(NotFoundError) as exc_info:
-        await service.delete_agent(uuid4())
+        await service.delete(uuid4())
 
     assert exc_info.value.detail == "Agent not found"
     mock_repo.archive.assert_not_called()
@@ -407,7 +407,7 @@ async def test_delete_agent_raises_403_for_non_owner(
     mock_repo.get.return_value = agent
 
     with pytest.raises(PermissionDeniedError):
-        await service.delete_agent(agent.id, user_id=uuid4())
+        await service.delete(agent.id, user_id=uuid4())
 
     mock_subagent_service.delete_all_for_agent.assert_not_called()
     mock_repo.archive.assert_not_called()
@@ -419,7 +419,7 @@ async def test_delete_agent_allows_workspace_admin(
     agent = make_agent()
     mock_repo.get.return_value = agent
 
-    await service.delete_agent(agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin)
+    await service.delete(agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin)
 
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
     mock_repo.archive.assert_awaited_once_with(agent)
@@ -434,7 +434,7 @@ async def test_check_ready_returns_ready_when_no_mcp_servers(service, mock_repo)
     agent = make_agent()
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    result = await service.check_ready(agent.id, "user-id")
+    result = await service.describe_readiness(agent.id, "user-id")
 
     assert result["ready"] is True
     assert result["status"] == "ready"
@@ -456,7 +456,7 @@ async def test_check_ready_returns_not_configured_when_tools_is_none(
     )
     mock_repo.list_with_permissions.return_value = [(agent, binding)]
 
-    result = await service.check_ready(agent.id, "user-id")
+    result = await service.describe_readiness(agent.id, "user-id")
 
     assert result["ready"] is False
     assert result["status"] == "not_configured"
@@ -482,10 +482,10 @@ async def test_check_ready_returns_ready_when_all_servers_connected(
     mock_db.execute.return_value = _make_mock_execute_result(scalars_list=[mcp_server])
 
     with patch(
-        "app.agents.core.service.check_mcp_server_connected",
+        "app.agents.core.service.probe_mcp_server",
         new=AsyncMock(return_value=True),
     ):
-        result = await service.check_ready(agent.id, "user-id")
+        result = await service.describe_readiness(agent.id, "user-id")
 
     assert result["ready"] is True
     assert result["disconnected_servers"] == []
@@ -511,10 +511,10 @@ async def test_check_ready_returns_not_ready_when_server_disconnected(
     mock_db.execute.return_value = _make_mock_execute_result(scalars_list=[mcp_server])
 
     with patch(
-        "app.agents.core.service.check_mcp_server_connected",
+        "app.agents.core.service.probe_mcp_server",
         new=AsyncMock(return_value=False),
     ):
-        result = await service.check_ready(agent.id, "user-id")
+        result = await service.describe_readiness(agent.id, "user-id")
 
     assert result["ready"] is False
     assert str(server_id) in result["disconnected_servers"]
@@ -538,10 +538,10 @@ async def test_check_ready_disconnected_status_label(service, mock_db, mock_repo
     mock_db.execute.return_value = _make_mock_execute_result(scalars_list=[mcp_server])
 
     with patch(
-        "app.agents.core.service.check_mcp_server_connected",
+        "app.agents.core.service.probe_mcp_server",
         new=AsyncMock(return_value=False),
     ):
-        result = await service.check_ready(agent.id, "user-id")
+        result = await service.describe_readiness(agent.id, "user-id")
 
     assert result["status"] == "disconnected"
 

--- a/backend/tests/agents/mcp_servers/test_service.py
+++ b/backend/tests/agents/mcp_servers/test_service.py
@@ -232,7 +232,7 @@ async def test_create_or_update_creates_and_fetches_tools_for_no_auth(
     mock_repo.get.return_value = None
     mock_repo.create.return_value = link
 
-    with patch.object(service, "_fetch_and_save_tools", new=AsyncMock()) as mock_fetch:
+    with patch.object(service, "_sync_tools", new=AsyncMock()) as mock_fetch:
         await service.create_or_update(
             uuid4(), server.id, AgentMCPServerCreate(), "user-id"
         )
@@ -250,7 +250,7 @@ async def test_create_or_update_creates_and_fetches_tools_for_api_key(
     mock_repo.get.return_value = None
     mock_repo.create.return_value = link
 
-    with patch.object(service, "_fetch_and_save_tools", new=AsyncMock()) as mock_fetch:
+    with patch.object(service, "_sync_tools", new=AsyncMock()) as mock_fetch:
         await service.create_or_update(
             uuid4(), server.id, AgentMCPServerCreate(), "user-id"
         )
@@ -269,10 +269,10 @@ async def test_create_or_update_oauth_fetches_tools_when_connected(
 
     with (
         patch(
-            "app.agents.mcp_servers.service.check_oauth_connected",
+            "app.agents.mcp_servers.service.is_oauth_connected",
             new=AsyncMock(return_value=True),
         ),
-        patch.object(service, "_fetch_and_save_tools", new=AsyncMock()) as mock_fetch,
+        patch.object(service, "_sync_tools", new=AsyncMock()) as mock_fetch,
     ):
         await service.create_or_update(
             uuid4(), server.id, AgentMCPServerCreate(), "user-id"
@@ -292,10 +292,10 @@ async def test_create_or_update_oauth_skips_fetch_when_not_connected(
 
     with (
         patch(
-            "app.agents.mcp_servers.service.check_oauth_connected",
+            "app.agents.mcp_servers.service.is_oauth_connected",
             new=AsyncMock(return_value=False),
         ),
-        patch.object(service, "_fetch_and_save_tools", new=AsyncMock()) as mock_fetch,
+        patch.object(service, "_sync_tools", new=AsyncMock()) as mock_fetch,
     ):
         await service.create_or_update(
             uuid4(), server.id, AgentMCPServerCreate(), "user-id"
@@ -336,7 +336,7 @@ async def test_sync_tools_calls_fetch_and_save_and_returns_link(
     mock_db.execute.return_value = make_mock_execute_result(scalar=server)
     mock_repo.get.return_value = link
 
-    with patch.object(service, "_fetch_and_save_tools", new=AsyncMock()) as mock_fetch:
+    with patch.object(service, "_sync_tools", new=AsyncMock()) as mock_fetch:
         result = await service.sync_tools(uuid4(), server.id, "user-id")
 
     mock_fetch.assert_awaited_once_with(link, server, "user-id")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -43,7 +43,7 @@ def current_user():
         name="Test User",
         email="test@test.com",
         role=WorkspaceRole.member,
-        hashed_password="hashed_password"
+        password_hash="hashed_password"
     )
     app.dependency_overrides[get_current_user] = lambda: user
     yield user
@@ -58,7 +58,7 @@ def editor_user():
         name="Editor User",
         email="editor@test.com",
         role=WorkspaceRole.editor,
-        hashed_password="hashed_password"
+        password_hash="hashed_password"
     )
     app.dependency_overrides[get_current_user] = lambda: user
     app.dependency_overrides[require_editor] = lambda: user
@@ -74,7 +74,7 @@ def admin_user():
         name="Admin User",
         email="admin@test.com",
         role=WorkspaceRole.admin,
-        hashed_password="hashed_password"
+        password_hash="hashed_password"
     )
     app.dependency_overrides[get_current_user] = lambda: user
     app.dependency_overrides[require_editor] = lambda: user

--- a/backend/tests/users/test_users_router.py
+++ b/backend/tests/users/test_users_router.py
@@ -12,7 +12,7 @@ def test_create_user(client: TestClient, mock_db, admin_user):
     user_data = {
         "name": "Test User",
         "email": "test@example.com",
-        "hashed_password": "hashed_password",
+        "password_hash": "hashed_password",
         "role": "member",
     }
 
@@ -44,7 +44,7 @@ def test_create_user_duplicate_email(client: TestClient, mock_db, admin_user):
     user_data = {
         "name": "Test User",
         "email": "duplicate@example.com",
-        "hashed_password": "hashed_password",
+        "password_hash": "hashed_password",
     }
 
     existing_user = UserDB(

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -410,9 +410,9 @@ const ChatPage = () => {
 	// BaseStream types do not include them. Cast to access the API.
 	const subagentApi = thread as unknown as SubagentApi;
 
-	// Coordinator todos from stream values
+	// Supervisor todos from stream values
 	const streamValues = thread.values as Record<string, unknown>;
-	const coordinatorTodos = (streamValues?.todos ?? []) as Todo[];
+	const supervisorTodos = (streamValues?.todos ?? []) as Todo[];
 
 	// Messages: use stream messages when available, else initial.
 	// Throttle to ~16Hz so streamed chunks don't trigger per-token re-renders
@@ -699,9 +699,9 @@ const ChatPage = () => {
 			<div className="h-full relative flex flex-1 flex-col min-h-0 w-full">
 				<Conversation>
 					<ConversationContent className="max-w-4xl mx-auto w-full lg:px-10 sm:px-6 px-2">
-						{coordinatorTodos.length > 0 && (
+						{supervisorTodos.length > 0 && (
 							<TodoList
-								todos={coordinatorTodos}
+								todos={supervisorTodos}
 								className="mb-4 rounded-lg border border-border/50 bg-muted/30 p-4"
 							/>
 						)}

--- a/web/src/app/(protected)/agents/[id]/components/add-agent-subagent-dialog.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/add-agent-subagent-dialog.tsx
@@ -24,7 +24,7 @@ interface AddAgentSubagentDialogProps {
 
 interface AgentCandidateCardProps {
 	candidate: Agent;
-	coordinatorId: string;
+	supervisorId: string;
 	onAdd: (subagentId: string) => void;
 	disabled: boolean;
 	disabledReason?: string;
@@ -34,7 +34,7 @@ interface AgentCandidateCardProps {
 
 function AgentCandidateCard({
 	candidate,
-	coordinatorId,
+	supervisorId,
 	onAdd,
 	disabled,
 	disabledReason,
@@ -48,7 +48,7 @@ function AgentCandidateCard({
 		onSaving?.();
 		try {
 			await api.post(
-				`/agents/${coordinatorId}/subagents/${candidate.id}`,
+				`/agents/${supervisorId}/subagents/${candidate.id}`,
 				{},
 			);
 			onAdd(candidate.id);
@@ -161,7 +161,7 @@ export default function AddAgentSubagentDialog({
 								<AgentCandidateCard
 									key={candidate.id}
 									candidate={candidate}
-									coordinatorId={agent.id}
+									supervisorId={agent.id}
 									onAdd={handleSubagentAdded}
 									disabled={disabled}
 									disabledReason={disabledReason}

--- a/web/src/app/(protected)/agents/[id]/components/add-agent-tool-dialog.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/add-agent-tool-dialog.tsx
@@ -97,7 +97,7 @@ function BuiltInCapabilities({
 	onSaving?: () => void;
 	onSaved?: () => void;
 }) {
-	const [sandboxEnabled, setSandboxEnabled] = useState(agent.sandbox);
+	const [sandboxEnabled, setSandboxEnabled] = useState(agent.hasCodeInterpreter);
 
 	if (!sandboxAvailable) return null;
 
@@ -105,7 +105,7 @@ function BuiltInCapabilities({
 		setSandboxEnabled(checked);
 		onSaving?.();
 		try {
-			await api.patch(`/agents/${agent.id}`, { sandbox: checked });
+			await api.patch(`/agents/${agent.id}`, { hasCodeInterpreter: checked });
 			onSandboxToggled?.();
 			onSaved?.();
 		} catch (error) {

--- a/web/src/app/(protected)/agents/[id]/components/agent-code-execution.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-code-execution.tsx
@@ -36,7 +36,7 @@ export default function AgentCodeExecution({
 	const handleDisable = async () => {
 		onSaving?.();
 		try {
-			await api.patch(`/agents/${agent.id}`, { sandbox: false });
+			await api.patch(`/agents/${agent.id}`, { hasCodeInterpreter: false });
 			onUpdate?.();
 			onSaved?.();
 		} catch (error) {

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
@@ -44,7 +44,7 @@ export default function AgentToolList({
 		return allMCPServers.filter((server) => enabledIds.has(server.id));
 	}, [allMCPServers, agent.mcpServers]);
 
-	const hasTools = agent.sandbox || enabledServers.length > 0;
+	const hasTools = agent.hasCodeInterpreter || enabledServers.length > 0;
 
 	return (
 		<div className="flex flex-col min-h-0">
@@ -63,7 +63,7 @@ export default function AgentToolList({
 			<div className="flex-1 overflow-y-auto rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-card min-h-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 				{hasTools ? (
 					<>
-						{agent.sandbox && (
+						{agent.hasCodeInterpreter && (
 							<AgentCodeExecution
 								agent={agent}
 								onUpdate={refreshAgent}

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -14,7 +14,7 @@ interface AgentCardProps {
 }
 
 const PERMISSION_HIERARCHY: Record<AgentPermission, number> = {
-	user: 0,
+	member: 0,
 	editor: 1,
 	admin: 2,
 	owner: 3,
@@ -42,8 +42,8 @@ const ROLE_BADGE_CONFIG: Record<
 		text: "text-[#9A7B3C] dark:text-amber-300",
 		dot: "bg-[#C4A04E] dark:bg-amber-400",
 	},
-	user: {
-		label: "User",
+	member: {
+		label: "Member",
 		bg: "bg-[#EDEEE9] dark:bg-stone-800",
 		text: "text-[#7D8077] dark:text-stone-400",
 		dot: "bg-[#A3A79C] dark:bg-stone-500",
@@ -80,7 +80,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
 	}, [agent.mcpServers, mcpServers]);
 
 	const handleChat = () => {
-		if (!hasPermission(agent.currentUserPermission, "user")) {
+		if (!hasPermission(agent.currentUserPermission, "member")) {
 			alert("You don't have permission to chat with this agent.");
 			return;
 		}

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -19,7 +19,7 @@ const TABS = [
 		filter: (a: Agent) =>
 			a.currentUserPermission === "admin" ||
 			a.currentUserPermission === "editor" ||
-			a.currentUserPermission === "user",
+			a.currentUserPermission === "member",
 	},
 	{
 		key: "discover",

--- a/web/src/app/(protected)/agents/components/agent-permissions-dialog.tsx
+++ b/web/src/app/(protected)/agents/components/agent-permissions-dialog.tsx
@@ -14,7 +14,7 @@ import { SearchBar } from "@/components/ui/search-bar";
 import { SageButton } from "@/components/ui/sage-button";
 import { SageDropdownMenu } from "@/components/ui/sage-dropdown-menu";
 
-type PermissionLevel = "user" | "editor" | "admin";
+type PermissionLevel = "member" | "editor" | "admin";
 
 interface User {
 	id: string;
@@ -37,7 +37,7 @@ interface AgentPermissionsDialogProps {
 const PERMISSION_LABELS: Record<PermissionLevel, string> = {
 	admin: "Admin",
 	editor: "Editor",
-	user: "User",
+	member: "Member",
 };
 
 function getInitials(name: string | null): string {
@@ -109,7 +109,7 @@ export default function AgentPermissionsDialog({
 	}, [search, allUsers, permissions, ownerId]);
 
 	const addUser = (userId: string) => {
-		setPermissions((prev) => [...prev, { userId, permission: "user" }]);
+		setPermissions((prev) => [...prev, { userId, permission: "member" }]);
 		setSearch("");
 	};
 
@@ -256,7 +256,7 @@ export default function AgentPermissionsDialog({
 										items={[
 											{ label: "Admin", onClick: () => updatePermission(user.id, "admin"), active: user.permission === "admin" },
 											{ label: "Editor", onClick: () => updatePermission(user.id, "editor"), active: user.permission === "editor" },
-											{ label: "User", onClick: () => updatePermission(user.id, "user"), active: user.permission === "user" },
+											{ label: "Member", onClick: () => updatePermission(user.id, "member"), active: user.permission === "member" },
 										]}
 									/>
 								</div>

--- a/web/src/components/ai-elements/subagent.tsx
+++ b/web/src/components/ai-elements/subagent.tsx
@@ -50,7 +50,7 @@ function getTextFromMessage(msg: any): string {
 
 /**
  * Parse a tool name into server + tool parts.
- * Same fallback logic as the coordinator chat page.
+ * Same fallback logic as the supervisor chat page.
  */
 function parseToolName(name: string): { serverName: string; toolName: string } {
 	const sep = name.indexOf("_");
@@ -82,7 +82,7 @@ type ToolRenderState =
 
 /**
  * Renders the subagent's conversation as a mini log:
- * AI text paragraphs + Tool cards (same as coordinator).
+ * AI text paragraphs + Tool cards (same as supervisor).
  */
 interface MCPServerInfo {
 	name: string;
@@ -124,7 +124,7 @@ const SubAgentConversation = memo(({ messages, isStreaming, mcpServers }: { mess
 				);
 			}
 
-			// Render tool calls with the same Tool components as the coordinator
+			// Render tool calls with the same Tool components as the supervisor
 			{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 			toolCalls.forEach((tc: any, j: number) => {
 				const tcId = tc.id ?? `${msg.id}-tc-${j}`;
@@ -384,7 +384,7 @@ export const SubAgentProgress = memo(({ subagents }: SubAgentProgressProps) => {
 SubAgentProgress.displayName = "SubAgentProgress";
 
 // ---------------------------------------------------------------------------
-// SynthesisIndicator: shown while coordinator synthesizes after subagents
+// SynthesisIndicator: shown while supervisor synthesizes after subagents
 // ---------------------------------------------------------------------------
 
 interface SynthesisIndicatorProps {

--- a/web/src/types/agents.ts
+++ b/web/src/types/agents.ts
@@ -7,7 +7,7 @@ interface AgentMCPServer extends MCPServer {
 	tools: Record<string, ToolStatus> | null;
 }
 
-export type AgentPermission = "owner" | "admin" | "editor" | "user";
+export type AgentPermission = "owner" | "admin" | "editor" | "member";
 
 interface SubagentInfo {
 	id: string;
@@ -25,7 +25,7 @@ export interface Agent {
 	emoji?: string | null;
 	color?: string | null;
 	description?: string | null;
-	sandbox: boolean;
+	hasCodeInterpreter: boolean;
 	mcpServers: AgentMCPServer[];
 	subagents: SubagentInfo[];
 	isSubagent: boolean;


### PR DESCRIPTION
## Summary

Brings the codebase into compliance with `backend/CONVENTIONS.md` per the punch list in `backend/CONVENTIONS_RENAMES.md`. Three commits, each individually runnable:

1. **`docs: refine backend naming conventions`** — edits to `CONVENTIONS.md` (the spec).
2. **`refactor: align services, routers, and exceptions with CONVENTIONS.md`** — Batches 1, 2, 4, 5 of the punch list. Service methods drop the entity noun (`UserService.get_user` → `get`), connectivity probes use `probe_*` not `check_*`, assertion helpers use `_ensure_*`, `AgentRuntime` becomes `Agent` (old `Agent` dataclass → `ResolvedAgent`), `ValidationError` → `DomainValidationError`, `InvalidCredentialsError` / `NoInviteError` moved to `app/exceptions.py`, `AlreadyExistsError` handler returns 400 (matches §7 and tests), MCP route path params unified to `{server_id}`.
3. **`refactor: rename schema fields per CONVENTIONS.md + Alembic migrations`** — Batch 3. Four metadata-only, reversible migrations:
   - `users.hashed_password` → `password_hash`
   - `agents.sandbox` → `has_code_interpreter`
   - `agent_subagents.coordinator_id` → `supervisor_id` (indexes renamed too)
   - `PermissionLevel` enum value `user` → `member`

Frontend types and components updated to match (`hasCodeInterpreter`, `supervisorId`, `PermissionLevel.member`); axios interceptor handles snake_case conversion on the wire.

## Test plan

- [x] `uv run pytest` — 160/160 pass
- [x] `uv run ruff check app/ tests/` — no new errors (only pre-existing C408 warnings)
- [x] `uv run alembic upgrade head` — applies cleanly on dev DB
- [x] `uv run alembic downgrade c9a4f1d83b27 && uv run alembic upgrade head` — fully reversible
- [x] `pnpm tsc --noEmit` — no new errors (1 pre-existing `mcp-app-widget.tsx` error)
- [ ] Manual smoke (`make dev`): sign in, create agent and toggle `has_code_interpreter`, attach MCP server + sync tools + hit `/is-connected*`, run a streaming thread, add a subagent, invite + accept + revoke PAT

## Deployment notes

- Stop the backend before running `alembic upgrade head` — pods on the old code will break against renamed columns.
- Rollback: `alembic downgrade c9a4f1d83b27` reverts cleanly to the pre-refactor schema.
- Stale browser tabs need a hard refresh after deploy (old JS would send `sandbox` / `coordinatorId`).
- Pre-existing wart not touched: `agent_subagents` still carries constraint names from when the table was called `agent_subagent_bindings` (PK `agent_subagent_bindings_pkey`, FK `agent_subagent_bindings_coordinator_id_fkey`). Cosmetic only — doesn't affect functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes naming across backend and frontend per `backend/CONVENTIONS.md`, with consistent service verbs, probes, exceptions, and reversible Alembic renames. Also fixes MCP server API key/OAuth credential upserts to avoid unique constraint errors on repeat saves, and updates Codacy config to ignore tests in gitleaks.

- **Refactors**
  - Services use simple verbs: create/list/get across agents, users, threads, MCP servers, PATs, invites; routers updated; router helpers moved into services (e.g. MCP server get, invite response mapping).
  - Connectivity: `probe_*` replaces `check_*`; added `is_oauth_connected`; `check_mcp_server_connected` → `probe_mcp_server`.
  - Errors: `DomainValidationError` replaces `ValidationError`; `InvalidCredentialsError` and `NoInviteError` moved to `app/exceptions.py`; global handlers updated; `AlreadyExistsError` now returns 400.
  - Agents: `AgentRuntime` → `Agent`; previous `Agent` dataclass → `ResolvedAgent`; subagent naming uses “supervisor” with `list_*` methods.
  - Auth/PATs: PAT repo `get_by_token`; PAT service verbs `create/list/delete`; `_ensure_*` naming for assertions; JWT helper is `build_jwt_for_user`.
  - MCP servers: path params use `{server_id}`; repository upserts via `create_or_update_api_key`/`create_or_update_oauth_credentials` now update existing rows to prevent IntegrityError on repeat saves.
  - Frontend: adopts `hasCodeInterpreter`, `supervisorId`, and `PermissionLevel.member`; related components updated; `axios` interceptor handles snake_case/camelCase.
  - CI: top-level Codacy `exclude_paths` excludes `backend/tests/**` to avoid gitleaks false positives.

- **Migration**
  - Stop the backend, then run: `alembic upgrade head` (renames only; reversible). Rollback: `alembic downgrade c9a4f1d83b27`.
  - Columns/enums renamed: `users.password_hash`, `agents.has_code_interpreter`, `agent_subagents.supervisor_id`, `PermissionLevel.member`.
  - MCP server routes now use `{server_id}`; update any external clients.
  - After deploy, hard refresh any open frontend tabs.

<sup>Written for commit ffebf630ded012d24a204e59664fe06461b5d92f. Summary will update on new commits. <a href="https://cubic.dev/pr/keurcien/auxilia/pull/100?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

