### PR TITLE
Add output_schema support to /runs/invoke for structured responses

### DIFF
--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -31,6 +31,7 @@ from app.agents.stream import (
     SlackStreamAdapter,
     encode_synthetic_ai_message_sse,
 )
+from app.agents.structured_output import DeferredStructuredOutputMiddleware
 from app.agents.tool_errors import RepairInvalidToolCallsMiddleware, ToolErrorMiddleware
 from app.agents.toolset import Toolset, sanitize_tool_name
 from app.database import get_checkpointer
@@ -46,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 RECURSION_LIMIT_MESSAGE = (
     "I reached my step limit for this turn. Send any follow-up message "
-    "(e.g. \"continue\") and I'll pick up where I left off."
+    '(e.g. "continue") and I\'ll pick up where I left off.'
 )
 
 
@@ -112,9 +113,7 @@ class ResolvedAgent:
                 model=model,
                 tools=self.toolset.all,
                 system_prompt=SystemMessage(
-                    content=[
-                        {"type": "text", "text": self.config.instructions or ""}
-                    ]
+                    content=[{"type": "text", "text": self.config.instructions or ""}]
                 ),
             )
 
@@ -148,7 +147,7 @@ class Agent:
             "user_id": self.thread.user_id,
             "thread_id": self.thread.id,
             "agent_id": self.thread.agent_id,
-            "langfuse_session_id": self.thread.id
+            "langfuse_session_id": self.thread.id,
         }
 
     @property
@@ -168,10 +167,11 @@ class Agent:
     ) -> "Agent":
         user_id = str(thread.user_id)
 
-        agent = await ResolvedAgent.resolve(thread.agent_id, db, user_id, is_parent=True)
+        agent = await ResolvedAgent.resolve(
+            thread.agent_id, db, user_id, is_parent=True
+        )
 
