### PR TITLE
ci: trigger Docker publish from release-please run

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,23 +1,33 @@
-name: Publish Docker images
+name: Publish Docker image
 
 on:
-  push:
-    tags:
-      - "backend-v*"
-      - "web-v*"
+  workflow_call:
+    inputs:
+      component:
+        description: "backend or web"
+        required: true
+        type: string
+      version:
+        description: "Version tag, e.g. 0.4.0"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      component:
+        description: "backend or web"
+        required: true
+        type: choice
+        options: [backend, web]
+      version:
+        description: "Version tag, e.g. 0.4.0"
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Parse component and version from tag
-        id: parse
-        run: |
-          tag="${GITHUB_REF_NAME}"
-          echo "component=${tag%-v*}" >> "$GITHUB_OUTPUT"
-          echo "version=${tag##*-v}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-qemu-action@v3
 
@@ -30,11 +40,11 @@ jobs:
 
       - uses: docker/build-push-action@v6
         with:
-          context: ${{ steps.parse.outputs.component }}
+          context: ${{ inputs.component }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            keurcien/auxilia-${{ steps.parse.outputs.component }}:${{ steps.parse.outputs.version }}
-            keurcien/auxilia-${{ steps.parse.outputs.component }}:latest
-          cache-from: type=gha,scope=${{ steps.parse.outputs.component }}
-          cache-to: type=gha,mode=max,scope=${{ steps.parse.outputs.component }}
+            keurcien/auxilia-${{ inputs.component }}:${{ inputs.version }}
+            keurcien/auxilia-${{ inputs.component }}:latest
+          cache-from: type=gha,scope=${{ inputs.component }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.component }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,31 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      backend_released: ${{ steps.release.outputs['backend--release_created'] }}
+      backend_version: ${{ steps.release.outputs['backend--version'] }}
+      web_released: ${{ steps.release.outputs['web--release_created'] }}
+      web_version: ${{ steps.release.outputs['web--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-backend:
+    needs: release-please
+    if: needs.release-please.outputs.backend_released == 'true'
+    uses: ./.github/workflows/docker-publish.yml
+    secrets: inherit
+    with:
+      component: backend
+      version: ${{ needs.release-please.outputs.backend_version }}
+
+  publish-web:
+    needs: release-please
+    if: needs.release-please.outputs.web_released == 'true'
+    uses: ./.github/workflows/docker-publish.yml
+    secrets: inherit
+    with:
+      component: web
+      version: ${{ needs.release-please.outputs.web_version }}


### PR DESCRIPTION
Tags created with the default GITHUB_TOKEN don't trigger on:push:tags
workflows. Make docker-publish a reusable workflow and call it from the
release-please run via release_created outputs, so it fires with the
built-in token and no extra PAT.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish Docker images from the `release-please` run using the built-in `GITHUB_TOKEN`, avoiding tag-push trigger issues and removing the need for a PAT. Converts Docker publish to a reusable workflow and triggers it for backend and web releases.

- **Refactors**
  - Made `docker-publish.yml` a reusable workflow (`workflow_call`) with `component` and `version` inputs; added manual `workflow_dispatch`.
  - Removed tag parsing; use inputs for build context, tags, and cache scopes; multi-arch build remains.
  - Updated `release-please.yml` to expose per-component release flags/versions and call the reusable publish workflow only when a release is created for `backend` or `web`.

<sup>Written for commit a42f37904ddd32610ef5a4f2f89a4aa692caeb55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

