### PR TITLE
Add xiaomi models

### DIFF
--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -46,6 +46,13 @@ if model_provider_settings.google_api_key:
     MODELS.append(Model(name="gemini-3-flash-preview", provider="google"))
     MODELS.append(Model(name="gemini-3-pro-preview", provider="google"))
 
+if model_provider_settings.xiaomi_api_key:
+    LLM_PROVIDERS.append(ModelProvider(
+        name="xiaomi", api_key=model_provider_settings.xiaomi_api_key
+    ))
+    MODELS.append(Model(name="mimo-v2.5-pro", provider="xiaomi"))
+    MODELS.append(Model(name="mimo-v2.5", provider="xiaomi"))
+
 
 class ChatModelFactory:
 
@@ -77,6 +84,12 @@ class ChatModelFactory:
                     include_thoughts=True,
                     thinking_budget=-1,
                     api_key=api_key,
+                )
+            case "xiaomi":
+                return ChatOpenAI(
+                    base_url="https://api.xiaomimimo.com/v1",
+                    model=model_id,
+                    api_key=api_key
                 )
             case _:
                 raise ValueError(f"Provider {provider} not supported")

--- a/backend/app/model_providers/models.py
+++ b/backend/app/model_providers/models.py
@@ -7,3 +7,4 @@ class ModelProviderType(str, Enum):
     anthropic = "anthropic"
     google = "google"
     ollama = "ollama"
+    xiaomi = "xiaomi"

--- a/backend/app/model_providers/router.py
+++ b/backend/app/model_providers/router.py
@@ -63,5 +63,12 @@ async def get_models() -> list[ModelResponse]:
             ModelResponse(name="Gemini 3 Pro Preview", providers=[
                 ModelProviderType.google], id="gemini-3-pro-preview", chef="Google", chefSlug="google"),
         ])
+    if model_provider_settings.xiaomi_api_key:
+        models.extend([
+            ModelResponse(name="MiMo-V2.5-Pro", providers=[
+                      ModelProviderType.xiaomi], id="mimo-v2.5-pro", chef="Xiaomi", chefSlug="xiaomi"),
+            ModelResponse(name="MiMo-V2.5", providers=[
+                ModelProviderType.xiaomi], id="mimo-v2.5", chef="Xiaomi", chefSlug="xiaomi"),
+        ])
 
     return list(models)

--- a/backend/app/model_providers/settings.py
+++ b/backend/app/model_providers/settings.py
@@ -13,6 +13,7 @@ class ModelProviderSettings(BaseSettings):
     deepseek_api_key: str | None = None
     anthropic_api_key: str | None = None
     google_api_key: str | None = None
+    xiaomi_api_key: str | None = None
 
     model_config: ConfigDict = ConfigDict(
         env_file=ROOT_ENV,

--- a/web/src/components/ai-elements/model-selector.tsx
+++ b/web/src/components/ai-elements/model-selector.tsx
@@ -64,6 +64,7 @@ export type ModelSelectorLogoProps = Omit<
 		| "scaleway"
 		| "amazon-bedrock"
 		| "cerebras"
+		| "xiaomi"
 		| (string & {});
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for Xiaomi MiMo models. Users can choose MiMo V2.5 and V2.5 Pro when a Xiaomi API key is configured.

- **New Features**
  - Added Xiaomi provider with models: mimo-v2.5 and mimo-v2.5-pro.
  - Backend routes chat calls to https://api.xiaomimimo.com/v1 and exposes these models in the models API when the key is set.
  - Frontend model selector recognizes the xiaomi provider.

- **Migration**
  - Set xiaomi_api_key in environment/config to enable the models. No other changes needed.

<sup>Written for commit b4397ebfe4c41ac92c1729272ef24790e4f188c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/103?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