-        model_entry = next(
-            (m for m in MODELS if m.name == thread.model_id), None)
+        model_entry = next((m for m in MODELS if m.name == thread.model_id), None)
         if model_entry is None:
             raise DomainValidationError(f"Unknown model: {thread.model_id}")
         provider = next(
@@ -196,8 +196,9 @@ class Agent:
         # tool_calls answered by error ToolMessages.
         middleware = [
             PatchToolCallsMiddleware(),
-            ToolCallLimitMiddleware(run_limit=(
-                agent_settings.recursion_limit - 1) // 2, exit_behavior="end"),
+            ToolCallLimitMiddleware(
+                run_limit=(agent_settings.recursion_limit - 1) // 2, exit_behavior="end"
+            ),
             RepairInvalidToolCallsMiddleware(),
             HumanInTheLoopMiddleware(
                 interrupt_on=agent.toolset.interrupt_on,
@@ -227,9 +228,9 @@ class Agent:
         """Build the LangGraph agent (deep or standard) with the given checkpointer.
 
         `output_schema` is a raw JSON Schema dict passed to langchain as
-        `response_format`: the provider's native structured output is used when
-        the model supports it, with a forced tool call as fallback. The parsed
-        result surfaces in the run state under `structured_response`.
+        `response_format`. DeferredStructuredOutputMiddleware keeps the schema
+        off the tool-calling loop and applies it on one final formatting turn;
+        the parsed result surfaces in the run state under `structured_response`.
         """
         if self.agent.config.has_code_interpreter and sandbox_settings.enabled:
             return self._build_deep_agent(checkpointer, output_schema)
@@ -240,6 +241,8 @@ class Agent:
             middleware.append(
                 SubAgentMiddleware(backend=StateBackend, subagents=compiled)
             )
+        if output_schema is not None:
+            middleware.append(DeferredStructuredOutputMiddleware())
 
         return create_agent(
             model=self.model,
@@ -299,8 +302,7 @@ class Agent:
     async def _persist_recursion_fallback(self, agent, config) -> AIMessage:
         """Persist a synthetic AI message after a GraphRecursionError so the
         next turn can pick up where we left off. Returns the message."""
-        logger.info(
-            "Graph recursion limit reached; persisting synthetic AI message")
+        logger.info("Graph recursion limit reached; persisting synthetic AI message")
         ai_msg = AIMessage(content=RECURSION_LIMIT_MESSAGE, id=str(uuid4()))
         await agent.aupdate_state(config, {"messages": [ai_msg]})
         return ai_msg
@@ -401,8 +403,7 @@ class Agent:
         sandbox_tools = create_sandbox_tools(lazy_backend)
 
         compiled_subagents = (
-            [s.compile(self.model)
-             for s in self.subagents] if self.subagents else None
+            [s.compile(self.model) for s in self.subagents] if self.subagents else None
         )
 
         # create_deep_agent injects its own PatchToolCallsMiddleware; passing
@@ -410,6 +411,8 @@ class Agent:
         extra_middleware = [
             m for m in self.middleware if not isinstance(m, PatchToolCallsMiddleware)
         ]
+        if output_schema is not None:
+            extra_middleware.append(DeferredStructuredOutputMiddleware())
 
         return create_deep_agent(
             model=self.model,

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -223,10 +223,16 @@ class Agent:
             subagents=subagents,
         )
 
-    def _build_agent(self, checkpointer):
-        """Build the LangGraph agent (deep or standard) with the given checkpointer."""
+    def _build_agent(self, checkpointer, output_schema: dict | None = None):
+        """Build the LangGraph agent (deep or standard) with the given checkpointer.
+
+        `output_schema` is a raw JSON Schema dict passed to langchain as
+        `response_format`: the provider's native structured output is used when
+        the model supports it, with a forced tool call as fallback. The parsed
+        result surfaces in the run state under `structured_response`.
+        """
         if self.agent.config.has_code_interpreter and sandbox_settings.enabled:
-            return self._build_deep_agent(checkpointer)
+            return self._build_deep_agent(checkpointer, output_schema)
 
         middleware = list(self.middleware)
         if self.subagents:
@@ -241,6 +247,7 @@ class Agent:
             system_prompt=SystemMessage(self.agent.config.instructions),
             checkpointer=checkpointer,
             middleware=middleware,
+            response_format=output_schema,
         )
 
     def _resolve_input(self, agent_input: dict | None, command: dict | None):
@@ -275,6 +282,7 @@ class Agent:
         command: dict | None,
         trigger: str | None,
         config_overrides: dict | None,
+        output_schema: dict | None = None,
     ):
         """Open a checkpointer scope and yield (agent, resolved_input, config).
 
@@ -283,7 +291,7 @@ class Agent:
         run config in one place.
         """
         async with get_checkpointer() as checkpointer:
-            agent = self._build_agent(checkpointer)
+            agent = self._build_agent(checkpointer, output_schema)
             resolved_input = self._resolve_input(agent_input, command)
             config = await self._resolve_config(agent, trigger, config_overrides)
             yield agent, resolved_input, config
@@ -353,9 +361,16 @@ class Agent:
         command: dict | None = None,
         trigger: str | None = None,
         config_overrides: dict | None = None,
+        output_schema: dict | None = None,
     ) -> dict:
-        """Run the agent to completion and return the text of the last AI message."""
-        async with self._setup(agent_input, command, trigger, config_overrides) as (
+        """Run the agent to completion and return the text of the last AI message.
+
+        With `output_schema`, the final answer is also returned as a parsed
+        object under `structured_response`.
+        """
+        async with self._setup(
+            agent_input, command, trigger, config_overrides, output_schema
+        ) as (
             agent,
             resolved_input,
             config,
@@ -364,13 +379,16 @@ class Agent:
                 result = await agent.ainvoke(resolved_input, config=config)
             except GraphRecursionError:
                 ai_msg = await self._persist_recursion_fallback(agent, config)
-                return {"content": ai_msg.content}
+                return {"content": ai_msg.content, "structured_response": None}
 
             messages = result.get("messages", [])
             last = messages[-1] if messages else None
-            return {"content": _extract_text(last) if last else ""}
+            return {
+                "content": _extract_text(last) if last else "",
+                "structured_response": result.get("structured_response"),
+            }
 
-    def _build_deep_agent(self, checkpointer):
+    def _build_deep_agent(self, checkpointer, output_schema: dict | None = None):
         """Build a deep agent with lazy sandbox backend for code execution.
 
         The sandbox is not created here — the LLM calls create_sandbox or
@@ -401,6 +419,7 @@ class Agent:
             middleware=[*extra_middleware, ToolErrorMiddleware()],
             subagents=compiled_subagents,
             checkpointer=checkpointer,
+            response_format=output_schema,
         )
 
 

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -31,7 +31,10 @@ from app.agents.stream import (
     SlackStreamAdapter,
     encode_synthetic_ai_message_sse,
 )
-from app.agents.structured_output import DeferredStructuredOutputMiddleware
+from app.agents.structured_output import (
+    DeferredStructuredOutputMiddleware,
+    is_structured_output_artifact,
+)
 from app.agents.tool_errors import RepairInvalidToolCallsMiddleware, ToolErrorMiddleware
 from app.agents.toolset import Toolset, sanitize_tool_name
 from app.database import get_checkpointer
@@ -383,8 +386,16 @@ class Agent:
                 ai_msg = await self._persist_recursion_fallback(agent, config)
                 return {"content": ai_msg.content, "structured_response": None}
 
-            messages = result.get("messages", [])
-            last = messages[-1] if messages else None
+            # Skip formatting-turn artifacts so `content` is the prose answer
+            # on every provider path (the parsed object has its own field).
+            last = next(
+                (
+                    m
+                    for m in reversed(result.get("messages", []))
+                    if not is_structured_output_artifact(m)
+                ),
+                None,
+            )
             return {
                 "content": _extract_text(last) if last else "",
                 "structured_response": result.get("structured_response"),

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -21,18 +21,25 @@ The synthetic formatting instruction is only part of the model request, never
 of the returned messages, so it does not pollute the thread history. The
 agent must still be built with ``response_format`` set — that is what registers
 the structured-output machinery this middleware re-enables on the last turn.
+
+Every message the formatting turn produces is tagged with
+``STRUCTURED_OUTPUT_FLAG`` in ``response_metadata`` (checkpointed, but never
+sent back to the provider), so read paths can recognize formatting artifacts —
+the raw-JSON message on the provider-native path, the synthetic tool-call pair
+on the ToolStrategy path — and keep them out of the rendered chat history.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     ModelRequest,
     ModelResponse,
 )
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
 
 FORMAT_INSTRUCTION = (
@@ -40,6 +47,25 @@ FORMAT_INSTRUCTION = (
     "structured format. Use only information from this conversation; do not "
     "invent values."
 )
+
+STRUCTURED_OUTPUT_FLAG = "auxilia_structured_output"
+
+
+def is_structured_output_artifact(message: Any) -> bool:
+    """True for messages produced by the formatting turn (chat-history noise)."""
+    metadata = getattr(message, "response_metadata", None) or {}
+    return bool(metadata.get(STRUCTURED_OUTPUT_FLAG))
+
+
+def _tag(message: BaseMessage) -> BaseMessage:
+    return message.model_copy(
+        update={
+            "response_metadata": {
+                **message.response_metadata,
+                STRUCTURED_OUTPUT_FLAG: True,
+            }
+        }
+    )
 
 
 class DeferredStructuredOutputMiddleware(AgentMiddleware):
@@ -78,6 +104,6 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
         )
         format_response = await handler(format_request)
         return ModelResponse(
-            result=[*response.result, *format_response.result],
+            result=[*response.result, *(_tag(m) for m in format_response.result)],
             structured_response=format_response.structured_response,
         )

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -1,0 +1,78 @@
+"""Defer structured output to a final formatting turn so the agent keeps its tools.
+
+Binding ``response_format`` on every model call (what ``create_agent`` does by
+default) breaks the ReAct loop in practice: with the provider's constrained
+decoding active, the model goes straight to emitting schema-conforming JSON
+instead of calling tools — and, having gathered nothing, fills the schema with
+fabricated values.
+
+``DeferredStructuredOutputMiddleware`` keeps the schema out of the loop:
+
+1. Every model call runs with ``response_format`` stripped, so the model calls
+   tools and reasons exactly as it would without a schema.
+2. When a call produces no tool calls (the final answer), one extra model call
+   is made — same conversation plus a formatting instruction — with the
+   original ``response_format`` restored. langchain's strategy resolution
+   (provider-native vs. forced tool call) applies only to that turn, and the
+   parsed result flows through the normal ``structured_response`` channel, so
+   it is checkpointed and returned in the run state like any other update.
+
+The synthetic formatting instruction is only part of the model request, never
+of the returned messages, so it does not pollute the thread history. The
+agent must still be built with ``response_format`` set — that is what registers
+the structured-output machinery this middleware re-enables on the last turn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+FORMAT_INSTRUCTION = (
+    "Based on your answer above, provide the final response in the requested "
+    "structured format. Use only information from this conversation; do not "
+    "invent values."
+)
+
+
+class DeferredStructuredOutputMiddleware(AgentMiddleware):
+    """Apply ``response_format`` only on a final formatting turn."""
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        if request.response_format is None:
+            return await handler(request)
+
+        # Loop turn: run unconstrained so the model can freely call tools.
+        response = await handler(request.override(response_format=None))
+        has_tool_calls = any(
+            isinstance(m, AIMessage) and m.tool_calls for m in response.result
+        )
+        if has_tool_calls:
+            return response
+
+        # Final answer reached: one constrained call formats it. The original
+        # response_format object is passed through untouched so the strategy
+        # (and ToolStrategy tool names) resolved at agent setup still apply.
+        format_request = request.override(
+            messages=[
+                *request.messages,
+                *response.result,
+                HumanMessage(FORMAT_INSTRUCTION),
+            ],
+        )
+        format_response = await handler(format_request)
+        return ModelResponse(
+            result=[*response.result, *format_response.result],
+            structured_response=format_response.structured_response,
+        )

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -54,11 +54,16 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
             return await handler(request)
 
         # Loop turn: run unconstrained so the model can freely call tools.
+        # invalid_tool_calls also keep the loop going: the message must stay
+        # last in state so RepairInvalidToolCallsMiddleware (after_model, keyed
+        # on messages[-1]) can answer it with an error ToolMessage and the
+        # model can retry — formatting waits for a clean final answer.
         response = await handler(request.override(response_format=None))
-        has_tool_calls = any(
-            isinstance(m, AIMessage) and m.tool_calls for m in response.result
+        loop_continues = any(
+            isinstance(m, AIMessage) and (m.tool_calls or m.invalid_tool_calls)
+            for m in response.result
         )
-        if has_tool_calls:
+        if loop_continues:
             return response
 
         # Final answer reached: one constrained call formats it. The original

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -48,7 +48,7 @@ FORMAT_INSTRUCTION = (
     "invent values."
 )
 
-STRUCTURED_OUTPUT_FLAG = "auxilia_structured_output"
+STRUCTURED_OUTPUT_FLAG = "structured_output"
 
 
 def is_structured_output_artifact(message: Any) -> bool:

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -4,6 +4,7 @@ from fastapi.responses import StreamingResponse
 from app.agents.core.service import AgentService, get_agent_service
 from app.agents.runtime import Agent
 from app.agents.stream import _serialize_lc_message
+from app.agents.structured_output import is_structured_output_artifact
 from app.auth.dependencies import detect_auth_method, get_current_user
 from app.database import get_checkpointer, get_db
 from app.exceptions import PermissionDeniedError
@@ -81,13 +82,22 @@ async def read_thread(
             }
 
         channel_values = checkpoint_tuple.checkpoint["channel_values"]
-        lc_messages = channel_values.get("messages", [])
+        # Formatting-turn artifacts (raw-JSON message or synthetic tool-call
+        # pair) are chat-history noise: the parsed object is exposed under
+        # values["structured_response"] instead.
+        lc_messages = [
+            m
+            for m in channel_values.get("messages", [])
+            if not is_structured_output_artifact(m)
+        ]
         todos = channel_values.get("todos", [])
         values: dict = {
             "messages": [_serialize_lc_message(m) for m in lc_messages],
         }
         if todos:
             values["todos"] = todos
+        if (structured := channel_values.get("structured_response")) is not None:
+            values["structured_response"] = structured
 
         interrupt_value = None
         for _, channel, value in checkpoint_tuple.pending_writes or []:

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -270,11 +270,16 @@ async def run_invoke(
     command: dict | None = Body(None, embed=True),
     config: dict | None = Body(None, embed=True),
     context: dict | None = Body(None, embed=True),  # noqa: ARG001
+    output_schema: dict | None = Body(None, embed=True),
     current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
     db=Depends(get_db),
 ):
-    """Non-streaming invoke endpoint. Returns the final agent response as JSON."""
+    """Non-streaming invoke endpoint. Returns the final agent response as JSON.
+
+    When `output_schema` (a JSON Schema object) is provided, the agent's final
+    answer is constrained to it and returned under `structured_response`.
+    """
     thread = await service.get(thread_id)
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to run this thread")
@@ -286,4 +291,5 @@ async def run_invoke(
         command=command,
         trigger=trigger,
         config_overrides=config_overrides,
+        output_schema=output_schema,
     )

--- a/backend/tests/agents/test_runtime.py
+++ b/backend/tests/agents/test_runtime.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from app.agents.runtime import Agent
+from app.agents.structured_output import DeferredStructuredOutputMiddleware
 
 
 def _make_agent() -> Agent:
@@ -32,6 +33,12 @@ def test_build_agent_forwards_output_schema(mock_create_agent):
     agent._build_agent(checkpointer=None, output_schema=schema)
 
     assert mock_create_agent.call_args.kwargs["response_format"] == schema
+    # The schema must be deferred off the tool-calling loop, otherwise the
+    # model skips tools and fabricates values to satisfy the constraint.
+    middleware = mock_create_agent.call_args.kwargs["middleware"]
+    assert any(
+        isinstance(m, DeferredStructuredOutputMiddleware) for m in middleware
+    )
 
 
 @patch("app.agents.runtime.create_agent")
@@ -42,3 +49,7 @@ def test_build_agent_without_output_schema(mock_create_agent):
     agent._build_agent(checkpointer=None)
 
     assert mock_create_agent.call_args.kwargs["response_format"] is None
+    middleware = mock_create_agent.call_args.kwargs["middleware"]
+    assert not any(
+        isinstance(m, DeferredStructuredOutputMiddleware) for m in middleware
+    )

--- a/backend/tests/agents/test_runtime.py
+++ b/backend/tests/agents/test_runtime.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+from app.agents.runtime import Agent
+
+
+def _make_agent() -> Agent:
+    resolved = MagicMock()
+    resolved.config.has_code_interpreter = False
+    resolved.config.instructions = "You are a test agent"
+    resolved.toolset.all = []
+    return Agent(
+        thread=MagicMock(),
+        agent=resolved,
+        model=MagicMock(),
+        middleware=[],
+        callbacks=[],
+        subagents=[],
+    )
+
+
+@patch("app.agents.runtime.create_agent")
+def test_build_agent_forwards_output_schema(mock_create_agent):
+    """An output schema is passed to create_agent as response_format."""
+    agent = _make_agent()
+    schema = {
+        "title": "answer",
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+    }
+
+    agent._build_agent(checkpointer=None, output_schema=schema)
+
+    assert mock_create_agent.call_args.kwargs["response_format"] == schema
+
+
+@patch("app.agents.runtime.create_agent")
+def test_build_agent_without_output_schema(mock_create_agent):
+    """Without an output schema, response_format stays None."""
+    agent = _make_agent()
+
+    agent._build_agent(checkpointer=None)
+
+    assert mock_create_agent.call_args.kwargs["response_format"] is None

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -72,6 +72,37 @@ async def test_loop_turn_runs_unconstrained():
     assert calls[0].response_format is None
 
 
+async def test_invalid_tool_calls_keep_the_loop_going():
+    """Malformed tool calls are not a final answer: the response passes through
+    untouched so RepairInvalidToolCallsMiddleware (keyed on messages[-1]) can
+    feed the error back for a retry instead of formatting a failed attempt."""
+    middleware = DeferredStructuredOutputMiddleware()
+    request = _make_request()
+    invalid_response = ModelResponse(
+        result=[
+            AIMessage(
+                "",
+                invalid_tool_calls=[
+                    {
+                        "name": "search",
+                        "args": '{"q": truncated',
+                        "id": "call_1",
+                        "error": "Invalid JSON",
+                    }
+                ],
+            )
+        ]
+    )
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request, _handler_recording([invalid_response], calls)
+    )
+
+    assert response is invalid_response
+    assert len(calls) == 1
+
+
 async def test_final_turn_adds_constrained_formatting_call():
     """The final answer triggers one extra call with response_format restored."""
     middleware = DeferredStructuredOutputMiddleware()

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock
+
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.agents.structured_output import (
+    FORMAT_INSTRUCTION,
+    DeferredStructuredOutputMiddleware,
+)
+
+
+SCHEMA = {
+    "title": "answer",
+    "type": "object",
+    "properties": {"answer": {"type": "integer"}},
+    "required": ["answer"],
+}
+
+
+def _make_request(response_format=SCHEMA) -> ModelRequest:
+    return ModelRequest(
+        model=MagicMock(),
+        messages=[HumanMessage("What is 2 + 2?")],
+        response_format=response_format,
+    )
+
+
+def _handler_recording(responses: list[ModelResponse], calls: list[ModelRequest]):
+    async def handler(request: ModelRequest) -> ModelResponse:
+        calls.append(request)
+        return responses[len(calls) - 1]
+
+    return handler
+
+
+async def test_no_response_format_passes_through():
+    """Without a response_format, the middleware is a no-op."""
+    middleware = DeferredStructuredOutputMiddleware()
+    request = _make_request(response_format=None)
+    expected = ModelResponse(result=[AIMessage("4")])
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request, _handler_recording([expected], calls)
+    )
+
+    assert response is expected
+    assert len(calls) == 1
+    assert calls[0] is request
+
+
+async def test_loop_turn_runs_unconstrained():
+    """A turn that produces tool calls runs without response_format and is returned as-is."""
+    middleware = DeferredStructuredOutputMiddleware()
+    request = _make_request()
+    tool_call_response = ModelResponse(
+        result=[
+            AIMessage(
+                "",
+                tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+            )
+        ]
+    )
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request, _handler_recording([tool_call_response], calls)
+    )
+
+    assert response is tool_call_response
+    assert len(calls) == 1
+    assert calls[0].response_format is None
+
+
+async def test_final_turn_adds_constrained_formatting_call():
+    """The final answer triggers one extra call with response_format restored."""
+    middleware = DeferredStructuredOutputMiddleware()
+    request = _make_request()
+    final_answer = AIMessage("2 + 2 = 4")
+    formatted = AIMessage('{"answer": 4}')
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[final_answer]),
+                ModelResponse(result=[formatted], structured_response={"answer": 4}),
+            ],
+            calls,
+        ),
+    )
+
+    assert len(calls) == 2
+    # Loop turn: schema stripped.
+    assert calls[0].response_format is None
+    # Formatting turn: original schema restored, conversation extended with the
+    # final answer and the formatting instruction (instruction stays out of state).
+    assert calls[1].response_format == SCHEMA
+    assert calls[1].messages[-2:] == [final_answer, HumanMessage(FORMAT_INSTRUCTION)]
+    # Combined response: both AI messages land in state, parsed object included.
+    assert response.result == [final_answer, formatted]
+    assert response.structured_response == {"answer": 4}

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -6,6 +6,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from app.agents.structured_output import (
     FORMAT_INSTRUCTION,
     DeferredStructuredOutputMiddleware,
+    is_structured_output_artifact,
 )
 
 
