### PR TITLE
Replace Slack agent button picker with a static_select dropdown

### DIFF
--- a/backend/app/integrations/slack/commands/chat.py
+++ b/backend/app/integrations/slack/commands/chat.py
@@ -17,11 +17,12 @@ from app.users.models import WorkspaceRole
 from app.users.repository import UserRepository
 
 
-# Slack caps an `actions` block at 25 elements, so each page shows at most 24
-# agent buttons and keeps the 25th slot free for the "Show more" button.
-PAGE_SIZE = 24
+# Slack caps a static_select at 100 options. Past that we'd need option groups
+# or an external_select; treat it as a soft ceiling and surface the truncation.
+MAX_OPTIONS = 100
 
 DEFAULT_PICKER_HEADER = "Choose an agent for this thread:"
+SELECT_AGENT_ACTION_ID = "select_agent"
 
 
 # ---------------------------------------------------------------------------
@@ -31,11 +32,7 @@ DEFAULT_PICKER_HEADER = "Choose an agent for this thread:"
 async def list_pickable_agents(
     db: AsyncSession, user_id: UUID, user_role: WorkspaceRole | None = None,
 ) -> list[AgentResponse]:
-    """Return the agents this user may pick, in a stable, paginated order.
-
-    Sorting by (name, id) keeps the order identical across the initial render
-    and every subsequent "Show more" click, so pagination stays consistent.
-    """
+    """Return the agents this user may pick, sorted by name."""
     all_agents = await AgentService(db).list(user_id=user_id, user_role=user_role)
     agents = [a for a in all_agents if a.current_user_permission is not None]
     agents.sort(key=lambda a: ((a.name or "").lower(), str(a.id)))
