### PR TITLE
Fix set_tokens for MCP that only provide refresh token on first auth

### DIFF
--- a/backend/app/mcp/client/storage.py
+++ b/backend/app/mcp/client/storage.py
@@ -92,6 +92,17 @@ class RedisTokenStorage(TokenStorage):
         return stored.token_payload
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
+        # Google only issues a refresh_token on the first authorization; refresh
+        # responses omit it. Carry the stored refresh_token forward so a silent
+        # refresh never wipes it (otherwise the next expiry forces a full re-auth).
+        if not tokens.refresh_token:
+            existing = await self.get_stored_token()
+            if existing and existing.token_payload.refresh_token:
+                tokens = tokens.model_copy(
+                    update={
+                        "refresh_token": existing.token_payload.refresh_token}
+                )
+
         expires_at: datetime | None = None
 
         if tokens.expires_in is not None:

--- a/backend/tests/mcp/client/test_storage.py
+++ b/backend/tests/mcp/client/test_storage.py
@@ -1,0 +1,86 @@
+from datetime import UTC, datetime
+
+import pytest
+from mcp.shared.auth import OAuthToken
+
+from app.mcp.client.storage import RedisTokenStorage
+
+
+class _FakeRedis:
+    """Minimal async Redis stand-in backed by a dict."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.store[key] = value
+
+
+def _storage() -> RedisTokenStorage:
+    return RedisTokenStorage("u1", "s1", redis=_FakeRedis())
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_refresh_token_preserves_stored_one():
+    """Google omits refresh_token on refresh; the stored one must survive."""
+    storage = _storage()
+
+    await storage.set_tokens(
+        OAuthToken(access_token="AT1", expires_in=3600, refresh_token="RT1")
+    )
+    # Simulate a Google refresh response: new access token, no refresh token.
+    await storage.set_tokens(OAuthToken(access_token="AT2", expires_in=3600))
+
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.access_token == "AT2"
+    assert tokens.refresh_token == "RT1"
+
+
+@pytest.mark.asyncio
+async def test_set_tokens_keeps_a_newly_issued_refresh_token():
+    """A genuinely new refresh_token must not be shadowed by the old one."""
+    storage = _storage()
+
+    await storage.set_tokens(
+        OAuthToken(access_token="AT1", expires_in=3600, refresh_token="RT1")
+    )
+    await storage.set_tokens(
+        OAuthToken(access_token="AT2", expires_in=3600, refresh_token="RT2")
+    )
+
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.refresh_token == "RT2"
+
+
+@pytest.mark.asyncio
+async def test_set_tokens_without_existing_token_stores_as_is():
+    """No prior token + no incoming refresh_token: store as-is, no crash."""
+    storage = _storage()
+
+    await storage.set_tokens(OAuthToken(access_token="AT1", expires_in=3600))
+
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.refresh_token is None
+
+
+@pytest.mark.asyncio
+async def test_set_tokens_updates_expiry_on_refresh():
+    """expires_at must track the refresh response's expires_in, not the old value."""
+    storage = _storage()
+
+    await storage.set_tokens(
+        OAuthToken(access_token="AT1", expires_in=10, refresh_token="RT1")
+    )
+    await storage.set_tokens(OAuthToken(access_token="AT2", expires_in=3600))
+
+    stored = await storage.get_stored_token()
+    assert stored is not None
+    assert stored.expires_at is not None
+    remaining = (stored.expires_at - datetime.now(UTC)).total_seconds()
+    assert remaining > 60


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves the stored refresh_token in MCP OAuth storage when providers (e.g., Google/BigQuery) omit it on refresh. Adds tests to ensure the token is retained on refresh, new refresh tokens override, and expiry updates correctly to avoid forced re-auth.

<sup>Written for commit 2e216ad18db1c72c36e32de6dc49d082ab000191. Summary will update on new commits. <a href="https://cubic.dev/pr/keurcien/auxilia/pull/101?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