@@ -130,5 +131,11 @@ async def test_final_turn_adds_constrained_formatting_call():
     assert calls[1].response_format == SCHEMA
     assert calls[1].messages[-2:] == [final_answer, HumanMessage(FORMAT_INSTRUCTION)]
     # Combined response: both AI messages land in state, parsed object included.
-    assert response.result == [final_answer, formatted]
     assert response.structured_response == {"answer": 4}
+    prose, structured = response.result
+    assert prose == final_answer
+    assert structured.content == formatted.content
+    # The formatting artifact is tagged so read paths can hide it from the
+    # rendered chat history; the prose answer is not.
+    assert is_structured_output_artifact(structured)
+    assert not is_structured_output_artifact(prose)

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -210,6 +210,85 @@ def test_delete_thread(mock_checkpointer, client: TestClient, mock_db, current_u
     mock_db.delete.assert_called_once()
 
 
+@patch("app.threads.router.Agent")
+def test_run_invoke_forwards_output_schema(
+    mock_agent_cls, client: TestClient, mock_db, current_user
+):
+    """`output_schema` from the request body reaches Agent.invoke."""
+    thread_id = str(uuid4())
+    thread = ThreadDB(
+        id=thread_id,
+        user_id=current_user.id,
+        agent_id=uuid4(),
+        first_message_content="Structured run",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    mock_db.execute.return_value = mock_result
+
+    mock_agent = AsyncMock()
+    mock_agent.invoke.return_value = {
+        "content": '{"answer": 42}',
+        "structured_response": {"answer": 42},
+    }
+    mock_agent_cls.build = AsyncMock(return_value=mock_agent)
+
+    output_schema = {
+        "title": "answer",
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+    }
+    response = client.post(
+        f"/threads/{thread_id}/runs/invoke",
+        json={
+            "input": {"messages": [{"type": "human", "content": "hi"}]},
+            "output_schema": output_schema,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["structured_response"] == {"answer": 42}
+    mock_agent.invoke.assert_awaited_once()
+    assert mock_agent.invoke.await_args.kwargs["output_schema"] == output_schema
+
+
+@patch("app.threads.router.Agent")
+def test_run_invoke_without_output_schema(
+    mock_agent_cls, client: TestClient, mock_db, current_user
+):
+    """Omitting `output_schema` invokes the agent with None (unchanged behavior)."""
+    thread_id = str(uuid4())
+    thread = ThreadDB(
+        id=thread_id,
+        user_id=current_user.id,
+        agent_id=uuid4(),
+        first_message_content="Plain run",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    mock_db.execute.return_value = mock_result
+
+    mock_agent = AsyncMock()
+    mock_agent.invoke.return_value = {"content": "hello", "structured_response": None}
+    mock_agent_cls.build = AsyncMock(return_value=mock_agent)
+
+    response = client.post(
+        f"/threads/{thread_id}/runs/invoke",
+        json={"input": {"messages": [{"type": "human", "content": "hi"}]}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["content"] == "hello"
+    assert mock_agent.invoke.await_args.kwargs["output_schema"] is None
+
+
 @pytest.mark.usefixtures("current_user")
 @patch("app.threads.router.get_checkpointer")
 def test_delete_thread_not_found(mock_checkpointer, client: TestClient, mock_db):

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -4,7 +4,9 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage, HumanMessage
 
+from app.agents.structured_output import STRUCTURED_OUTPUT_FLAG
 from app.threads.models import ThreadDB, ThreadSource
 
 
@@ -137,6 +139,59 @@ def test_get_thread(mock_checkpointer, client: TestClient, mock_db, current_user
     assert data["thread"]["id"] == thread_id
     assert data["messages"] == []
     assert data["viewer_role"] is None
+
+
+@patch("app.threads.router.get_checkpointer")
+def test_get_thread_hides_structured_output_artifacts(
+    mock_checkpointer, client: TestClient, mock_db, current_user
+):
+    """Formatting-turn messages are filtered out of both message payloads and
+    the parsed object is exposed under values.structured_response instead."""
+    thread_id = str(uuid4())
+    thread = ThreadDB(
+        id=thread_id,
+        user_id=current_user.id,
+        agent_id=uuid4(),
+        first_message_content="Test thread",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    mock_result.one_or_none.return_value = (thread, "Test Agent", "🤖", None, False)
+    mock_db.execute.return_value = mock_result
+
+    checkpoint_tuple = MagicMock()
+    checkpoint_tuple.checkpoint = {
+        "channel_values": {
+            "messages": [
+                HumanMessage("What is 2 + 2?"),
+                AIMessage("2 + 2 = 4"),
+                AIMessage(
+                    '{"answer": 4}',
+                    response_metadata={STRUCTURED_OUTPUT_FLAG: True},
+                ),
+            ],
+            "structured_response": {"answer": 4},
+        }
+    }
+    checkpoint_tuple.pending_writes = []
+    mock_saver_instance = AsyncMock()
+    mock_saver_instance.aget_tuple = AsyncMock(return_value=checkpoint_tuple)
+    mock_checkpointer.return_value.__aenter__ = AsyncMock(
+        return_value=mock_saver_instance
+    )
+    mock_checkpointer.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    response = client.get(f"/threads/{thread_id}")
+    assert response.status_code == 200
+    data = response.json()
+
+    raw_messages = data["values"]["messages"]
+    assert len(raw_messages) == 2
+    assert all('{"answer": 4}' not in str(m.get("content")) for m in raw_messages)
+    assert data["values"]["structured_response"] == {"answer": 4}
 
 
 @pytest.mark.usefixtures("current_user")


### PR DESCRIPTION
Accept an optional `output_schema` (raw JSON Schema dict) in the /threads/{id}/runs/invoke body and thread it through Agent.invoke into create_agent / create_deep_agent as `response_format`. langchain then uses the provider's native structured output when the model supports it, falling back to a forced tool call otherwise, and the parsed result is returned under `structured_response` alongside `content`.

https://claude.ai/code/session_012y7eVYwXq3G7D8z4ezoh9s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional structured output to `/threads/{id}/runs/invoke` via an `output_schema` so users get a clean prose answer plus a parsed object; preserves normal tool calling and hides formatting artifacts across APIs.

- **New Features**
  - Accept `output_schema` in invoke and pass it as `response_format` to `create_agent`/`create_deep_agent`; `Agent.invoke` returns `content` and `structured_response`, and `GET /threads/{id}` now exposes `values.structured_response`.
  - Defer structured formatting to a final turn with `DeferredStructuredOutputMiddleware` so regular turns run unconstrained; use native `langchain` structured output when available, else fall back; `structured_response` is null when no schema or on recursion fallback.

- **Bug Fixes**
  - Treat `invalid_tool_calls` as loop turns so repair middleware can respond and the model retries.
  - Hide formatting-turn artifacts: tag them in middleware and filter them from thread messages; `invoke` picks the last non-artifact for `content`.

<sup>Written for commit 20ea093024d716538047847181a5fde6633fd964. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