@@ -46,11 +43,9 @@ async def list_pickable_agents(
 # Block Kit builders
 # ---------------------------------------------------------------------------
 
-def _agent_button(agent: AgentResponse) -> dict:
+def _agent_option(agent: AgentResponse) -> dict:
     return {
-        "type": "button",
         "text": {"type": "plain_text", "text": f"{agent.emoji or ''} {agent.name}".strip()},
-        "action_id": f"select_agent:{agent.id}",
         "value": str(agent.id),
     }
 
@@ -58,35 +53,34 @@ def _agent_button(agent: AgentResponse) -> dict:
 def build_agent_picker_blocks(
     agents: list[AgentResponse],
     *,
-    shown: int = PAGE_SIZE,
     header_text: str = DEFAULT_PICKER_HEADER,
 ) -> list[dict]:
-    """Build the agent picker, revealing the first ``shown`` agents.
+    """Build the picker as a single static_select.
 
-    Agent buttons are chunked into ``actions`` blocks of ``PAGE_SIZE`` (Slack
-    caps each block at 25 elements). When more agents remain, a trailing
-    "Show more" button reveals the next ``PAGE_SIZE`` via the
-    ``load_more_agents:<count>`` action — each click accumulates onto the
-    agents already shown rather than replacing them.
+    A dropdown scrolls/filters natively and sidesteps Slack's button-overflow
+    UI (the "+ N more" chip that fights a paginated button grid in the
+    AI-assistant thread view). Slack caps options at ``MAX_OPTIONS``; beyond
+    that we render the first N and append a truncation note.
     """
-    visible = agents[:shown]
+    options = [_agent_option(a) for a in agents[:MAX_OPTIONS]]
     blocks: list[dict] = [
         {"type": "section", "text": {"type": "mrkdwn", "text": header_text}},
-    ]
-    for start in range(0, len(visible), PAGE_SIZE):
-        batch = visible[start:start + PAGE_SIZE]
-        blocks.append({"type": "actions", "elements": [_agent_button(a) for a in batch]})
-
-    if shown < len(agents):
-        next_shown = min(shown + PAGE_SIZE, len(agents))
-        remaining = len(agents) - shown
-        blocks.append({
+        {
             "type": "actions",
             "elements": [{
-                "type": "button",
-                "text": {"type": "plain_text", "text": f"➕ Show {remaining} more"},
-                "action_id": f"load_more_agents:{next_shown}",
-                "value": str(next_shown),
+                "type": "static_select",
+                "action_id": SELECT_AGENT_ACTION_ID,
+                "placeholder": {"type": "plain_text", "text": "Pick an agent…"},
+                "options": options,
+            }],
+        },
+    ]
+    if len(agents) > MAX_OPTIONS:
+        blocks.append({
+            "type": "context",
+            "elements": [{
+                "type": "mrkdwn",
+                "text": f"_Showing the first {MAX_OPTIONS} of {len(agents)} agents._",
             }],
         })
     return blocks
@@ -129,20 +123,23 @@ async def post_agent_picker(
 
 
 # ---------------------------------------------------------------------------
-# Interaction handler (agent button click)
+# Interaction handler (dropdown selection)
 # ---------------------------------------------------------------------------
 
 async def handle_agent_selection(payload: SlackInteractionPayload) -> None:
-    """Process an agent-selection button click.
+    """Process an agent-selection dropdown choice.
 
     Creates (or retrieves) the thread and replaces the picker message
     with a confirmation showing the chosen agent.
     """
     action = payload.actions[0]
-    agent_id = action.value
-
-    if not action.action_id.startswith("select_agent:"):
+    if action.action_id != SELECT_AGENT_ACTION_ID:
         return
+
+    selected = action.selected_option
+    if not selected:
+        return
+    agent_id = selected.value
 
     channel_id = (
         payload.channel.id if payload.channel
@@ -189,66 +186,3 @@ async def handle_agent_selection(payload: SlackInteractionPayload) -> None:
             channel=channel_id, ts=message_ts,
             blocks=blocks, text=f"{agent.emoji or ''} *{agent.name}*\n\nAsk me anything to begin.",
         )
-
-
-# ---------------------------------------------------------------------------
-# Interaction handler ("Show more" button click)
-# ---------------------------------------------------------------------------
-
-def _extract_header_text(payload: SlackInteractionPayload) -> str | None:
-    """Recover the picker's original header so re-renders keep the same greeting."""
-    blocks = payload.message.blocks if payload.message else []
-    for block in blocks:
-        if block.get("type") == "section":
-            text = block.get("text")
-            if isinstance(text, dict):
-                return text.get("text")
-    return None
-
-
-async def handle_load_more_agents(payload: SlackInteractionPayload) -> None:
-    """Reveal the next page of agents in-place when "Show more" is clicked.
-
-    Re-fetches the (permission-scoped, stably ordered) agent list and rebuilds
-    the picker showing the first ``shown`` agents — the count encoded in the
-    button — then updates the message so previously shown agents stay visible.
-    """
-    action = payload.actions[0]
-    if not action.action_id.startswith("load_more_agents:"):
-        return
-
-    try:
-        shown = int(action.value)
-    except (TypeError, ValueError):
-        return
-
-    channel_id = (
-        payload.channel.id if payload.channel
-        else payload.container.channel_id if payload.container
-        else None
-    )
-    message_ts = payload.container.message_ts if payload.container else None
-    if not channel_id or not message_ts:
-        return
-
-    # Resolve Slack user → internal user (the agent list is permission-scoped)
-    user_info = await get_user_info(payload.user.id)
-    if not user_info or not user_info.profile.email:
-        return
-    async with AsyncSessionLocal() as db:
-        user = await UserRepository(db).get_by_email(user_info.profile.email)
-    if not user:
-        return
-
-    async with AsyncSessionLocal() as db:
-        agents = await list_pickable_agents(db, user.id, user.role)
-    if not agents:
-        return
-
-    header_text = _extract_header_text(payload) or DEFAULT_PICKER_HEADER
-    blocks = build_agent_picker_blocks(agents, shown=shown, header_text=header_text)
-
-    client = AsyncWebClient(token=slack_settings.slack_bot_token)
-    await client.chat_update(
-        channel=channel_id, ts=message_ts, blocks=blocks, text="Choose an agent",
-    )

--- a/backend/app/integrations/slack/models.py
+++ b/backend/app/integrations/slack/models.py
@@ -48,10 +48,16 @@ class SlackEventPayload(BaseModel):
     event: SlackEvent | None = None
 
 
+class SlackSelectedOption(BaseModel):
+    """The option chosen from a static_select / overflow / radio interaction."""
+    value: str
+
+
 class SlackAction(BaseModel):
     """A single action from a block_actions interaction payload."""
     action_id: str
     value: str | None = None
+    selected_option: SlackSelectedOption | None = None
 
 
 class SlackInteractionChannel(BaseModel):

--- a/backend/app/integrations/slack/router.py
+++ b/backend/app/integrations/slack/router.py
@@ -12,10 +12,7 @@ from urllib.parse import parse_qs
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
-from app.integrations.slack.commands.chat import (
-    handle_agent_selection,
-    handle_load_more_agents,
-)
+from app.integrations.slack.commands.chat import handle_agent_selection
 from app.integrations.slack.handlers import (
     handle_assistant_thread_started,
     handle_interaction,
@@ -77,10 +74,8 @@ async def slack_interactions(body: bytes = Depends(verify_slack_signature)):
 
     if payload.type == "block_actions":
         action = payload.actions[0] if payload.actions else None
-        if action and action.action_id.startswith("select_agent:"):
+        if action and action.action_id == "select_agent":
             asyncio.create_task(handle_agent_selection(payload))
-        elif action and action.action_id.startswith("load_more_agents:"):
-            asyncio.create_task(handle_load_more_agents(payload))
         elif action and action.action_id in ("tool_approve", "tool_reject"):
             asyncio.create_task(handle_interaction(payload))
 

--- a/backend/tests/integrations/slack/test_chat.py
+++ b/backend/tests/integrations/slack/test_chat.py
@@ -1,9 +1,13 @@
-"""Unit tests for the paginated Slack agent picker (``build_agent_picker_blocks``)."""
+"""Unit tests for the Slack agent picker (``build_agent_picker_blocks``)."""
 
 from types import SimpleNamespace
 from uuid import uuid4
 
-from app.integrations.slack.commands.chat import PAGE_SIZE, build_agent_picker_blocks
+from app.integrations.slack.commands.chat import (
+    MAX_OPTIONS,
+    SELECT_AGENT_ACTION_ID,
+    build_agent_picker_blocks,
+)
 
 
 def _agents(n: int) -> list[SimpleNamespace]:
@@ -13,71 +17,62 @@ def _agents(n: int) -> list[SimpleNamespace]:
     ]
 
 
-def _action_blocks(blocks: list[dict]) -> list[dict]:
-    return [b for b in blocks if b["type"] == "actions"]
+def _select_element(blocks: list[dict]) -> dict:
+    for block in blocks:
+        if block.get("type") != "actions":
+            continue
+        for el in block.get("elements", []):
+            if el.get("type") == "static_select":
+                return el
+    raise AssertionError("no static_select found in blocks")
 
 
-def _elements(blocks: list[dict]) -> list[dict]:
-    return [el for b in _action_blocks(blocks) for el in b["elements"]]
+def _context_blocks(blocks: list[dict]) -> list[dict]:
+    return [b for b in blocks if b.get("type") == "context"]
 
 
-def _select_buttons(blocks: list[dict]) -> list[dict]:
-    return [
-        el for el in _elements(blocks) if el["action_id"].startswith("select_agent:")
-    ]
+def test_builds_one_static_select_with_one_option_per_agent():
+    blocks = build_agent_picker_blocks(_agents(7))
+
+    select = _select_element(blocks)
+    assert select["action_id"] == SELECT_AGENT_ACTION_ID
+    assert len(select["options"]) == 7
 
 
-def _show_more(blocks: list[dict]) -> dict | None:
-    more = [
-        el for el in _elements(blocks) if el["action_id"].startswith("load_more_agents:")
-    ]
-    return more[0] if more else None
+def test_option_value_is_agent_id():
+    agents = _agents(3)
+    options = _select_element(build_agent_picker_blocks(agents))["options"]
+
+    assert [o["value"] for o in options] == [str(a.id) for a in agents]
 
 
-def test_first_page_shows_one_batch_with_show_more_when_more_exist():
-    blocks = build_agent_picker_blocks(_agents(25))
+def test_option_text_includes_emoji_and_name():
+    agents = [SimpleNamespace(id=uuid4(), name="Bug-Data", emoji="🐛")]
+    options = _select_element(build_agent_picker_blocks(agents))["options"]
 
-    assert len(_select_buttons(blocks)) == PAGE_SIZE
-    more = _show_more(blocks)
-    assert more is not None
-    # Encodes the new cumulative count to reveal next.
-    assert more["action_id"] == f"load_more_agents:{PAGE_SIZE + 1}"
-    assert more["value"] == str(PAGE_SIZE + 1)
+    assert options[0]["text"]["text"] == "🐛 Bug-Data"
 
 
-def test_no_show_more_when_everything_fits_on_first_page():
-    blocks = build_agent_picker_blocks(_agents(PAGE_SIZE))
+def test_options_capped_at_slack_limit():
+    # Regression guard: Slack rejects a static_select with more than 100 options.
+    blocks = build_agent_picker_blocks(_agents(MAX_OPTIONS + 25))
 
-    assert len(_select_buttons(blocks)) == PAGE_SIZE
-    assert _show_more(blocks) is None
-
-
-def test_no_actions_block_exceeds_slack_limit():
-    # Regression guard: the original picker crammed every agent into a single
-    # actions block, which Slack rejects past 25 elements (the >25 agents bug).
-    blocks = build_agent_picker_blocks(_agents(120), shown=120)
-
-    for block in _action_blocks(blocks):
-        assert len(block["elements"]) <= 25
+    assert len(_select_element(blocks)["options"]) == MAX_OPTIONS
 
 
-def test_accumulates_previously_shown_agents():
-    blocks = build_agent_picker_blocks(_agents(100), shown=2 * PAGE_SIZE)
+def test_truncation_note_added_when_over_cap():
+    blocks = build_agent_picker_blocks(_agents(MAX_OPTIONS + 5))
 
-    # All agents revealed so far stay visible, not just the latest batch.
-    assert len(_select_buttons(blocks)) == 2 * PAGE_SIZE
-    more = _show_more(blocks)
-    assert more is not None
-    assert more["action_id"] == f"load_more_agents:{3 * PAGE_SIZE}"
+    notes = _context_blocks(blocks)
+    assert len(notes) == 1
+    assert f"{MAX_OPTIONS}" in notes[0]["elements"][0]["text"]
+    assert f"{MAX_OPTIONS + 5}" in notes[0]["elements"][0]["text"]
 
 
-def test_next_count_is_capped_at_total():
-    blocks = build_agent_picker_blocks(_agents(30), shown=PAGE_SIZE)
+def test_no_truncation_note_when_within_cap():
+    blocks = build_agent_picker_blocks(_agents(MAX_OPTIONS))
 
-    more = _show_more(blocks)
-    assert more is not None
-    assert more["action_id"] == "load_more_agents:30"
-    assert "6 more" in more["text"]["text"]
+    assert _context_blocks(blocks) == []
 
 
 def test_header_text_is_rendered():


### PR DESCRIPTION
## Problem

The paginated button picker shipped in #102 collides with Slack's own button-overflow UI in the AI-assistant thread. Slack collapses an `actions` block to ~5 visible buttons and injects its own `+ N more` chip for the rest. With pagination on top, users saw **two different `+ N more` controls** meaning different things:

- Slack's `+ 19 more` — expand the hidden buttons already in the current `actions` block.
- Our `+ Show 22 more` — load the next page from the backend.

The 25-element API limit is real but the *display* limit is far lower, so paginating by 24 doesn't actually solve the UX.

## Fix

Replace the button grid with a single Block Kit `static_select` (`Pick an agent…` dropdown). Slack natively supports up to **100 options** per `static_select` with scroll and typeahead — no overflow chip, no pagination, no conflict.

## Changes

- **`commands/chat.py`** — drop `PAGE_SIZE`, the chunked builder, `handle_load_more_agents`, and `_extract_header_text`. Rebuild `build_agent_picker_blocks` as a single `static_select` with one option per agent (capped at 100 with a context note past that). Update `handle_agent_selection` to read `action.selected_option.value` and exact-match the new `select_agent` action id.
- **`models.py`** — `SlackAction.selected_option` so the interaction payload model carries the dropdown's chosen option.
- **`router.py`** — remove the `load_more_agents:*` dispatch; exact-match `select_agent`.
- **`tests/integrations/slack/test_chat.py`** — rewrite for the dropdown builder, including a **100-option cap regression guard** and the truncation-note check.

Net: **−70 lines** across the four files.

## Testing

`uv run pytest tests/integrations/slack/test_chat.py --noconftest` — 7 passed. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the paginated Slack agent button grid with a single `static_select` dropdown to remove the conflicting "+ N more" UI and simplify agent selection.

- **Bug Fixes**
  - Swapped the button grid for one `static_select` (`select_agent`) with native scroll and typeahead; no Slack overflow chip or pagination.
  - Capped options at 100 (`MAX_OPTIONS`) and show a context note when truncated.

- **Refactors**
  - Removed pagination code and handlers (`PAGE_SIZE`, `handle_load_more_agents`, `_extract_header_text`); rebuilt `build_agent_picker_blocks`.
  - Updated interaction handling to read `selected_option.value`; router now exact-matches `select_agent`.
  - Added `SlackAction.selected_option`; refreshed tests for the dropdown and the 100-option cap guard.

<sup>Written for commit 80b988685c908e7c70866d82a0d6148f140abc75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/104?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

