### PR TITLE
Replace agent editor auto-save with explicit Edit/Save/Cancel

### DIFF
--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -9,11 +9,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.agents.core.repository import AgentRepository
+from app.agents.mcp_servers.service import AgentMCPServerService
 from app.agents.models import (
     AgentDB,
     AgentUserPermissionDB,
 )
 from app.agents.schemas import (
+    AgentConfig,
     AgentCreateDB,
     AgentMCPServerResponse,
     AgentPatch,
@@ -38,6 +40,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     def __init__(self, db: AsyncSession):
         super().__init__(db, AgentRepository(db))
         self.subagent_service = SubagentService(db)
+        self.mcp_server_service = AgentMCPServerService(db)
 
     @staticmethod
     def _resolve_permission(
@@ -160,6 +163,36 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             raise PermissionDeniedError("Not authorized to edit this agent")
         agent = await self.get_or_404(agent_id)
         await self.repository.update(agent, data)
+        return await self.get(agent_id, user_id=user_id, user_role=user_role)
+
+    async def set_config(
+        self,
+        agent_id: UUID,
+        config: AgentConfig,
+        user_id: UUID | None = None,
+        user_role: WorkspaceRole | None = None,
+    ) -> AgentResponse:
+        """Bulk-replace the whole agent config (scalars, MCP bindings,
+        subagents) atomically — one Save from the editor, one transaction."""
+        existing = await self.get(agent_id, user_id=user_id, user_role=user_role)
+        if existing.current_user_permission not in ("owner", "admin", "editor"):
+            raise PermissionDeniedError("Not authorized to edit this agent")
+        agent = await self.get_or_404(agent_id)
+        await self.repository.update(
+            agent,
+            AgentPatch(
+                name=config.name,
+                instructions=config.instructions,
+                description=config.description,
+                emoji=config.emoji,
+                color=config.color,
+                has_code_interpreter=config.has_code_interpreter,
+            ),
+        )
+        await self.mcp_server_service.set_for_agent(agent_id, config.mcp_servers)
+        await self.subagent_service.set_for_supervisor(
+            agent_id, config.subagent_ids, user_role=user_role
+        )
         return await self.get(agent_id, user_id=user_id, user_role=user_role)
 
     async def delete(

--- a/backend/app/agents/mcp_servers/repository.py
+++ b/backend/app/agents/mcp_servers/repository.py
@@ -20,3 +20,10 @@ class AgentMCPServerRepository(BaseRepository[AgentMCPServerDB]):
         )
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def list_for_agent(self, agent_id: UUID) -> list[AgentMCPServerDB]:
+        stmt = select(AgentMCPServerDB).where(
+            AgentMCPServerDB.agent_id == agent_id
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())

--- a/backend/app/agents/mcp_servers/service.py
+++ b/backend/app/agents/mcp_servers/service.py
@@ -6,7 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.mcp_servers.repository import AgentMCPServerRepository
 from app.agents.models import AgentMCPServerBase, AgentMCPServerDB
-from app.agents.schemas import AgentMCPServerCreate, AgentMCPServerPatch
+from app.agents.schemas import (
+    AgentMCPServerConfig,
+    AgentMCPServerCreate,
+    AgentMCPServerPatch,
+)
 from app.database import get_db
 from app.exceptions import NotFoundError
 from app.mcp.client.connectivity import is_oauth_connected
@@ -105,6 +109,37 @@ class AgentMCPServerService(
         if not link:
             raise NotFoundError(self.not_found_message)
         await self.repository.delete(link)
+
+    async def set_for_agent(
+        self, agent_id: UUID, configs: list[AgentMCPServerConfig]
+    ) -> None:
+        """Bulk-replace the agent's MCP server bindings.
+
+        Pure DB reconcile — tool maps are written as provided (whole-map
+        replace, no merge) and no server connection is opened.
+        """
+        existing = await self.repository.list_for_agent(agent_id)
+        by_server = {link.mcp_server_id: link for link in existing}
+        wanted = {config.mcp_server_id for config in configs}
+
+        for config in configs:
+            link = by_server.get(config.mcp_server_id)
+            if link:
+                link.tools = config.tools
+                self.db.add(link)
+            else:
+                await self._ensure_server(config.mcp_server_id)
+                await self.repository.create(
+                    AgentMCPServerBase(
+                        agent_id=agent_id,
+                        mcp_server_id=config.mcp_server_id,
+                        tools=config.tools,
+                    )
+                )
+        for server_id, link in by_server.items():
+            if server_id not in wanted:
+                await self.repository.delete(link)
+        await self.db.flush()
 
     async def sync_tools(
         self, agent_id: UUID, server_id: UUID, user_id: str

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -8,6 +8,7 @@ from app.agents.mcp_servers.service import (
     get_agent_mcp_server_service,
 )
 from app.agents.schemas import (
+    AgentConfig,
     AgentCreate,
     AgentCreateDB,
     AgentMCPServerCreate,
@@ -77,6 +78,18 @@ async def update_agent(
 ) -> AgentResponse:
     return await service.update(
         agent_id, agent_update, user_id=current_user.id, user_role=current_user.role
+    )
+
+
+@router.put("/{agent_id}/config", response_model=AgentResponse)
+async def set_agent_config(
+    agent_id: UUID,
+    config: AgentConfig,
+    current_user: UserDB = Depends(get_current_user),
+    service: AgentService = Depends(get_agent_service),
+) -> AgentResponse:
+    return await service.set_config(
+        agent_id, config, user_id=current_user.id, user_role=current_user.role
     )
 
 

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -59,6 +59,29 @@ class AgentPatch(SQLModel):
         return v
 
 
+class AgentMCPServerConfig(SQLModel):
+    mcp_server_id: UUID
+    tools: dict[str, ToolStatus] | None = None
+
+
+class AgentConfig(SQLModel):
+    name: str
+    instructions: str
+    description: str | None = None
+    emoji: str | None = None
+    color: str | None = None
+    has_code_interpreter: bool = False
+    mcp_servers: list[AgentMCPServerConfig] = []
+    subagent_ids: list[UUID] = []
+
+    @field_validator("color")
+    @classmethod
+    def validate_color(cls, v: str | None) -> str | None:
+        if v is not None and v not in ALLOWED_COLORS:
+            raise ValueError(f"color must be one of {sorted(ALLOWED_COLORS)}")
+        return v
+
+
 class AgentMCPServerCreate(SQLModel):
     tools: dict[str, ToolStatus] | None = None
 

--- a/backend/app/agents/subagents/service.py
+++ b/backend/app/agents/subagents/service.py
@@ -9,7 +9,12 @@ from app.agents.models import AgentDB, AgentSubagentDB
 from app.agents.schemas import SubagentResponse
 from app.agents.subagents.repository import SubagentRepository
 from app.database import get_db
-from app.exceptions import DomainValidationError, NotFoundError
+from app.exceptions import (
+    DomainValidationError,
+    NotFoundError,
+    PermissionDeniedError,
+)
+from app.users.models import WorkspaceRole
 
 
 def _to_response(agent: AgentDB) -> SubagentResponse:
@@ -101,6 +106,32 @@ class SubagentService:
             )
 
         return await self.repository.create_or_update(supervisor_id, subagent_id)
+
+    async def set_for_supervisor(
+        self,
+        supervisor_id: UUID,
+        subagent_ids: list[UUID],
+        user_role: WorkspaceRole | None = None,
+    ) -> None:
+        """Bulk-replace the supervisor's subagents.
+
+        Changing the set is admin-only (mirrors the granular endpoints);
+        an unchanged set is a no-op so non-admins can still save configs
+        that carry their agent's existing subagents.
+        """
+        current = {
+            link.subagent_id
+            for link in await self.repository.list_for_supervisor(supervisor_id)
+        }
+        wanted = set(subagent_ids)
+        if current == wanted:
+            return
+        if user_role != WorkspaceRole.admin:
+            raise PermissionDeniedError("Only admins can modify subagents")
+        for subagent_id in wanted - current:
+            await self.create_or_update(supervisor_id, subagent_id)
+        for subagent_id in current - wanted:
+            await self.delete(supervisor_id, subagent_id)
 
     async def delete(self, supervisor_id: UUID, subagent_id: UUID) -> None:
         link = await self.repository.get(supervisor_id, subagent_id)

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -11,7 +11,13 @@ from app.agents.models import (
     PermissionLevel,
     ToolStatus,
 )
-from app.agents.schemas import AgentCreateDB, AgentPatch, AgentResponse
+from app.agents.schemas import (
+    AgentConfig,
+    AgentCreateDB,
+    AgentMCPServerConfig,
+    AgentPatch,
+    AgentResponse,
+)
 from app.exceptions import NotFoundError, PermissionDeniedError
 from app.users.models import WorkspaceRole
 
@@ -52,16 +58,25 @@ def mock_subagent_service():
     svc.list_subagents = AsyncMock(return_value=[])
     svc.list_all_subagent_data = AsyncMock(return_value=({}, set()))
     svc.delete_all_for_agent = AsyncMock()
+    svc.set_for_supervisor = AsyncMock()
     svc.repository = MagicMock()
     svc.repository.is_subagent = AsyncMock(return_value=False)
     return svc
 
 
 @pytest.fixture
-def service(mock_db, mock_repo, mock_subagent_service):
+def mock_mcp_server_service():
+    svc = MagicMock()
+    svc.set_for_agent = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def service(mock_db, mock_repo, mock_subagent_service, mock_mcp_server_service):
     svc = AgentService(mock_db)
     svc.repository = mock_repo
     svc.subagent_service = mock_subagent_service
+    svc.mcp_server_service = mock_mcp_server_service
     return svc
 
 
@@ -367,6 +382,93 @@ async def test_update_agent_allows_workspace_admin(service, mock_repo):
         AgentPatch(name="Renamed"),
         user_id=uuid4(),
         user_role=WorkspaceRole.admin,
+    )
+
+    mock_repo.update.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# set_config
+# ---------------------------------------------------------------------------
+
+
+def make_config(**kwargs):
+    defaults = {"name": "Configured", "instructions": "Do things"}
+    return AgentConfig(**{**defaults, **kwargs})
+
+
+async def test_set_config_updates_scalars_and_reconciles(
+    service, mock_repo, mock_subagent_service, mock_mcp_server_service
+):
+    agent = make_agent()
+    subagent_id = uuid4()
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+    config = make_config(
+        description="desc",
+        has_code_interpreter=True,
+        mcp_servers=[
+            AgentMCPServerConfig(
+                mcp_server_id=uuid4(),
+                tools={"search": ToolStatus.needs_approval},
+            )
+        ],
+        subagent_ids=[subagent_id],
+    )
+
+    result = await service.set_config(agent.id, config, user_id=agent.owner_id)
+
+    update_schema = mock_repo.update.call_args[0][1]
+    assert isinstance(update_schema, AgentPatch)
+    assert update_schema.model_dump(exclude_unset=True) == {
+        "name": "Configured",
+        "instructions": "Do things",
+        "description": "desc",
+        "emoji": None,
+        "color": None,
+        "has_code_interpreter": True,
+    }
+    mock_mcp_server_service.set_for_agent.assert_awaited_once_with(
+        agent.id, config.mcp_servers
+    )
+    mock_subagent_service.set_for_supervisor.assert_awaited_once_with(
+        agent.id, [subagent_id], user_role=None
+    )
+    assert isinstance(result, AgentResponse)
+    assert result.id == agent.id
+
+
+async def test_set_config_raises_404_when_not_found(service, mock_repo):
+    mock_repo.list_with_permissions.return_value = []
+
+    with pytest.raises(NotFoundError):
+        await service.set_config(uuid4(), make_config())
+
+    mock_repo.update.assert_not_called()
+
+
+async def test_set_config_raises_403_when_no_permission(
+    service, mock_repo, mock_mcp_server_service
+):
+    agent = make_agent()
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+
+    with pytest.raises(PermissionDeniedError):
+        await service.set_config(agent.id, make_config(), user_id=uuid4())
+
+    mock_repo.update.assert_not_called()
+    mock_mcp_server_service.set_for_agent.assert_not_awaited()
+
+
+async def test_set_config_allows_granted_editor(service, mock_repo):
+    agent = make_agent()
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [
+        (agent, None, PermissionLevel.editor)
+    ]
+
+    await service.set_config(
+        agent.id, make_config(), user_id=uuid4(), user_role=WorkspaceRole.member
     )
 
     mock_repo.update.assert_awaited_once()

--- a/backend/tests/agents/mcp_servers/test_service.py
+++ b/backend/tests/agents/mcp_servers/test_service.py
@@ -6,7 +6,11 @@ import pytest
 
 from app.agents.mcp_servers.service import AgentMCPServerService
 from app.agents.models import AgentMCPServerDB, ToolStatus
-from app.agents.schemas import AgentMCPServerCreate, AgentMCPServerPatch
+from app.agents.schemas import (
+    AgentMCPServerConfig,
+    AgentMCPServerCreate,
+    AgentMCPServerPatch,
+)
 from app.exceptions import NotFoundError
 from app.mcp.servers.models import MCPAuthType
 
@@ -33,6 +37,7 @@ def mock_repo():
     repo.create = AsyncMock()
     repo.update = AsyncMock()
     repo.delete = AsyncMock()
+    repo.list_for_agent = AsyncMock(return_value=[])
     return repo
 
 
@@ -302,6 +307,65 @@ async def test_create_or_update_oauth_skips_fetch_when_not_connected(
         )
 
     mock_fetch.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# set_for_agent
+# ---------------------------------------------------------------------------
+
+
+async def test_set_for_agent_replaces_tools_on_existing(service, mock_repo):
+    link = make_link(tools={"old": ToolStatus.always_allow})
+    mock_repo.list_for_agent.return_value = [link]
+    new_tools = {"search": ToolStatus.needs_approval}
+
+    await service.set_for_agent(
+        link.agent_id,
+        [AgentMCPServerConfig(mcp_server_id=link.mcp_server_id, tools=new_tools)],
+    )
+
+    # Whole-map replace, not a merge — "old" is gone
+    assert link.tools == new_tools
+    mock_repo.create.assert_not_awaited()
+    mock_repo.delete.assert_not_awaited()
+
+
+async def test_set_for_agent_creates_missing_binding(service, mock_repo, mock_db):
+    server = make_mcp_server()
+    mock_db.execute.return_value = make_mock_execute_result(scalar=server)
+    agent_id = uuid4()
+    tools = {"search": ToolStatus.always_allow}
+
+    await service.set_for_agent(
+        agent_id, [AgentMCPServerConfig(mcp_server_id=server.id, tools=tools)]
+    )
+
+    created = mock_repo.create.call_args[0][0]
+    assert created.agent_id == agent_id
+    assert created.mcp_server_id == server.id
+    assert created.tools == tools
+
+
+async def test_set_for_agent_raises_404_for_unknown_server(
+    service, mock_repo, mock_db
+):
+    mock_db.execute.return_value = make_mock_execute_result(scalar=None)
+
+    with pytest.raises(NotFoundError):
+        await service.set_for_agent(
+            uuid4(), [AgentMCPServerConfig(mcp_server_id=uuid4())]
+        )
+
+    mock_repo.create.assert_not_awaited()
+
+
+async def test_set_for_agent_deletes_unwanted_bindings(service, mock_repo):
+    link = make_link()
+    mock_repo.list_for_agent.return_value = [link]
+
+    await service.set_for_agent(link.agent_id, [])
+
+    mock_repo.delete.assert_awaited_once_with(link)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/agents/subagents/test_service.py
+++ b/backend/tests/agents/subagents/test_service.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.agents.subagents.service import SubagentService
+from app.exceptions import PermissionDeniedError
+from app.users.models import WorkspaceRole
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    svc = SubagentService(mock_db)
+    svc.repository = MagicMock()
+    svc.repository.list_for_supervisor = AsyncMock(return_value=[])
+    svc.create_or_update = AsyncMock()
+    svc.delete = AsyncMock()
+    return svc
+
+
+def make_link(supervisor_id, subagent_id):
+    link = MagicMock()
+    link.supervisor_id = supervisor_id
+    link.subagent_id = subagent_id
+    return link
+
+
+# ---------------------------------------------------------------------------
+# set_for_supervisor
+# ---------------------------------------------------------------------------
+
+
+async def test_set_for_supervisor_noop_when_unchanged_for_non_admin(service):
+    supervisor_id = uuid4()
+    subagent_id = uuid4()
+    service.repository.list_for_supervisor.return_value = [
+        make_link(supervisor_id, subagent_id)
+    ]
+
+    await service.set_for_supervisor(
+        supervisor_id, [subagent_id], user_role=WorkspaceRole.member
+    )
+
+    service.create_or_update.assert_not_awaited()
+    service.delete.assert_not_awaited()
+
+
+async def test_set_for_supervisor_raises_403_for_non_admin_change(service):
+    with pytest.raises(PermissionDeniedError):
+        await service.set_for_supervisor(
+            uuid4(), [uuid4()], user_role=WorkspaceRole.editor
+        )
+
+    service.create_or_update.assert_not_awaited()
+    service.delete.assert_not_awaited()
+
+
+async def test_set_for_supervisor_adds_and_removes_for_admin(service):
+    supervisor_id = uuid4()
+    kept_id = uuid4()
+    removed_id = uuid4()
+    added_id = uuid4()
+    service.repository.list_for_supervisor.return_value = [
+        make_link(supervisor_id, kept_id),
+        make_link(supervisor_id, removed_id),
+    ]
+
+    await service.set_for_supervisor(
+        supervisor_id, [kept_id, added_id], user_role=WorkspaceRole.admin
+    )
+
+    service.create_or_update.assert_awaited_once_with(supervisor_id, added_id)
+    service.delete.assert_awaited_once_with(supervisor_id, removed_id)

--- a/web/src/app/(protected)/agents/[id]/components/add-agent-subagent-dialog.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/add-agent-subagent-dialog.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import { Plus } from "lucide-react";
-import { api } from "@/lib/api/client";
-import { Agent } from "@/types/agents";
+import { Agent, SubagentInfo } from "@/types/agents";
 import { useAgentsStore } from "@/stores/agents-store";
 import {
 	Dialog,
@@ -16,49 +15,32 @@ import { Button } from "@/components/ui/button";
 interface AddAgentSubagentDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	agent: Agent;
-	onSubagentAdded?: (subagentId: string) => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	agentId: string;
+	boundSubagentIds: string[];
+	onAdd: (subagent: SubagentInfo) => void;
 }
 
 interface AgentCandidateCardProps {
 	candidate: Agent;
-	supervisorId: string;
-	onAdd: (subagentId: string) => void;
+	onAdd: (subagent: SubagentInfo) => void;
 	disabled: boolean;
 	disabledReason?: string;
-	onSaving?: () => void;
-	onSaved?: () => void;
 }
 
 function AgentCandidateCard({
 	candidate,
-	supervisorId,
 	onAdd,
 	disabled,
 	disabledReason,
-	onSaving,
-	onSaved,
 }: AgentCandidateCardProps) {
-	const [isAdding, setIsAdding] = useState(false);
-
-	const handleAdd = async () => {
-		setIsAdding(true);
-		onSaving?.();
-		try {
-			await api.post(
-				`/agents/${supervisorId}/subagents/${candidate.id}`,
-				{},
-			);
-			onAdd(candidate.id);
-			onSaved?.();
-		} catch (error) {
-			console.error("Failed to add subagent:", error);
-			onSaved?.();
-		} finally {
-			setIsAdding(false);
-		}
+	const handleAdd = () => {
+		onAdd({
+			id: candidate.id,
+			name: candidate.name,
+			emoji: candidate.emoji,
+			color: candidate.color,
+			description: candidate.description,
+		});
 	};
 
 	return (
@@ -91,7 +73,7 @@ function AgentCandidateCard({
 				size="icon"
 				className="cursor-pointer shrink-0"
 				onClick={handleAdd}
-				disabled={disabled || isAdding}
+				disabled={disabled}
 			>
 				<Plus className="w-4 h-4" />
 			</Button>
@@ -102,22 +84,21 @@ function AgentCandidateCard({
 export default function AddAgentSubagentDialog({
 	open,
 	onOpenChange,
-	agent,
-	onSubagentAdded,
-	onSaving,
-	onSaved,
+	agentId,
+	boundSubagentIds,
+	onAdd,
 }: AddAgentSubagentDialogProps) {
 	const allAgents = useAgentsStore((state) => state.agents);
 
 	const alreadyBoundIds = useMemo(
-		() => new Set(agent.subagents?.map((s) => s.id) || []),
-		[agent.subagents],
+		() => new Set(boundSubagentIds),
+		[boundSubagentIds],
 	);
 
 	// Candidates: all agents except self, already-bound, and archived
 	const candidates = useMemo(() => {
 		return allAgents
-			.filter((a) => a.id !== agent.id && !alreadyBoundIds.has(a.id))
+			.filter((a) => a.id !== agentId && !alreadyBoundIds.has(a.id))
 			.map((a) => {
 				let disabled = false;
 				let disabledReason: string | undefined;
@@ -137,10 +118,10 @@ export default function AddAgentSubagentDialog({
 				if (a.disabled !== b.disabled) return a.disabled ? 1 : -1;
 				return a.agent.name.localeCompare(b.agent.name);
 			});
-	}, [allAgents, agent.id, alreadyBoundIds]);
+	}, [allAgents, agentId, alreadyBoundIds]);
 
-	const handleSubagentAdded = (subagentId: string) => {
-		onSubagentAdded?.(subagentId);
+	const handleAdd = (subagent: SubagentInfo) => {
+		onAdd(subagent);
 		// Close if no more eligible candidates
 		const eligibleCount = candidates.filter((c) => !c.disabled).length;
 		if (eligibleCount <= 1) {
@@ -161,12 +142,9 @@ export default function AddAgentSubagentDialog({
 								<AgentCandidateCard
 									key={candidate.id}
 									candidate={candidate}
-									supervisorId={agent.id}
-									onAdd={handleSubagentAdded}
+									onAdd={handleAdd}
 									disabled={disabled}
 									disabledReason={disabledReason}
-									onSaving={onSaving}
-									onSaved={onSaved}
 								/>
 							))}
 						</div>

--- a/web/src/app/(protected)/agents/[id]/components/add-agent-tool-dialog.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/add-agent-tool-dialog.tsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 import { Plus } from "lucide-react";
 import { api } from "@/lib/api/client";
 import { MCPServer } from "@/types/mcp-servers";
-import { Agent } from "@/types/agents";
 import {
 	Dialog,
 	DialogContent,
@@ -19,45 +18,18 @@ import { Switch } from "@/components/ui/switch";
 interface AddAgentToolDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	agent: Agent;
-	onServerAdded?: () => void;
-	onSandboxToggled?: () => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	boundServerIds: string[];
+	hasCodeInterpreter: boolean;
+	onAddServer: (serverId: string) => void;
+	onSandboxToggle: (checked: boolean) => void;
 }
 
 interface AvailableMCPServerCardProps {
 	server: MCPServer;
-	agentId: string;
 	onAdd: () => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
 }
 
-function AvailableMCPServerCard({
-	server,
-	agentId,
-	onAdd,
-	onSaving,
-	onSaved,
-}: AvailableMCPServerCardProps) {
-	const [isAdding, setIsAdding] = useState(false);
-
-	const handleAdd = async () => {
-		setIsAdding(true);
-		onSaving?.();
-		try {
-			await api.post(`/agents/${agentId}/mcp-servers/${server.id}`, {});
-			onAdd();
-			onSaved?.();
-		} catch (error) {
-			console.error("Failed to add MCP server to agent:", error);
-			onSaved?.();
-		} finally {
-			setIsAdding(false);
-		}
-	};
-
+function AvailableMCPServerCard({ server, onAdd }: AvailableMCPServerCardProps) {
 	return (
 		<div className="flex items-center gap-3 px-4 py-3 rounded-2xl border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-white/5 hover:bg-sidebar-hover transition-colors">
 			<Image
@@ -74,9 +46,8 @@ function AvailableMCPServerCard({
 				<h3 className="font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground truncate">{server.name}</h3>
 			</div>
 			<button
-				className="w-8 h-8 rounded-full bg-white dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15 disabled:opacity-50"
-				onClick={() => void handleAdd()}
-				disabled={isAdding}
+				className="w-8 h-8 rounded-full bg-white dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
+				onClick={onAdd}
 			>
 				<Plus className="w-3.5 h-3.5 text-[#6B7F76]" />
 			</button>
@@ -85,35 +56,15 @@ function AvailableMCPServerCard({
 }
 
 function BuiltInCapabilities({
-	agent,
+	hasCodeInterpreter,
 	sandboxAvailable,
-	onSandboxToggled,
-	onSaving,
-	onSaved,
+	onSandboxToggle,
 }: {
-	agent: Agent;
+	hasCodeInterpreter: boolean;
 	sandboxAvailable: boolean;
-	onSandboxToggled?: () => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	onSandboxToggle: (checked: boolean) => void;
 }) {
-	const [sandboxEnabled, setSandboxEnabled] = useState(agent.hasCodeInterpreter);
-
 	if (!sandboxAvailable) return null;
-
-	const handleSandboxToggle = async (checked: boolean) => {
-		setSandboxEnabled(checked);
-		onSaving?.();
-		try {
-			await api.patch(`/agents/${agent.id}`, { hasCodeInterpreter: checked });
-			onSandboxToggled?.();
-			onSaved?.();
-		} catch (error) {
-			console.error("Failed to toggle sandbox:", error);
-			setSandboxEnabled(!checked);
-			onSaved?.();
-		}
-	};
 
 	return (
 		<div>
@@ -138,8 +89,8 @@ function BuiltInCapabilities({
 				</div>
 				<Switch
 					className="cursor-pointer"
-					checked={sandboxEnabled}
-					onCheckedChange={handleSandboxToggle}
+					checked={hasCodeInterpreter}
+					onCheckedChange={onSandboxToggle}
 				/>
 			</div>
 		</div>
@@ -147,15 +98,11 @@ function BuiltInCapabilities({
 }
 
 function MCPServerSection({
-	agent,
-	onServerAdded,
-	onSaving,
-	onSaved,
+	boundServerIds,
+	onAddServer,
 }: {
-	agent: Agent;
-	onServerAdded?: () => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	boundServerIds: string[];
+	onAddServer: (serverId: string) => void;
 }) {
 	const router = useRouter();
 	const [allServers, setAllServers] = useState<MCPServer[]>([]);
@@ -169,18 +116,9 @@ function MCPServerSection({
 	}, []);
 
 	const availableServers = useMemo(() => {
-		const enabledIds = new Set(
-			agent.mcpServers?.map((s) => s.mcpServerId) || [],
-		);
+		const enabledIds = new Set(boundServerIds);
 		return allServers.filter((server) => !enabledIds.has(server.id));
-	}, [allServers, agent.mcpServers]);
-
-	const handleServerAdded = () => {
-		onServerAdded?.();
-		api.get("/mcp-servers").then((res) => {
-			setAllServers(res.data);
-		});
-	};
+	}, [allServers, boundServerIds]);
 
 	if (isLoading) {
 		return (
@@ -212,10 +150,7 @@ function MCPServerSection({
 						>
 							<AvailableMCPServerCard
 								server={server}
-								agentId={agent.id}
-								onAdd={handleServerAdded}
-								onSaving={onSaving}
-								onSaved={onSaved}
+								onAdd={() => onAddServer(server.id)}
 							/>
 						</div>
 					))}
@@ -249,11 +184,10 @@ function MCPServerSection({
 export default function AddAgentToolDialog({
 	open,
 	onOpenChange,
-	agent,
-	onServerAdded,
-	onSandboxToggled,
-	onSaving,
-	onSaved,
+	boundServerIds,
+	hasCodeInterpreter,
+	onAddServer,
+	onSandboxToggle,
 }: AddAgentToolDialogProps) {
 	const [sandboxAvailable, setSandboxAvailable] = useState(false);
 
@@ -276,18 +210,14 @@ export default function AddAgentToolDialog({
 				</DialogHeader>
 				<div className="overflow-y-auto max-h-[450px] space-y-7 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 					<MCPServerSection
-						agent={agent}
-						onServerAdded={onServerAdded}
-						onSaving={onSaving}
-						onSaved={onSaved}
+						boundServerIds={boundServerIds}
+						onAddServer={onAddServer}
 					/>
 					{sandboxAvailable && <div className="border-t border-[#E0E8E4] dark:border-white/10" />}
 					<BuiltInCapabilities
-						agent={agent}
+						hasCodeInterpreter={hasCodeInterpreter}
 						sandboxAvailable={sandboxAvailable}
-						onSandboxToggled={onSandboxToggled}
-						onSaving={onSaving}
-						onSaved={onSaved}
+						onSandboxToggle={onSandboxToggle}
 					/>
 				</div>
 			</DialogContent>

--- a/web/src/app/(protected)/agents/[id]/components/agent-code-execution.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-code-execution.tsx
@@ -3,10 +3,8 @@
 import { useState } from "react";
 import Image from "next/image";
 import { ChevronRight } from "lucide-react";
-import { Agent } from "@/types/agents";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { api } from "@/lib/api/client";
 
 const SANDBOX_TOOLS = [
 	{ name: "ls", description: "List files in a directory with metadata (size, modified time)" },
@@ -19,31 +17,15 @@ const SANDBOX_TOOLS = [
 ];
 
 interface AgentCodeExecutionProps {
-	agent: Agent;
-	onUpdate?: () => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	isEditing: boolean;
+	onDisable: () => void;
 }
 
 export default function AgentCodeExecution({
-	agent,
-	onUpdate,
-	onSaving,
-	onSaved,
+	isEditing,
+	onDisable,
 }: AgentCodeExecutionProps) {
 	const [isExpanded, setIsExpanded] = useState(false);
-
-	const handleDisable = async () => {
-		onSaving?.();
-		try {
-			await api.patch(`/agents/${agent.id}`, { hasCodeInterpreter: false });
-			onUpdate?.();
-			onSaved?.();
-		} catch (error) {
-			console.error("Failed to disable code execution:", error);
-			onSaved?.();
-		}
-	};
 
 	return (
 		<div className="border-b last:border-b-0">
@@ -107,16 +89,18 @@ export default function AgentCodeExecution({
 							))}
 						</div>
 					</div>
-					<div className="flex w-full justify-center">
-						<Button
-							variant="ghost"
-							size="sm"
-							className="text-destructive cursor-pointer hover:text-destructive/80"
-							onClick={handleDisable}
-						>
-							Disable Code execution
-						</Button>
-					</div>
+					{isEditing && (
+						<div className="flex w-full justify-center">
+							<Button
+								variant="ghost"
+								size="sm"
+								className="text-destructive cursor-pointer hover:text-destructive/80"
+								onClick={onDisable}
+							>
+								Disable Code execution
+							</Button>
+						</div>
+					)}
 				</div>
 			)}
 		</div>

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import { MCPServer } from "@/types/mcp-servers";
-import { Agent } from "@/types/agents";
+import { ToolStatus } from "@/types/agents";
 import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -11,11 +11,16 @@ import AgentMCPTool from "./agent-mcp-tool";
 import { api } from "@/lib/api/client";
 
 interface AgentMCPServerProps {
-	agent: Agent;
+	agentId: string;
 	server: MCPServer;
-	onUpdate?: () => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	tools: Record<string, ToolStatus> | null;
+	isEditing: boolean;
+	onToolStatusChange: (toolName: string, status: ToolStatus) => void;
+	onDetach: () => void;
+	// Connecting (OAuth) and tool discovery are resource provisioning, not
+	// config — they run immediately, outside the draft. After a successful
+	// connect + sync, the parent gets the discovered tool names.
+	onToolsSynced: (toolNames: string[]) => void;
 }
 
 interface MCPServerTool {
@@ -24,17 +29,16 @@ interface MCPServerTool {
 }
 
 export default function AgentMCPServer({
-	agent,
+	agentId,
 	server,
-	onUpdate,
-	onSaving,
-	onSaved,
+	tools,
+	isEditing,
+	onToolStatusChange,
+	onDetach,
+	onToolsSynced,
 }: AgentMCPServerProps) {
-	const initialAttached =
-		agent.mcpServers?.some((s) => s.mcpServerId === server.id) || false;
-	const [isAttached, setIsAttached] = useState(initialAttached);
 	const [isExpanded, setIsExpanded] = useState(false);
-	const [tools, setTools] = useState<MCPServerTool[]>([]);
+	const [serverTools, setServerTools] = useState<MCPServerTool[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
 	const [toolsFetched, setToolsFetched] = useState(false);
 	const [isConnected, setIsConnected] = useState(false);
@@ -47,34 +51,6 @@ export default function AgentMCPServer({
 		}
 	}, [isCheckingConnection, isConnected]);
 
-	const handleToggleServer = async (serverId: string, isEnabled: boolean) => {
-		setIsAttached(isEnabled);
-		onSaving?.();
-
-		try {
-			if (isEnabled) {
-				await api.post(`/agents/${agent.id}/mcp-servers/${serverId}`, {});
-
-				// Notify parent to update
-				onUpdate?.();
-
-				if (!toolsFetched) {
-					await fetchTools();
-				}
-			} else {
-				await api.delete(`/agents/${agent.id}/mcp-servers/${serverId}`);
-
-				// Notify parent to update
-				onUpdate?.();
-			}
-			onSaved?.();
-		} catch (error) {
-			console.error("Failed to toggle server:", error);
-			setIsAttached(!isEnabled);
-			onSaved?.();
-		}
-	};
-
 	const handleToggleExpand = () => {
 		setIsExpanded(!isExpanded);
 	};
@@ -84,7 +60,7 @@ export default function AgentMCPServer({
 		try {
 			const res = await api.get(`/mcp-servers/${server.id}/list-tools`);
 			const fetchedTools = res.data;
-			setTools(fetchedTools);
+			setServerTools(fetchedTools);
 			setToolsFetched(true);
 		} catch (error: unknown) {
 			// Check if this is an OAuth authorization required error
@@ -115,24 +91,23 @@ export default function AgentMCPServer({
 						if (statusData.connected) {
 							clearInterval(pollInterval);
 							setIsConnected(true);
-							setIsAttached(true);
 
 							// Sync tools to the agent MCP server (saves with always_allow)
 							await api.post(
-								`/agents/${agent.id}/mcp-servers/${server.id}/sync-tools`,
+								`/agents/${agentId}/mcp-servers/${server.id}/sync-tools`,
 							);
 
 							// Fetch tools for display
 							const retryRes = await api.get(
 								`/mcp-servers/${server.id}/list-tools`,
 							);
-							const fetchedTools = retryRes.data;
-							setTools(fetchedTools);
+							const fetchedTools: MCPServerTool[] = retryRes.data;
+							setServerTools(fetchedTools);
 							setToolsFetched(true);
 							setIsLoading(false);
 
-							// Notify parent to refresh agent data with updated tools
-							onUpdate?.();
+							// Let the parent refresh the agent / seed the draft
+							onToolsSynced(fetchedTools.map((tool) => tool.name));
 
 							if (popup && !popup.closed) {
 								popup.close();
@@ -152,11 +127,11 @@ export default function AgentMCPServer({
 			}
 
 			console.error("Failed to fetch tools:", error);
-			setTools([]);
+			setServerTools([]);
 		} finally {
 			setIsLoading(false);
 		}
-	}, [server.id, agent.id, onUpdate]);
+	}, [server.id, agentId, onToolsSynced]);
 
 	const handleConnect = async () => {
 		await fetchTools();
@@ -178,12 +153,12 @@ export default function AgentMCPServer({
 			});
 	}, [server.id]);
 
-	// Fetch tools on initial load if server is already attached
+	// Fetch tools on initial load
 	useEffect(() => {
-		if (isAttached && !toolsFetched && isConnected) {
+		if (!toolsFetched && isConnected) {
 			fetchTools();
 		}
-	}, [isAttached, toolsFetched, isConnected, fetchTools]);
+	}, [toolsFetched, isConnected, fetchTools]);
 
 	return (
 		<div className="border-b last:border-b-0">
@@ -285,18 +260,18 @@ export default function AgentMCPServer({
 							<div className="text-sm text-muted-foreground py-2">
 								Loading tools...
 							</div>
-						) : tools && tools.length > 0 ? (
+						) : serverTools && serverTools.length > 0 ? (
 							<div className="space-y-2">
-								{tools.map((tool) => (
+								{serverTools.map((tool) => (
 									<AgentMCPTool
 										key={tool.name}
-										agent={agent}
-										serverId={server.id}
 										toolName={tool.name}
 										toolDescription={tool.description}
-										onUpdate={onUpdate}
-										onSaving={onSaving}
-										onSaved={onSaved}
+										status={tools?.[tool.name] ?? "always_allow"}
+										isEditing={isEditing}
+										onStatusChange={(status) =>
+											onToolStatusChange(tool.name, status)
+										}
 									/>
 								))}
 							</div>
@@ -306,16 +281,18 @@ export default function AgentMCPServer({
 							</div>
 						)}
 					</div>
-					<div className="flex w-full justify-center">
-						<Button
-							variant="ghost"
-							size="sm"
-							className="text-destructive cursor-pointer hover:text-destructive/80"
-							onClick={() => handleToggleServer(server.id, false)}
-						>
-							Disable {server.name}
-						</Button>
-					</div>
+					{isEditing && (
+						<div className="flex w-full justify-center">
+							<Button
+								variant="ghost"
+								size="sm"
+								className="text-destructive cursor-pointer hover:text-destructive/80"
+								onClick={onDetach}
+							>
+								Disable {server.name}
+							</Button>
+						</div>
+					)}
 				</div>
 			)}
 		</div>

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-tool.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-tool.tsx
@@ -1,65 +1,29 @@
 "use client";
 
-import { useState } from "react";
-import { Agent, ToolStatus } from "@/types/agents";
-import { api } from "@/lib/api/client";
+import { ToolStatus } from "@/types/agents";
 import {
 	ThreeStateToggle,
 	ToggleState,
 } from "@/components/ui/three-state-toggle";
 
 interface AgentMCPToolProps {
-	agent: Agent;
-	serverId: string;
 	toolName: string;
 	toolDescription?: string;
-	onUpdate?: () => void;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	status: ToolStatus;
+	isEditing: boolean;
+	onStatusChange: (status: ToolStatus) => void;
 }
 
 export default function AgentMCPTool({
-	agent,
-	serverId,
 	toolName,
 	toolDescription,
-	onUpdate,
-	onSaving,
-	onSaved,
+	status,
+	isEditing,
+	onStatusChange,
 }: AgentMCPToolProps) {
-	const agentServer = agent.mcpServers?.find((s) => s.mcpServerId === serverId);
-
-	const getInitialStatus = (): ToolStatus => {
-		if (agentServer?.tools && toolName in agentServer.tools) {
-			return agentServer.tools[toolName];
-		}
-		return "always_allow";
-	};
-
-	const [toolStatus, setToolStatus] = useState<ToolStatus>(getInitialStatus);
-
-	const handleStatusChange = async (newStatus: ToggleState) => {
-		const previousStatus = toolStatus;
-		setToolStatus(newStatus);
-		onSaving?.();
-
-		try {
-			const toolsUpdate: Record<string, ToolStatus> = {
-				[toolName]: newStatus,
-			};
-
-			await api.patch(`/agents/${agent.id}/mcp-servers/${serverId}`, {
-				tools: toolsUpdate,
-			});
-
-			// Notify parent to refresh/update
-			onUpdate?.();
-			onSaved?.();
-		} catch (error) {
-			console.error("Failed to update tool status:", error);
-			setToolStatus(previousStatus);
-			onSaved?.();
-		}
+	const handleStatusChange = (newStatus: ToggleState) => {
+		if (!isEditing) return;
+		onStatusChange(newStatus);
 	};
 
 	return (
@@ -80,7 +44,11 @@ export default function AgentMCPTool({
 			</div>
 
 			<div className="flex items-center shrink-0">
-				<ThreeStateToggle value={toolStatus} onChange={handleStatusChange} />
+				<ThreeStateToggle
+					value={status}
+					onChange={handleStatusChange}
+					disabled={!isEditing}
+				/>
 			</div>
 		</div>
 	);

--- a/web/src/app/(protected)/agents/[id]/components/agent-subagent-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-subagent-list.tsx
@@ -2,56 +2,43 @@
 
 import { useState } from "react";
 import { Plus, X, Info } from "lucide-react";
-import { Agent } from "@/types/agents";
-import { api } from "@/lib/api/client";
-import { useAgentsStore } from "@/stores/agents-store";
+import {
+	Agent,
+	AgentDraft,
+	AgentDraftUpdater,
+	SubagentInfo,
+} from "@/types/agents";
 import AddAgentSubagentDialog from "./add-agent-subagent-dialog";
 
 interface AgentSubagentListProps {
 	agent: Agent;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	draft: AgentDraft | null;
+	onDraftChange: (update: AgentDraftUpdater) => void;
 }
 
 export default function AgentSubagentList({
-	agent: initialAgent,
-	onSaving,
-	onSaved,
+	agent,
+	draft,
+	onDraftChange,
 }: AgentSubagentListProps) {
-	const updateAgent = useAgentsStore((state) => state.updateAgent);
-	const [agent, setAgent] = useState<Agent>(initialAgent);
 	const [dialogOpen, setDialogOpen] = useState(false);
-	const [removingId, setRemovingId] = useState<string | null>(null);
 
-	const refreshAgent = async (affectedSubagentId?: string) => {
-		const [coordRes] = await Promise.all([
-			api.get(`/agents/${agent.id}`),
-			// Also refresh the affected subagent so its isSubagent flag updates in the store
-			...(affectedSubagentId
-				? [
-						api.get(`/agents/${affectedSubagentId}`).then((res) => {
-							updateAgent(affectedSubagentId, res.data);
-						}),
-					]
-				: []),
-		]);
-		setAgent(coordRes.data);
-		updateAgent(agent.id, coordRes.data);
+	const isEditing = draft !== null;
+	const subagents = draft ? draft.subagents : agent.subagents || [];
+
+	const handleRemove = (subagentId: string) => {
+		onDraftChange((prev) => ({
+			...prev,
+			subagents: prev.subagents.filter((s) => s.id !== subagentId),
+		}));
 	};
 
-	const handleRemove = async (subagentId: string) => {
-		setRemovingId(subagentId);
-		onSaving?.();
-		try {
-			await api.delete(`/agents/${agent.id}/subagents/${subagentId}`);
-			await refreshAgent(subagentId);
-			onSaved?.();
-		} catch (error) {
-			console.error("Failed to remove subagent:", error);
-			onSaved?.();
-		} finally {
-			setRemovingId(null);
-		}
+	const handleAdd = (subagent: SubagentInfo) => {
+		onDraftChange((prev) =>
+			prev.subagents.some((s) => s.id === subagent.id)
+				? prev
+				: { ...prev, subagents: [...prev.subagents, subagent] },
+		);
 	};
 
 	// If this agent is used as a subagent elsewhere, show info banner instead
@@ -77,21 +64,23 @@ export default function AgentSubagentList({
 				<span className="text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] font-[family-name:var(--font-dm-sans)]">
 					Subagents
 				</span>
-				<button
-					className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[12.5px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
-					onClick={() => setDialogOpen(true)}
-				>
-					<Plus className="w-[13px] h-[13px] text-[#8FA89E]" />
-					Add Subagent
-				</button>
+				{isEditing && (
+					<button
+						className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[12.5px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
+						onClick={() => setDialogOpen(true)}
+					>
+						<Plus className="w-[13px] h-[13px] text-[#8FA89E]" />
+						Add Subagent
+					</button>
+				)}
 			</div>
 			<div className="rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 overflow-hidden min-h-0">
-				{agent.subagents && agent.subagents.length > 0 ? (
-					agent.subagents.map((sub, i) => (
+				{subagents.length > 0 ? (
+					subagents.map((sub, i) => (
 						<div
 							key={sub.id}
 							className={`group flex items-center px-4.5 py-3.5 cursor-default transition-colors hover:bg-[#F8FAF9] dark:hover:bg-white/5 ${
-								i < agent.subagents!.length - 1 ? "border-b border-[#F0F3F2] dark:border-white/5" : ""
+								i < subagents.length - 1 ? "border-b border-[#F0F3F2] dark:border-white/5" : ""
 							}`}
 						>
 							<div
@@ -106,13 +95,14 @@ export default function AgentSubagentList({
 							<span className="font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground flex-1 truncate">
 								{sub.name}
 							</span>
-							<button
-								className="w-[30px] h-[30px] rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all hover:bg-[#F0F3F2] dark:hover:bg-white/10 cursor-pointer"
-								onClick={() => handleRemove(sub.id)}
-								disabled={removingId === sub.id}
-							>
-								<X className="w-[14px] h-[14px] text-[#A3B5AD]" />
-							</button>
+							{isEditing && (
+								<button
+									className="w-[30px] h-[30px] rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all hover:bg-[#F0F3F2] dark:hover:bg-white/10 cursor-pointer"
+									onClick={() => handleRemove(sub.id)}
+								>
+									<X className="w-[14px] h-[14px] text-[#A3B5AD]" />
+								</button>
+							)}
 						</div>
 					))
 				) : (
@@ -125,10 +115,9 @@ export default function AgentSubagentList({
 			<AddAgentSubagentDialog
 				open={dialogOpen}
 				onOpenChange={setDialogOpen}
-				agent={agent}
-				onSubagentAdded={(subagentId) => refreshAgent(subagentId)}
-				onSaving={onSaving}
-				onSaved={onSaved}
+				agentId={agent.id}
+				boundSubagentIds={subagents.map((s) => s.id)}
+				onAdd={handleAdd}
 			/>
 		</div>
 	);

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { Plus } from "lucide-react";
 import { MCPServer } from "@/types/mcp-servers";
-import { Agent } from "@/types/agents";
+import {
+	Agent,
+	AgentDraft,
+	AgentDraftUpdater,
+	ToolStatus,
+} from "@/types/agents";
 import AgentMCPServer from "./agent-mcp-server";
 import AgentCodeExecution from "./agent-code-execution";
 import AddAgentToolDialog from "./add-agent-tool-dialog";
@@ -12,19 +17,20 @@ import { useAgentsStore } from "@/stores/agents-store";
 
 interface AgentToolListProps {
 	agent: Agent;
-	onSaving?: () => void;
-	onSaved?: () => void;
+	draft: AgentDraft | null;
+	onDraftChange: (update: AgentDraftUpdater) => void;
 }
 
 export default function AgentToolList({
-	agent: initialAgent,
-	onSaving,
-	onSaved,
+	agent,
+	draft,
+	onDraftChange,
 }: AgentToolListProps) {
 	const updateAgent = useAgentsStore((state) => state.updateAgent);
 	const [allMCPServers, setAllMCPServers] = useState<MCPServer[]>([]);
-	const [agent, setAgent] = useState<Agent>(initialAgent);
 	const [dialogOpen, setDialogOpen] = useState(false);
+
+	const isEditing = draft !== null;
 
 	useEffect(() => {
 		api.get("/mcp-servers").then((res) => {
@@ -32,19 +38,123 @@ export default function AgentToolList({
 		});
 	}, []);
 
-	const refreshAgent = () => {
+	const refreshAgent = useCallback(() => {
 		api.get(`/agents/${agent.id}`).then((res) => {
-			setAgent(res.data);
 			updateAgent(agent.id, res.data);
 		});
-	};
+	}, [agent.id, updateAgent]);
+
+	// In edit mode the draft drives what's shown; otherwise the live agent.
+	const boundServers = useMemo(
+		() =>
+			draft
+				? draft.mcpServers
+				: (agent.mcpServers || []).map((s) => ({
+						mcpServerId: s.mcpServerId,
+						tools: s.tools,
+					})),
+		[draft, agent.mcpServers],
+	);
+
+	const hasCodeInterpreter = draft
+		? draft.hasCodeInterpreter
+		: agent.hasCodeInterpreter;
 
 	const enabledServers = useMemo(() => {
-		const enabledIds = new Set(agent.mcpServers?.map((s) => s.mcpServerId) || []);
+		const enabledIds = new Set(boundServers.map((s) => s.mcpServerId));
 		return allMCPServers.filter((server) => enabledIds.has(server.id));
-	}, [allMCPServers, agent.mcpServers]);
+	}, [allMCPServers, boundServers]);
 
-	const hasTools = agent.hasCodeInterpreter || enabledServers.length > 0;
+	const toolsByServerId = useMemo(
+		() =>
+			new Map(boundServers.map((s) => [s.mcpServerId, s.tools] as const)),
+		[boundServers],
+	);
+
+	const handleToolStatusChange = (
+		serverId: string,
+		toolName: string,
+		status: ToolStatus,
+	) => {
+		onDraftChange((prev) => ({
+			...prev,
+			mcpServers: prev.mcpServers.map((s) =>
+				s.mcpServerId === serverId
+					? { ...s, tools: { ...(s.tools || {}), [toolName]: status } }
+					: s,
+			),
+		}));
+	};
+
+	const handleDetachServer = (serverId: string) => {
+		onDraftChange((prev) => ({
+			...prev,
+			mcpServers: prev.mcpServers.filter((s) => s.mcpServerId !== serverId),
+		}));
+	};
+
+	const handleAddServer = (serverId: string) => {
+		onDraftChange((prev) =>
+			prev.mcpServers.some((s) => s.mcpServerId === serverId)
+				? prev
+				: {
+						...prev,
+						mcpServers: [
+							...prev.mcpServers,
+							{ mcpServerId: serverId, tools: null },
+						],
+					},
+		);
+		// Seed the per-tool map from live discovery (best effort — the server
+		// may need an OAuth connect first, in which case tools stays null).
+		api
+			.get(`/mcp-servers/${serverId}/list-tools`)
+			.then((res) => {
+				const seeded = Object.fromEntries(
+					(res.data as { name: string }[]).map((tool) => [
+						tool.name,
+						"always_allow" as ToolStatus,
+					]),
+				);
+				onDraftChange((prev) => ({
+					...prev,
+					mcpServers: prev.mcpServers.map((s) =>
+						s.mcpServerId === serverId && s.tools === null
+							? { ...s, tools: seeded }
+							: s,
+					),
+				}));
+			})
+			.catch(() => {});
+	};
+
+	const handleToolsSynced = (serverId: string, toolNames: string[]) => {
+		// sync-tools persisted always_allow defaults server-side; mirror them
+		// into the draft so a later Save doesn't overwrite them with null.
+		onDraftChange((prev) => ({
+			...prev,
+			mcpServers: prev.mcpServers.map((s) =>
+				s.mcpServerId === serverId && s.tools === null
+					? {
+							...s,
+							tools: Object.fromEntries(
+								toolNames.map((name) => [
+									name,
+									"always_allow" as ToolStatus,
+								]),
+							),
+						}
+					: s,
+			),
+		}));
+		refreshAgent();
+	};
+
+	const handleSandboxToggle = (checked: boolean) => {
+		onDraftChange((prev) => ({ ...prev, hasCodeInterpreter: checked }));
+	};
+
+	const hasTools = hasCodeInterpreter || enabledServers.length > 0;
 
 	return (
 		<div className="flex flex-col min-h-0">
@@ -52,33 +162,39 @@ export default function AgentToolList({
 				<span className="text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] font-[family-name:var(--font-dm-sans)]">
 					Tools
 				</span>
-				<button
-					className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[12.5px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
-					onClick={() => setDialogOpen(true)}
-				>
-					<Plus className="w-[13px] h-[13px] text-[#8FA89E]" />
-					Add tool
-				</button>
+				{isEditing && (
+					<button
+						className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[12.5px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
+						onClick={() => setDialogOpen(true)}
+					>
+						<Plus className="w-[13px] h-[13px] text-[#8FA89E]" />
+						Add tool
+					</button>
+				)}
 			</div>
 			<div className="flex-1 overflow-y-auto rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-card min-h-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 				{hasTools ? (
 					<>
-						{agent.hasCodeInterpreter && (
+						{hasCodeInterpreter && (
 							<AgentCodeExecution
-								agent={agent}
-								onUpdate={refreshAgent}
-								onSaving={onSaving}
-								onSaved={onSaved}
+								isEditing={isEditing}
+								onDisable={() => handleSandboxToggle(false)}
 							/>
 						)}
 						{enabledServers.map((server) => (
 							<AgentMCPServer
 								key={server.id}
-								agent={agent}
+								agentId={agent.id}
 								server={server}
-								onUpdate={refreshAgent}
-								onSaving={onSaving}
-								onSaved={onSaved}
+								tools={toolsByServerId.get(server.id) ?? null}
+								isEditing={isEditing}
+								onToolStatusChange={(toolName, status) =>
+									handleToolStatusChange(server.id, toolName, status)
+								}
+								onDetach={() => handleDetachServer(server.id)}
+								onToolsSynced={(toolNames) =>
+									handleToolsSynced(server.id, toolNames)
+								}
 							/>
 						))}
 					</>
@@ -92,11 +208,10 @@ export default function AgentToolList({
 			<AddAgentToolDialog
 				open={dialogOpen}
 				onOpenChange={setDialogOpen}
-				agent={agent}
-				onServerAdded={refreshAgent}
-				onSandboxToggled={refreshAgent}
-				onSaving={onSaving}
-				onSaved={onSaved}
+				boundServerIds={boundServers.map((s) => s.mcpServerId)}
+				hasCodeInterpreter={hasCodeInterpreter}
+				onAddServer={handleAddServer}
+				onSandboxToggle={handleSandboxToggle}
 			/>
 		</div>
 	);

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -1,12 +1,23 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import EmojiPicker, { EmojiClickData, Theme } from "emoji-picker-react";
 import { AGENT_COLORS, agentColorBackground } from "@/lib/colors";
 import { useTheme } from "next-themes";
-import { ShieldCheck, ArrowRight, ArchiveIcon, History } from "lucide-react";
-import { Agent } from "@/types/agents";
+import {
+	ShieldCheck,
+	ArrowRight,
+	ArchiveIcon,
+	History,
+	Pencil,
+} from "lucide-react";
+import {
+	Agent,
+	AgentDraft,
+	AgentDraftUpdater,
+	buildAgentDraft,
+} from "@/types/agents";
 import AgentToolList from "../[id]/components/agent-tool-list";
 import AgentSubagentList from "../[id]/components/agent-subagent-list";
 import { api } from "@/lib/api/client";
@@ -33,19 +44,99 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 		(state) => state.agents.find((a) => a.id === agent.id) ?? agent,
 	);
 
-	const [name, setName] = useState(agent.name || "");
-	const [instructions, setInstructions] = useState(agent.instructions || "");
-	const [description, setDescription] = useState(agent.description || "");
-	const [emoji, setEmoji] = useState(agent.emoji || "🤖");
-	const [color, setColor] = useState(agent.color || AGENT_COLORS[0]);
+	const [draft, setDraft] = useState<AgentDraft | null>(null);
+	const [isSaving, setIsSaving] = useState(false);
+	const [saveError, setSaveError] = useState<string | null>(null);
 	const [showEmojiPicker, setShowEmojiPicker] = useState(false);
-	const [saveStatus, setSaveStatus] = useState<"saved" | "saving">("saved");
 	const [permissionsOpen, setPermissionsOpen] = useState(false);
-	const savingTimerRef = useRef<NodeJS.Timeout | undefined>(undefined);
 	const emojiPickerRef = useRef<HTMLDivElement>(null);
-	const nameTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
-	const instructionsTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
-	const descriptionTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+	const isEditing = draft !== null;
+	const baseline = useMemo(() => buildAgentDraft(liveAgent), [liveAgent]);
+	const view = draft ?? baseline;
+	const isDirty =
+		draft !== null && JSON.stringify(draft) !== JSON.stringify(baseline);
+
+	const emoji = view.emoji || "🤖";
+	const color = view.color || AGENT_COLORS[0];
+
+	const canManageAgent =
+		liveAgent.currentUserPermission === "owner" ||
+		liveAgent.currentUserPermission === "admin";
+	const canEdit =
+		canManageAgent || liveAgent.currentUserPermission === "editor";
+
+	const handleDraftChange = useCallback((update: AgentDraftUpdater) => {
+		setDraft((prev) => (prev ? update(prev) : prev));
+	}, []);
+
+	const startEditing = () => {
+		setSaveError(null);
+		setDraft(buildAgentDraft(liveAgent));
+	};
+
+	const cancelEditing = () => {
+		setDraft(null);
+		setSaveError(null);
+		setShowEmojiPicker(false);
+	};
+
+	const handleSave = async () => {
+		if (!draft) return;
+		setIsSaving(true);
+		setSaveError(null);
+		try {
+			const response = await api.put(`/agents/${agent.id}/config`, {
+				name: draft.name.trim(),
+				instructions: draft.instructions.trim(),
+				description: draft.description.trim() || null,
+				emoji: draft.emoji,
+				color: draft.color,
+				hasCodeInterpreter: draft.hasCodeInterpreter,
+				mcpServers: draft.mcpServers,
+				subagentIds: draft.subagents.map((s) => s.id),
+			});
+			updateAgent(agent.id, response.data);
+
+			// Refresh agents whose subagent status changed so their
+			// isSubagent flag stays accurate in the store.
+			const before = new Set(
+				(liveAgent.subagents || []).map((s) => s.id),
+			);
+			const after = new Set(draft.subagents.map((s) => s.id));
+			const affected = [...new Set([...before, ...after])].filter(
+				(id) => before.has(id) !== after.has(id),
+			);
+			await Promise.all(
+				affected.map((id) =>
+					api
+						.get(`/agents/${id}`)
+						.then((res) => updateAgent(id, res.data))
+						.catch(() => {}),
+				),
+			);
+
+			setDraft(null);
+			setShowEmojiPicker(false);
+		} catch (error) {
+			console.error("Error saving agent:", error);
+			setSaveError("Failed to save changes. Please try again.");
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	// Warn before leaving the page with unsaved changes
+	useEffect(() => {
+		if (!isDirty) return;
+		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+			event.preventDefault();
+		};
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		return () => {
+			window.removeEventListener("beforeunload", handleBeforeUnload);
+		};
+	}, [isDirty]);
 
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -67,35 +158,13 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 	}, [showEmojiPicker]);
 
 	const handleEmojiClick = (emojiData: EmojiClickData) => {
-		setEmoji(emojiData.emoji);
+		handleDraftChange((prev) => ({ ...prev, emoji: emojiData.emoji }));
 		setShowEmojiPicker(false);
-		saveAgent({ emoji: emojiData.emoji });
 	};
 
 	const handleColorClick = (c: string) => {
-		setColor(c);
-		saveAgent({ color: c });
+		handleDraftChange((prev) => ({ ...prev, color: c }));
 	};
-
-	const saveAgent = useCallback(
-		async (
-			updates: Partial<
-				Pick<Agent, "name" | "instructions" | "emoji" | "color" | "description">
-			>,
-		) => {
-			setSaveStatus("saving");
-			try {
-				const response = await api.patch(`/agents/${agent.id}`, updates);
-				const updatedAgent: Agent = response.data;
-				updateAgent(agent.id, updatedAgent);
-				if (savingTimerRef.current) clearTimeout(savingTimerRef.current);
-				savingTimerRef.current = setTimeout(() => setSaveStatus("saved"), 500);
-			} catch (error) {
-				console.error("Error saving agent:", error);
-			}
-		},
-		[agent.id, updateAgent],
-	);
 
 	const handleManagePermissions = () => {
 		setPermissionsOpen(true);
@@ -104,10 +173,6 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 	const handleViewThreads = () => {
 		router.push(`/agents/${agent.id}/threads`);
 	};
-
-	const canManageAgent =
-		liveAgent.currentUserPermission === "owner" ||
-		liveAgent.currentUserPermission === "admin";
 
 	const handleDeleteAgent = async () => {
 		if (
@@ -129,58 +194,6 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 		}
 	};
 
-	// Auto-save name changes with 300ms debounce
-	useEffect(() => {
-		if (!name.trim() || name === liveAgent.name) return;
-
-		if (nameTimeoutRef.current) clearTimeout(nameTimeoutRef.current);
-		nameTimeoutRef.current = setTimeout(() => {
-			saveAgent({ name: name.trim() });
-		}, 300);
-
-		return () => {
-			if (nameTimeoutRef.current) clearTimeout(nameTimeoutRef.current);
-		};
-	}, [name, liveAgent.name, saveAgent]);
-
-	// Auto-save instructions with debounce
-	useEffect(() => {
-		if (instructionsTimeoutRef.current) {
-			clearTimeout(instructionsTimeoutRef.current);
-		}
-
-		instructionsTimeoutRef.current = setTimeout(() => {
-			if (instructions !== liveAgent.instructions) {
-				saveAgent({ instructions: instructions.trim() });
-			}
-		}, 600);
-
-		return () => {
-			if (instructionsTimeoutRef.current) {
-				clearTimeout(instructionsTimeoutRef.current);
-			}
-		};
-	}, [instructions, liveAgent.instructions, saveAgent]);
-
-	// Auto-save description with debounce
-	useEffect(() => {
-		if (descriptionTimeoutRef.current) {
-			clearTimeout(descriptionTimeoutRef.current);
-		}
-
-		descriptionTimeoutRef.current = setTimeout(() => {
-			if (description !== (liveAgent.description || "")) {
-				saveAgent({ description: description.trim() });
-			}
-		}, 600);
-
-		return () => {
-			if (descriptionTimeoutRef.current) {
-				clearTimeout(descriptionTimeoutRef.current);
-			}
-		};
-	}, [description, liveAgent.description, saveAgent]);
-
 	return (
 		<div className="h-full flex flex-col font-[family-name:var(--font-dm-sans)] animate-in fade-in duration-300">
 			{/* Top bar */}
@@ -188,12 +201,14 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 				<div className="flex items-center gap-4 flex-1 min-w-0">
 					<div className="relative">
 						<div
-							onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+							onClick={() => isEditing && setShowEmojiPicker(!showEmojiPicker)}
 							style={{
 								background: agentColorBackground(color),
 								border: `1.5px solid ${color}18`,
 							}}
-							className="flex items-center justify-center shrink-0 w-14 h-14 rounded-full text-[28px] cursor-pointer transition-colors hover:opacity-80"
+							className={`flex items-center justify-center shrink-0 w-14 h-14 rounded-full text-[28px] transition-colors ${
+								isEditing ? "cursor-pointer hover:opacity-80" : "cursor-default"
+							}`}
 						>
 							{emoji}
 						</div>
@@ -227,58 +242,84 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 					<div className="flex flex-col overflow-hidden flex-1">
 						<input
 							type="text"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
+							value={view.name}
+							readOnly={!isEditing}
+							onChange={(e) =>
+								handleDraftChange((prev) => ({ ...prev, name: e.target.value }))
+							}
 							placeholder="Agent name"
 							className="font-[family-name:var(--font-jakarta-sans)] text-[24px] font-extrabold text-[#1E2D28] dark:text-foreground leading-tight tracking-[-0.03em] truncate w-full bg-transparent border-none focus:outline-none focus:ring-0 p-0"
 						/>
 						<p className="text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium mt-0.5 truncate w-full">
-							@{name.toLowerCase().replace(/\s+/g, "_") || "agent_name"}
+							@{view.name.toLowerCase().replace(/\s+/g, "_") || "agent_name"}
 						</p>
 					</div>
 				</div>
 
 				<div className="flex items-center gap-2.5">
-					{/* Save status pill */}
-					<div
-						className={`inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-[13px] font-semibold transition-all duration-300 ${
-							saveStatus === "saving"
-								? "bg-[#FFF5CC] dark:bg-amber-950/40 text-[#D4A832] dark:text-amber-400"
-								: "bg-[#EDF4F0] dark:bg-emerald-950/40 text-[#3D8B63] dark:text-emerald-400"
-						}`}
-					>
-						<span
-							className={`block w-[7px] h-[7px] rounded-full transition-all duration-300 ${
-								saveStatus === "saving"
-									? "bg-[#FDCB6E] animate-pulse-dot"
-									: "bg-[#4CA882]"
-							}`}
-						/>
-						{saveStatus === "saving" ? "Saving..." : "Saved"}
-					</div>
+					{saveError && (
+						<span className="text-[13px] font-semibold text-red-500">
+							{saveError}
+						</span>
+					)}
 
-					{/* Chat button */}
-					<button
-						className="flex items-center gap-2 px-5.5 py-2.5 rounded-full bg-[#111111] dark:bg-white text-white dark:text-[#111111] text-[14px] font-semibold cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90"
-						onClick={() => router.push(`/agents/${agent.id}/chat`)}
-					>
-						Chat
-						<ArrowRight className="size-[15px]" />
-					</button>
+					{isEditing ? (
+						<>
+							{/* Cancel button */}
+							<button
+								className="flex items-center gap-2 px-5.5 py-2.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent text-[14px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD] disabled:opacity-50"
+								onClick={cancelEditing}
+								disabled={isSaving}
+							>
+								Cancel
+							</button>
 
-					{/* More menu */}
-					<SageDropdownMenu
-						items={[
-							...(canManageAgent
-								? [
-									{ label: "View thread history", icon: <History />, onClick: handleViewThreads },
-									{ label: "Manage permissions", icon: <ShieldCheck />, onClick: handleManagePermissions },
-									{ separator: true as const },
-								]
-								: []),
-							{ label: "Archive agent", icon: <ArchiveIcon />, destructive: true, onClick: handleDeleteAgent },
-						]}
-					/>
+							{/* Save button */}
+							<button
+								className="flex items-center gap-2 px-5.5 py-2.5 rounded-full bg-[#111111] dark:bg-white text-white dark:text-[#111111] text-[14px] font-semibold cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90 disabled:opacity-50 disabled:cursor-default"
+								onClick={handleSave}
+								disabled={isSaving || !isDirty || !view.name.trim()}
+							>
+								{isSaving ? "Saving..." : "Save"}
+							</button>
+						</>
+					) : (
+						<>
+							{/* Edit button */}
+							{canEdit && (
+								<button
+									className="flex items-center gap-2 px-5.5 py-2.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent text-[14px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
+									onClick={startEditing}
+								>
+									<Pencil className="size-[14px]" />
+									Edit
+								</button>
+							)}
+
+							{/* Chat button */}
+							<button
+								className="flex items-center gap-2 px-5.5 py-2.5 rounded-full bg-[#111111] dark:bg-white text-white dark:text-[#111111] text-[14px] font-semibold cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90"
+								onClick={() => router.push(`/agents/${agent.id}/chat`)}
+							>
+								Chat
+								<ArrowRight className="size-[15px]" />
+							</button>
+
+							{/* More menu */}
+							<SageDropdownMenu
+								items={[
+									...(canManageAgent
+										? [
+											{ label: "View thread history", icon: <History />, onClick: handleViewThreads },
+											{ label: "Manage permissions", icon: <ShieldCheck />, onClick: handleManagePermissions },
+											{ separator: true as const },
+										]
+										: []),
+									{ label: "Archive agent", icon: <ArchiveIcon />, destructive: true, onClick: handleDeleteAgent },
+								]}
+							/>
+						</>
+					)}
 				</div>
 			</div>
 
@@ -295,14 +336,20 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 						<input
 							type="text"
 							maxLength={255}
-							className="w-full px-5 py-3.5 rounded-[18px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none focus:border-[#4CA882] transition-colors"
-							value={description}
-							onChange={(e) => setDescription(e.target.value)}
+							className="w-full px-5 py-3.5 rounded-[18px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none focus:border-[#4CA882] transition-colors read-only:focus:border-[#E0E8E4] dark:read-only:focus:border-white/10"
+							value={view.description}
+							readOnly={!isEditing}
+							onChange={(e) =>
+								handleDraftChange((prev) => ({
+									...prev,
+									description: e.target.value,
+								}))
+							}
 							placeholder="A short description of your agent..."
 						/>
-						{description.length > 240 && (
+						{view.description.length > 240 && (
 							<p className="text-xs text-[#B8C8C0] mt-1 text-right">
-								{description.length}/255
+								{view.description.length}/255
 							</p>
 						)}
 					</div>
@@ -312,9 +359,15 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 							Instructions
 						</label>
 						<textarea
-							className="flex-1 w-full h-full px-5 py-4.5 rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 resize-vertical focus:outline-none focus:border-[#4CA882] transition-colors [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-							value={instructions}
-							onChange={(e) => setInstructions(e.target.value)}
+							className="flex-1 w-full h-full px-5 py-4.5 rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 resize-vertical focus:outline-none focus:border-[#4CA882] transition-colors read-only:focus:border-[#E0E8E4] dark:read-only:focus:border-white/10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+							value={view.instructions}
+							readOnly={!isEditing}
+							onChange={(e) =>
+								handleDraftChange((prev) => ({
+									...prev,
+									instructions: e.target.value,
+								}))
+							}
 							placeholder="Enter instructions for your agent..."
 						/>
 					</div>
@@ -322,28 +375,16 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 
 				{/* Right: Tools + Subagents */}
 				<div className="h-full w-full md:w-1/2 flex flex-col min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden animate-in fade-in slide-in-from-bottom-3 duration-400" style={{ animationDelay: "100ms", animationFillMode: "both" }}>
-					<AgentToolList
+						<AgentToolList
 						agent={liveAgent}
-						onSaving={() => setSaveStatus("saving")}
-						onSaved={() => {
-							if (savingTimerRef.current) clearTimeout(savingTimerRef.current);
-							savingTimerRef.current = setTimeout(
-								() => setSaveStatus("saved"),
-								400,
-							);
-						}}
+						draft={draft}
+						onDraftChange={handleDraftChange}
 					/>
 					{isAdmin && (
 						<AgentSubagentList
 							agent={liveAgent}
-							onSaving={() => setSaveStatus("saving")}
-							onSaved={() => {
-								if (savingTimerRef.current) clearTimeout(savingTimerRef.current);
-								savingTimerRef.current = setTimeout(
-									() => setSaveStatus("saved"),
-									400,
-								);
-							}}
+							draft={draft}
+							onDraftChange={handleDraftChange}
 						/>
 					)}
 				</div>

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -101,9 +101,7 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 
 			// Refresh agents whose subagent status changed so their
 			// isSubagent flag stays accurate in the store.
-			const before = new Set(
-				(liveAgent.subagents || []).map((s) => s.id),
-			);
+			const before = new Set((liveAgent.subagents || []).map((s) => s.id));
 			const after = new Set(draft.subagents.map((s) => s.id));
 			const affected = [...new Set([...before, ...after])].filter(
 				(id) => before.has(id) !== after.has(id),
@@ -176,11 +174,7 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 	};
 
 	const handleDeleteAgent = async () => {
-		if (
-			!confirm(
-				"Are you sure you want to archive this agent?",
-			)
-		) {
+		if (!confirm("Are you sure you want to archive this agent?")) {
 			return;
 		}
 
@@ -198,7 +192,10 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 	return (
 		<div className="h-full flex flex-col font-[family-name:var(--font-dm-sans)] animate-in fade-in duration-300">
 			{/* Top bar */}
-			<div className="flex flex-col md:flex-row md:items-center gap-3 md:gap-4 px-8 py-6 shrink-0 z-10 animate-in fade-in slide-in-from-bottom-3 duration-400" style={{ animationDelay: "0ms", animationFillMode: "both" }}>
+			<div
+				className="flex flex-col md:flex-row md:items-center gap-3 md:gap-4 px-8 py-6 shrink-0 z-10 animate-in fade-in slide-in-from-bottom-3 duration-400"
+				style={{ animationDelay: "0ms", animationFillMode: "both" }}
+			>
 				<div className="flex items-center gap-4 flex-1 min-w-0">
 					<div className="relative">
 						<div
@@ -311,12 +308,25 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 								items={[
 									...(canManageAgent
 										? [
-											{ label: "View thread history", icon: <History />, onClick: handleViewThreads },
-											{ label: "Manage permissions", icon: <ShieldCheck />, onClick: handleManagePermissions },
-											{ separator: true as const },
-										]
+												{
+													label: "View thread history",
+													icon: <History />,
+													onClick: handleViewThreads,
+												},
+												{
+													label: "Manage permissions",
+													icon: <ShieldCheck />,
+													onClick: handleManagePermissions,
+												},
+												{ separator: true as const },
+											]
 										: []),
-									{ label: "Archive agent", icon: <ArchiveIcon />, destructive: true, onClick: handleDeleteAgent },
+									{
+										label: "Archive agent",
+										icon: <ArchiveIcon />,
+										destructive: true,
+										onClick: handleDeleteAgent,
+									},
 								]}
 							/>
 						</>
@@ -327,7 +337,10 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 			{/* Two column layout */}
 			<div className="relative flex flex-col md:flex-row flex-1 min-h-0 px-8 gap-8">
 				{/* Left: Description + Instructions */}
-				<div className="h-full w-full md:flex-1 flex flex-col min-w-0 animate-in fade-in slide-in-from-bottom-3 duration-400" style={{ animationDelay: "50ms", animationFillMode: "both" }}>
+				<div
+					className="h-full w-full md:flex-1 flex flex-col min-w-0 animate-in fade-in slide-in-from-bottom-3 duration-400"
+					style={{ animationDelay: "50ms", animationFillMode: "both" }}
+				>
 					<div className="shrink-0 mb-7">
 						<div className="flex items-center min-h-[34px] mb-2.5">
 							<label className="text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
@@ -337,7 +350,11 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 						<input
 							type="text"
 							maxLength={255}
-							className="w-full px-5 py-3.5 rounded-[18px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none focus:border-[#4CA882] transition-colors read-only:focus:border-[#E0E8E4] dark:read-only:focus:border-white/10"
+							className={`w-full text-[14px] font-medium text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none transition-colors ${
+								isEditing
+									? "px-5 py-3.5 rounded-[18px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 focus:border-[#4CA882]"
+									: "p-0 border-none bg-transparent"
+							}`}
 							value={view.description}
 							readOnly={!isEditing}
 							onChange={(e) =>
@@ -348,7 +365,7 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 							}
 							placeholder="A short description of your agent..."
 						/>
-						{view.description.length > 240 && (
+						{isEditing && view.description.length > 240 && (
 							<p className="text-xs text-[#B8C8C0] mt-1 text-right">
 								{view.description.length}/255
 							</p>
@@ -372,7 +389,7 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 								placeholder="Enter instructions for your agent..."
 							/>
 						) : (
-							<div className="flex-1 w-full min-h-0 overflow-y-auto px-5 py-4.5 rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+							<div className="flex-1 w-full min-h-0 overflow-y-auto text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 								{view.instructions.trim() ? (
 									<Streamdown className="size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
 										{view.instructions}
@@ -388,8 +405,11 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 				</div>
 
 				{/* Right: Tools + Subagents */}
-				<div className="h-full w-full md:w-1/2 flex flex-col min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden animate-in fade-in slide-in-from-bottom-3 duration-400" style={{ animationDelay: "100ms", animationFillMode: "both" }}>
-						<AgentToolList
+				<div
+					className="h-full w-full md:w-1/2 flex flex-col min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden animate-in fade-in slide-in-from-bottom-3 duration-400"
+					style={{ animationDelay: "100ms", animationFillMode: "both" }}
+				>
+					<AgentToolList
 						agent={liveAgent}
 						draft={draft}
 						onDraftChange={handleDraftChange}

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/types/agents";
 import AgentToolList from "../[id]/components/agent-tool-list";
 import AgentSubagentList from "../[id]/components/agent-subagent-list";
+import { Streamdown } from "streamdown";
 import { api } from "@/lib/api/client";
 import { useAgentsStore } from "@/stores/agents-store";
 import { useThreadsStore } from "@/stores/threads-store";
@@ -358,18 +359,31 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 						<label className="block text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-2.5">
 							Instructions
 						</label>
-						<textarea
-							className="flex-1 w-full h-full px-5 py-4.5 rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 resize-vertical focus:outline-none focus:border-[#4CA882] transition-colors read-only:focus:border-[#E0E8E4] dark:read-only:focus:border-white/10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-							value={view.instructions}
-							readOnly={!isEditing}
-							onChange={(e) =>
-								handleDraftChange((prev) => ({
-									...prev,
-									instructions: e.target.value,
-								}))
-							}
-							placeholder="Enter instructions for your agent..."
-						/>
+						{isEditing ? (
+							<textarea
+								className="flex-1 w-full h-full px-5 py-4.5 rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 resize-vertical focus:outline-none focus:border-[#4CA882] transition-colors [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+								value={view.instructions}
+								onChange={(e) =>
+									handleDraftChange((prev) => ({
+										...prev,
+										instructions: e.target.value,
+									}))
+								}
+								placeholder="Enter instructions for your agent..."
+							/>
+						) : (
+							<div className="flex-1 w-full min-h-0 overflow-y-auto px-5 py-4.5 rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+								{view.instructions.trim() ? (
+									<Streamdown className="size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+										{view.instructions}
+									</Streamdown>
+								) : (
+									<span className="text-[#A3B5AD] dark:text-white/30">
+										No instructions yet.
+									</span>
+								)}
+							</div>
+						)}
 					</div>
 				</div>
 

--- a/web/src/components/ui/three-state-toggle.tsx
+++ b/web/src/components/ui/three-state-toggle.tsx
@@ -83,12 +83,14 @@ const iconMap = {
 interface ThreeStateToggleProps {
 	value: ToggleState;
 	onChange: (value: ToggleState) => void;
+	disabled?: boolean;
 	className?: string;
 }
 
 export function ThreeStateToggle({
 	value,
 	onChange,
+	disabled = false,
 	className,
 }: ThreeStateToggleProps) {
 	const selectedIndex = states.findIndex((s) => s.id === value);
@@ -116,13 +118,17 @@ export function ThreeStateToggle({
 					<React.Fragment key={state.id}>
 						<button
 							type="button"
+							disabled={disabled}
 							onClick={() => onChange(state.id)}
 							className={cn(
 								"relative z-10 w-10 h-8 flex items-center justify-center rounded-full",
-								"transition-colors duration-200 cursor-pointer",
+								"transition-colors duration-200",
+								disabled ? "cursor-default" : "cursor-pointer",
 								isSelected
 									? "text-gray-800 dark:text-gray-100"
-									: "text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400",
+									: disabled
+										? "text-gray-400 dark:text-gray-500"
+										: "text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400",
 							)}
 							aria-label={state.label}
 							aria-pressed={isSelected}

--- a/web/src/types/agents.ts
+++ b/web/src/types/agents.ts
@@ -9,7 +9,7 @@ interface AgentMCPServer extends MCPServer {
 
 export type AgentPermission = "owner" | "admin" | "editor" | "member";
 
-interface SubagentInfo {
+export interface SubagentInfo {
 	id: string;
 	name: string;
 	emoji?: string | null;
@@ -30,4 +30,40 @@ export interface Agent {
 	subagents: SubagentInfo[];
 	isSubagent: boolean;
 	currentUserPermission?: AgentPermission | null;
+}
+
+export interface AgentMCPServerDraft {
+	mcpServerId: string;
+	tools: Record<string, ToolStatus> | null;
+}
+
+// In-memory copy of the editable agent config. Created on "Edit", mutated by
+// the editor and its children, sent as one PUT /agents/{id}/config on "Save".
+export interface AgentDraft {
+	name: string;
+	instructions: string;
+	description: string;
+	emoji: string | null;
+	color: string | null;
+	hasCodeInterpreter: boolean;
+	mcpServers: AgentMCPServerDraft[];
+	subagents: SubagentInfo[];
+}
+
+export type AgentDraftUpdater = (prev: AgentDraft) => AgentDraft;
+
+export function buildAgentDraft(agent: Agent): AgentDraft {
+	return {
+		name: agent.name || "",
+		instructions: agent.instructions || "",
+		description: agent.description || "",
+		emoji: agent.emoji ?? null,
+		color: agent.color ?? null,
+		hasCodeInterpreter: agent.hasCodeInterpreter,
+		mcpServers: (agent.mcpServers || []).map((s) => ({
+			mcpServerId: s.mcpServerId,
+			tools: s.tools ? { ...s.tools } : null,
+		})),
+		subagents: (agent.subagents || []).map((s) => ({ ...s })),
+	};
 }


### PR DESCRIPTION
## Summary

Replaces the agent editor's per-field auto-save (debounced scalars + immediate tool/subagent clicks across ~6 endpoints) with an explicit **Edit → draft → Save/Cancel** flow, backed by one atomic save endpoint. This also lays the groundwork for config versioning (see `agent-config-edit-save-versioning.md`): Save is now the single moment where the whole config exists as one object.

### Backend

- New `PUT /agents/{agent_id}/config` taking an `AgentConfig` document (scalars + full per-tool maps + subagent ids), saved atomically in one request transaction via `AgentService.set_config`
- `AgentMCPServerService.set_for_agent` — pure DB reconcile of MCP bindings, whole-map tool replace (no merge), no network calls
- `SubagentService.set_for_supervisor` — reuses `create_or_update` so cycle/leaf/archived validations still fire; admin-gated only when the set actually changes
- Granular endpoints kept during migration; naming follows `CONVENTIONS.md` (`set_*` bulk-replace, mirroring `set_permissions`)

### Frontend

- Editor clones the live agent into an `AgentDraft` on Edit; Save sends one PUT, Cancel discards; Save disabled until dirty; `beforeunload` guard on unsaved changes
- All children (tool list, MCP server/tool toggles, code execution, subagent list, both dialogs) converted to controlled components — they mutate the draft and make zero write API calls
- Carve-out: MCP OAuth connect + tool discovery stay immediate (provisioning, not config); discovered tools are mirrored into the draft
- View mode renders instructions as **markdown** (Streamdown, same renderer as chat) and flattens readonly field styling

## Testing

- 188 backend tests pass (12 new covering `set_config` / `set_for_agent` / `set_for_supervisor`)
- Verified end-to-end against an isolated DB with Playwright: no writes while typing or staging (auto-save fully gone), Cancel restores, Save fires exactly one `PUT /config`, subagent add/remove persists across reloads, markdown renders in view mode

## Known follow-ups

- Bullet list markers don't render in the markdown instructions view (likely a preflight/list-style reset)
- Empty description shows its placeholder in view mode
- In-app route changes aren't guarded for unsaved drafts (App Router has no route events; only browser unload is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces per-field auto-save with an explicit Edit → Save/Cancel flow in the agent editor, saving the entire config in one atomic request. This simplifies updates, removes background writes, and lays groundwork for config versioning.

- **New Features**
  - Added PUT /agents/{agent_id}/config to atomically save scalars, MCP bindings (full tools map), and subagent IDs in one transaction.
  - Editor creates an in-memory `AgentDraft` on Edit; children mutate the draft only; Save sends one PUT; Cancel discards; Save is disabled until there are changes; warns on tab close if unsaved.
  - View mode renders instructions as markdown via `streamdown`; readonly inputs use flattened styling.

- **API/Behavior Changes**
  - MCP bindings use whole-map replacement via `AgentMCPServerService.set_for_agent` (pure DB reconcile, no merges, no network).
  - Subagents bulk-set with `SubagentService.set_for_supervisor`; changing the set is admin-only; unchanged sets are a no-op.
  - Granular endpoints remain during migration; MCP OAuth connect and tool discovery still run immediately and sync discovered tools, which are mirrored into the draft.

<sup>Written for commit c75514a9d661226d73ae8d0bbb1e91add611ccc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

