### PR TITLE
Restore subagent thought process in thread history on refresh

### DIFF
--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -156,8 +156,12 @@ async def get_subagent_state(thread_id: str, tool_call_id: str) -> dict:
 
         # alist() with only thread_id walks every namespace's checkpoints
         # newest-first; the first time we see a namespace is its latest checkpoint.
+        # The subagent's seed message is `HumanMessage(content=description)`, so it
+        # equals the task call's description exactly — match strictly. A substring
+        # match would risk picking the wrong subagent when one description contains
+        # another.
         lc_messages: list = []
-        if description is not None:
+        if description:
             seen_ns: set[str] = set()
             async for ct in checkpointer.alist(
                 config={"configurable": {"thread_id": thread_id}}
@@ -167,8 +171,7 @@ async def get_subagent_state(thread_id: str, tool_call_id: str) -> dict:
                     continue
                 seen_ns.add(ns)
                 ns_messages = ct.checkpoint["channel_values"].get("messages", [])
-                seed = _seed_human_content(ns_messages)
-                if seed is not None and (seed == description or description in seed):
+                if _seed_human_content(ns_messages) == description:
                     lc_messages = ns_messages
                     break
 

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -110,27 +110,82 @@ async def read_thread(
         }
 
 
+def _task_description(messages: list, tool_call_id: str) -> str | None:
+    """Return the ``description`` arg of the ``task`` tool call with this id.
+
+    The subagent is seeded with a ``HumanMessage(content=description)``, so the
+    description is what links a parent tool call to its subgraph checkpoint.
+    """
+    for msg in messages:
+        for tc in getattr(msg, "tool_calls", None) or []:
+            if tc.get("id") == tool_call_id:
+                return (tc.get("args") or {}).get("description")
+    return None
+
+
+def _seed_human_content(messages: list) -> str | None:
+    """Return the text content of a subgraph's seed (first) message, if any."""
+    if not messages:
+        return None
+    content = getattr(messages[0], "content", None)
+    return content if isinstance(content, str) else None
+
+
 @router.get("/{thread_id}/subagents/{tool_call_id}/state")
 async def get_subagent_state(thread_id: str, tool_call_id: str) -> dict:
-    """Fetch a subagent's checkpoint state (its internal messages) by tool call ID."""
+    """Fetch a subagent's checkpoint state (its internal messages) by tool call ID.
+
+    A subagent runs as a Pregel subgraph whose checkpoint namespace is keyed by an
+    internal task id — not the ``tool_call_id`` used to invoke it. So we can't look
+    it up directly. Instead we resolve the namespace the way the frontend SDK does
+    while streaming: match the ``task`` tool call's ``description`` against each
+    subgraph checkpoint's seed message.
+    """
     async with get_checkpointer() as checkpointer:
-        checkpoint = await checkpointer.aget(
-            config={
-                "configurable": {
-                    "thread_id": thread_id,
-                    "checkpoint_ns": f"tools:{tool_call_id}",
-                }
-            }
+        # The task call's description lives in the parent (root-namespace) state.
+        parent = await checkpointer.aget_tuple(
+            config={"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        )
+        description = (
+            _task_description(
+                parent.checkpoint["channel_values"].get("messages", []), tool_call_id
+            )
+            if parent
+            else None
         )
 
-        if not checkpoint:
-            return {"messages": [], "values": {}}
+        # alist() with only thread_id walks every namespace's checkpoints
+        # newest-first; the first time we see a namespace is its latest checkpoint.
+        lc_messages: list = []
+        if description is not None:
+            seen_ns: set[str] = set()
+            async for ct in checkpointer.alist(
+                config={"configurable": {"thread_id": thread_id}}
+            ):
+                ns = ct.config["configurable"].get("checkpoint_ns") or ""
+                if not ns or ns in seen_ns:
+                    continue
+                seen_ns.add(ns)
+                ns_messages = ct.checkpoint["channel_values"].get("messages", [])
+                seed = _seed_human_content(ns_messages)
+                if seed is not None and (seed == description or description in seed):
+                    lc_messages = ns_messages
+                    break
 
-        channel_values = checkpoint["channel_values"]
-        lc_messages = channel_values.get("messages", [])
-        return {
-            "messages": [_serialize_lc_message(m) for m in lc_messages],
-        }
+        # Legacy fallback: threads that stored state under tools:{tool_call_id}.
+        if not lc_messages:
+            checkpoint = await checkpointer.aget(
+                config={
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": f"tools:{tool_call_id}",
+                    }
+                }
+            )
+            if checkpoint:
+                lc_messages = checkpoint["channel_values"].get("messages", [])
+
+        return {"messages": [_serialize_lc_message(m) for m in lc_messages]}
 
 
 @router.get("/")

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -220,6 +220,47 @@ type LocalToolCall = {
 	state: "pending" | "completed" | "error";
 };
 
+// The LangGraph SDK reconstructs subagent containers from history, but it reads
+// LangChain's snake_case keys (`tool_calls`, `tool_call_id`, `args.subagent_type`).
+// Our axios response interceptor camelCases API payloads, so messages loaded via
+// GET /threads/{id} arrive as `toolCalls` / `toolCallId` / `args.subagentType` and
+// the SDK builds zero subagents. Restore the snake_case shape the SDK expects
+// before handing it the initial values. Streaming is unaffected (SSE bypasses the
+// interceptor and is already snake_case).
+function toSdkMessages(messages: LCMessage[]): LCMessage[] {
+	return messages.map((msg) => {
+		const m = msg as unknown as Record<string, unknown>;
+		const out: Record<string, unknown> = { ...m };
+
+		if ("toolCallId" in out) {
+			out.tool_call_id = out.toolCallId;
+			delete out.toolCallId;
+		}
+
+		const toolCalls = (m.toolCalls ?? m.tool_calls) as
+			| Array<Record<string, unknown>>
+			| undefined;
+		if (Array.isArray(toolCalls)) {
+			out.tool_calls = toolCalls.map((tc) => {
+				// Subagent (task) args carry `subagent_type`; the interceptor
+				// camelCased it to `subagentType`. Restore it so the SDK's
+				// isValidSubagentType() check passes during reconstruction.
+				if (tc.name === "task" && tc.args && typeof tc.args === "object") {
+					const args = tc.args as Record<string, unknown>;
+					return {
+						...tc,
+						args: { ...args, subagent_type: args.subagent_type ?? args.subagentType },
+					};
+				}
+				return tc;
+			});
+			delete out.toolCalls;
+		}
+
+		return out as unknown as LCMessage;
+	});
+}
+
 function computeToolCallsFromMessages(messages: LCMessage[]): LocalToolCall[] {
 	// Axios camelCase interceptor converts snake_case keys from the API:
 	//   tool_call_id → toolCallId, tool_calls → toolCalls
@@ -364,6 +405,13 @@ const ChatPage = () => {
 	const [rehydratedInterrupt, setRehydratedInterrupt] = useState(false);
 	const [rehydratedInterruptValue, setRehydratedInterruptValue] =
 		useState<unknown>(null);
+	// Subagent internal conversations restored from subgraph checkpoints on
+	// refresh, keyed by tool_call_id. The SDK's custom transport doesn't expose a
+	// way to inject these into the reconstructed subagents, so we hold them here
+	// and pass them to SubAgentCard as a fallback.
+	const [subagentMessages, setSubagentMessages] = useState<
+		Record<string, unknown[]>
+	>({});
 
 	const { mcpServers } = useMcpServersStore();
 	const {
@@ -607,12 +655,6 @@ const ChatPage = () => {
 
 		hasFetchedSubagentHistory.current = true;
 
-		// Access the private subagentManager to call updateSubagentFromSubgraphState
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const streamManager = thread as any;
-		const subagentManager =
-			streamManager.subagentManager ?? streamManager._subagentManager;
-
 		Promise.all(
 			toFetch.map(async ([toolCallId]) => {
 				try {
@@ -621,16 +663,7 @@ const ChatPage = () => {
 					);
 					const msgs = res.data?.messages;
 					if (!Array.isArray(msgs) || msgs.length === 0) return;
-
-					if (subagentManager?.updateSubagentFromSubgraphState) {
-						subagentManager.updateSubagentFromSubgraphState(toolCallId, msgs);
-					} else {
-						// Fallback: mutate the subagent entry directly
-						const sub = subagentApi.getSubagent(toolCallId);
-						if (sub && sub.messages.length === 0) {
-							sub.messages = msgs;
-						}
-					}
+					setSubagentMessages((prev) => ({ ...prev, [toolCallId]: msgs }));
 				} catch {
 					// Subgraph checkpoint may not exist — ignore
 				}
@@ -675,16 +708,23 @@ const ChatPage = () => {
 				}
 			}
 
+			const values = data.values || { messages: [] };
+			// Restore snake_case message keys so the SDK can reconstruct subagents.
+			const normalizedValues = {
+				...values,
+				messages: toSdkMessages((values.messages ?? []) as LCMessage[]),
+			};
+
 			const pendingMessage = consumePendingMessage(threadId);
 			if (pendingMessage) {
 				// Set initial values first so submit has proper history base
-				setInitialValues(data.values || { messages: [] });
+				setInitialValues(normalizedValues);
 				// Defer submit to next tick so initialValues takes effect
 				setTimeout(() => {
 					handleSubmit(pendingMessage);
 				}, 0);
 			} else {
-				setInitialValues(data.values || { messages: [] });
+				setInitialValues(normalizedValues);
 			}
 		};
 
@@ -955,6 +995,7 @@ const ChatPage = () => {
 															key={sub.id}
 															subagent={sub}
 															mcpServers={mcpServers}
+															fallbackMessages={subagentMessages[sub.id]}
 														/>
 													))}
 													<SynthesisIndicator

--- a/web/src/components/ai-elements/subagent.tsx
+++ b/web/src/components/ai-elements/subagent.tsx
@@ -239,9 +239,14 @@ interface SubAgentCardProps {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	subagent: SubagentStreamInterface<any, any, any>;
 	mcpServers?: MCPServerInfo[];
+	// Internal conversation restored from the subgraph checkpoint on refresh.
+	// The SDK can't inject these into the (reconstructed) subagent via the custom
+	// transport, so the page fetches them separately and passes them here.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	fallbackMessages?: any[];
 }
 
-export const SubAgentCard = memo(({ subagent, mcpServers }: SubAgentCardProps) => {
+export const SubAgentCard = memo(({ subagent, mcpServers, fallbackMessages }: SubAgentCardProps) => {
 	const { status, toolCall, result, startedAt, completedAt, messages, values } =
 		subagent;
 	const isStreaming = status === "running";
@@ -265,7 +270,9 @@ export const SubAgentCard = memo(({ subagent, mcpServers }: SubAgentCardProps) =
 		if (isStreaming) setIsOpen(true);
 	}, [isStreaming, setIsOpen]);
 
-	const hasConversation = messages && messages.length > 0;
+	const convoMessages =
+		messages && messages.length > 0 ? messages : (fallbackMessages ?? []);
+	const hasConversation = convoMessages.length > 0;
 	const hasBody =
 		description || todos.length > 0 || hasConversation || result || isError;
 
@@ -320,7 +327,7 @@ export const SubAgentCard = memo(({ subagent, mcpServers }: SubAgentCardProps) =
 							{todos.length > 0 && <TodoList todos={todos} />}
 							{hasConversation && (
 								<SubAgentConversation
-									messages={messages}
+									messages={convoMessages}
 									isStreaming={isStreaming}
 									mcpServers={mcpServers}
 								/>


### PR DESCRIPTION
## Problem

A coordinator agent's subagent reasoning and tool calls render fine **during streaming**, but **on refresh** they disappeared — the subagent container collapsed to just the supervisor's raw `task` tool call. The subagent "thought process" was effectively lost after reload even though it's persisted in the checkpointer.

## Root causes (three, across the stack)

1. **camelCase mismatch.** The LangGraph SDK reconstructs subagent containers from thread history using LangChain's snake_case keys (`tool_calls`, `tool_call_id`, `args.subagent_type`). Our axios response interceptor camelCases all API payloads, so on refresh the history arrived as `toolCalls` / `args.subagentType` and the SDK built **zero** subagents. Streaming works because SSE bypasses the interceptor.

2. **Wrong checkpoint namespace.** `GET /threads/{id}/subagents/{tool_call_id}/state` looked up `checkpoint_ns=f"tools:{tool_call_id}"` directly, but a subagent subgraph's namespace is keyed by an internal **pregel task id**, not the `tool_call_id` — so the lookup was always empty.

3. **Fetched internals discarded.** The custom `useStream` transport doesn't expose `subagentManager`, so the fetch effect's `updateSubagentFromSubgraphState` call fell through to a fallback that mutated a throwaway copy. The fetched messages never reached the rendered card.

## Fixes

- **`web/.../chat/[threadId]/page.tsx`**
  - `toSdkMessages()` restores snake_case message keys before passing history to `useStream`, so the SDK can reconstruct containers.
  - Fetched subagent conversations are held in a `subagentMessages` state (keyed by tool_call_id) and passed to `SubAgentCard` via a new `fallbackMessages` prop.
- **`web/src/components/ai-elements/subagent.tsx`** — `SubAgentCard` accepts `fallbackMessages` and uses it for the internal conversation when `subagent.messages` is empty (the refresh case).
- **`backend/app/threads/router.py`** — `/subagents/{tool_call_id}/state` resolves the subgraph namespace by matching the `task` call's `description` against each subgraph checkpoint's seed message (via `checkpointer.alist`), with a legacy direct lookup as fallback.

## Verification

Confirmed against a real thread (`inspect_subagent_checkpoints.py`, a local-only diagnostic): a simple subagent's tool-call turns live in its top-level `tools:<id>` namespace and now render in the container on refresh (description, internal tool calls, and final summary).

## Known limitation

If a subagent is *itself* a deep agent, its inner tool loop checkpoints under deeper nested namespaces, which this PR does not yet merge. Not handled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores subagent reasoning and tool-call history after page refresh so the full conversation appears, not just the parent `task` call. Normalizes message keys and resolves the correct subgraph checkpoint the same way streaming does.

- **Bug Fixes**
  - Normalize loaded history to snake_case (`tool_calls`, `tool_call_id`, `args.subagent_type`) before passing it to the SDK.
  - Resolve subagent checkpoint by strictly matching the `task` description to the subgraph’s seed HumanMessage (non-empty), with a legacy `tools:{tool_call_id}` fallback.
  - Store fetched subagent conversations in page state and pass them to `SubAgentCard` via `fallbackMessages` when the reconstructed subagent has no messages.

<sup>Written for commit d1a86b30807e445ae29fa65e5fecd19b8515d7dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/105?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

