### PR TITLE
Add Google Calendar MCP server support

### DIFF
--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -24,6 +24,8 @@ def build_oauth_client_metadata(mcp_server: dict) -> OAuthClientMetadata:
         scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/gmail.modify"
     elif mcp_server.name == "Google Sheets":
         scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive"
+    elif mcp_server.name == "Calendar":
+        scope = "openid https://www.googleapis.com/auth/calendar.calendarlist.readonly https://www.googleapis.com/auth/calendar.events.freebusy https://www.googleapis.com/auth/calendar.events.readonly"
     else:
         scope = "user"
 

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -33,7 +33,8 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
 
     async def create(self, data: MCPServerCreate) -> MCPServerDB:
         if data.auth_type == MCPAuthType.api_key and not data.api_key:
-            raise DomainValidationError("API key is required when auth_type is 'api_key'")
+            raise DomainValidationError(
+                "API key is required when auth_type is 'api_key'")
 
         db_server = await self.repository.create(data)
 
@@ -71,7 +72,8 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
     async def list_official(self) -> list[OfficialMCPServerResponse]:
         rows = await self.repository.list_official()
         return [
-            OfficialMCPServerResponse(**row[0].model_dump(), is_installed=row[1])
+            OfficialMCPServerResponse(
+                **row[0].model_dump(), is_installed=row[1])
             for row in rows
         ]
 
@@ -198,8 +200,10 @@ async def connect_to_server(mcp_server: MCPServerDB, user_id: str, db: AsyncSess
 
                 if mcp_server.url == "https://bigquery.googleapis.com/mcp":
                     await session.call_tool("list_dataset_ids", {"project_id": os.getenv("GCLOUD_PROJECT")})
-
+                elif mcp_server.url == "https://calendarmcp.googleapis.com/mcp/v1":
+                    await session.call_tool("list_calendars", {})
                 yield session, tools
+
             except Exception as e:
                 raise DomainError(str(e)) from e
 

--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -79,7 +79,7 @@ class ChatModelFactory:
                 return ChatAnthropic(
                     model=model_id,
                     temperature=1,
-                    max_tokens=16384,
+                    max_tokens=32768,
                     streaming=True,
                     timeout=None,
                     max_retries=2,


### PR DESCRIPTION
Wires up a Google Calendar MCP server, plus a small Anthropic output-limit bump that was sitting in the working tree.

## Changes

- **`app/mcp/client/auth.py`** — Request Google Calendar read scopes when connecting the `"Calendar"` MCP server: `calendar.calendarlist.readonly`, `calendar.events.freebusy`, `calendar.events.readonly`.
- **`app/mcp/servers/service.py`** — Warm up the Calendar connection with a `list_calendars` call on connect for `https://calendarmcp.googleapis.com/mcp/v1`, mirroring the existing BigQuery `list_dataset_ids` probe. (Also minor line-wrap reformatting, no behavior change.)
- **`app/model_providers/catalog.py`** — Bump `ChatAnthropic` `max_tokens` from 16384 → 32768 so large responses are less likely to be truncated.

## Notes

Split out of the invalid-tool-call recovery PR (#108) — these were unrelated working-tree changes. The `max_tokens` bump is loosely related (truncation was one suspected trigger for malformed tool-call JSON), but it's an independent change so it lives here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Calendar MCP server support with read-only OAuth scopes and a connection warm-up that lists calendars. Also raises `ChatAnthropic` `max_tokens` to reduce response truncation.

- **New Features**
  - Request Calendar scopes on connect: `calendar.calendarlist.readonly`, `calendar.events.freebusy`, `calendar.events.readonly`.
  - Warm up Calendar MCP at `https://calendarmcp.googleapis.com/mcp/v1` by calling `list_calendars` on connect (mirrors BigQuery probe).
  - Increase `ChatAnthropic` `max_tokens` from 16384 to 32768.

<sup>Written for commit e96345a269007291f85b0162f78197a321f10d90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

