### PR TITLE
feat(web): Studio shell redesign — floating sidebar, page specs & smooth collapse

### DIFF
--- a/web/src/app/(protected)/agents/[id]/chat/components/connect-servers-dialog.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/connect-servers-dialog.tsx
@@ -157,6 +157,7 @@ export function ConnectServersDialog({
 							>
 								<div className="w-8 h-8 rounded-md flex items-center justify-center overflow-hidden relative shrink-0">
 									<Image
+										unoptimized
 										width={32}
 										height={32}
 										src={

--- a/web/src/app/(protected)/agents/[id]/components/add-agent-tool-dialog.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/add-agent-tool-dialog.tsx
@@ -61,6 +61,7 @@ function AvailableMCPServerCard({
 	return (
 		<div className="flex items-center gap-3 px-4 py-3 rounded-2xl border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-white/5 hover:bg-sidebar-hover transition-colors">
 			<Image
+				unoptimized
 				src={
 					server.iconUrl ??
 					"https://storage.googleapis.com/choose-assets/mcp.png"

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -190,6 +190,7 @@ export default function AgentMCPServer({
 			<div className="flex items-center p-3 hover:bg-[#F8FAF9] dark:hover:bg-white/5 transition-colors">
 				<div className="w-6 h-6 rounded-sm flex items-center justify-center text-white font-semibold mr-3 overflow-hidden relative">
 					<Image
+						unoptimized
 						width={24}
 						height={24}
 						src={

--- a/web/src/app/(protected)/agents/[id]/components/agent-subagent-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-subagent-list.tsx
@@ -58,12 +58,12 @@ export default function AgentSubagentList({
 	if (agent.isSubagent) {
 		return (
 			<div className="flex flex-col mt-8">
-				<span className="text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] font-[family-name:var(--font-dm-sans)] mb-3.5">
+				<span className="text-[10.5px] font-bold text-[#94a59d] dark:text-muted-foreground uppercase tracking-[0.12em] font-[family-name:var(--font-dm-sans)] mb-2.5">
 					Subagents
 				</span>
-				<div className="flex items-start gap-2 rounded-[18px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 p-3.5">
-					<Info className="w-4 h-4 text-[#8FA89E] mt-0.5 shrink-0" />
-					<p className="font-[family-name:var(--font-dm-sans)] text-[13px] text-[#6B7F76] dark:text-muted-foreground">
+				<div className="flex items-start gap-2.5 rounded-[12px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card shadow-[0_1px_3px_rgba(33,36,31,0.04)] px-4 py-3.5">
+					<Info className="w-4 h-4 text-[#94a59d] mt-0.5 shrink-0" />
+					<p className="font-[family-name:var(--font-dm-sans)] text-[12.5px] text-[#5f7068] dark:text-muted-foreground">
 						This agent is already used as a subagent, it cannot have subagents.
 					</p>
 				</div>
@@ -74,18 +74,18 @@ export default function AgentSubagentList({
 	return (
 		<div className="flex flex-col mt-8">
 			<div className="flex items-center justify-between mb-3.5 shrink-0">
-				<span className="text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] font-[family-name:var(--font-dm-sans)]">
+				<span className="text-[10.5px] font-bold text-[#94a59d] dark:text-muted-foreground uppercase tracking-[0.12em] font-[family-name:var(--font-dm-sans)]">
 					Subagents
 				</span>
 				<button
-					className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[12.5px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
+					className="flex items-center gap-1.5 px-[13px] py-1.5 rounded-[9px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card shadow-[0_1px_3px_rgba(33,36,31,0.05)] font-[family-name:var(--font-dm-sans)] text-[12px] font-medium normal-case tracking-normal text-[#1e2d28] dark:text-foreground cursor-pointer transition-colors hover:border-[#A3B5AD]"
 					onClick={() => setDialogOpen(true)}
 				>
-					<Plus className="w-[13px] h-[13px] text-[#8FA89E]" />
-					Add Subagent
+					<Plus className="w-3 h-3 text-[#6b7f76] dark:text-muted-foreground" />
+					Add subagent
 				</button>
 			</div>
-			<div className="rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 overflow-hidden min-h-0">
+			<div className="rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card shadow-[0_1px_3px_rgba(33,36,31,0.04)] overflow-hidden min-h-0">
 				{agent.subagents && agent.subagents.length > 0 ? (
 					agent.subagents.map((sub, i) => (
 						<div

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
@@ -49,18 +49,18 @@ export default function AgentToolList({
 	return (
 		<div className="flex flex-col min-h-0">
 			<div className="flex items-center justify-between min-h-[34px] mb-2.5 shrink-0">
-				<span className="text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] font-[family-name:var(--font-dm-sans)]">
+				<span className="text-[10.5px] font-bold text-[#94a59d] dark:text-muted-foreground uppercase tracking-[0.12em] font-[family-name:var(--font-dm-sans)]">
 					Tools
 				</span>
 				<button
-					className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[12.5px] font-semibold text-[#6B7F76] dark:text-muted-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
+					className="flex items-center gap-1.5 px-[13px] py-1.5 rounded-[9px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card shadow-[0_1px_3px_rgba(33,36,31,0.05)] font-[family-name:var(--font-dm-sans)] text-[12px] font-medium normal-case tracking-normal text-[#1e2d28] dark:text-foreground cursor-pointer transition-colors hover:border-[#A3B5AD]"
 					onClick={() => setDialogOpen(true)}
 				>
-					<Plus className="w-[13px] h-[13px] text-[#8FA89E]" />
+					<Plus className="w-3 h-3 text-[#6b7f76] dark:text-muted-foreground" />
 					Add tool
 				</button>
 			</div>
-			<div className="flex-1 overflow-y-auto rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-card min-h-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<div className="flex-1 overflow-y-auto rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card shadow-[0_1px_3px_rgba(33,36,31,0.04)] min-h-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 				{hasTools ? (
 					<>
 						{agent.hasCodeInterpreter && (

--- a/web/src/app/(protected)/agents/[id]/threads/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/threads/page.tsx
@@ -86,7 +86,7 @@ export default function AgentThreadsPage() {
 				message="You don't have permission to view this agent's threads."
 			/>
 
-			<div className="flex items-start gap-4 mb-8">
+			<div className="flex items-start gap-4 my-8">
 				<button
 					type="button"
 					onClick={() => {

--- a/web/src/app/(protected)/agents/[id]/threads/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/threads/page.tsx
@@ -86,7 +86,7 @@ export default function AgentThreadsPage() {
 				message="You don't have permission to view this agent's threads."
 			/>
 
-			<div className="flex items-start gap-4 my-8">
+			<div className="flex items-start gap-4 mb-8">
 				<button
 					type="button"
 					onClick={() => {

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
-import { ArrowRight, ListTree, Pencil, X } from "lucide-react";
+import { ArrowRight, Pencil, X } from "lucide-react";
 import { Agent, AgentPermission } from "@/types/agents";
 import { agentColorBackground, PASTEL_MAP } from "@/lib/colors";
 import { useMcpServersStore } from "@/stores/mcp-servers-store";
@@ -22,31 +22,27 @@ const PERMISSION_HIERARCHY: Record<AgentPermission, number> = {
 
 const ROLE_BADGE_CONFIG: Record<
 	AgentPermission,
-	{ label: string; bg: string; text: string; dot: string }
+	{ label: string; bg: string; text: string }
 > = {
 	owner: {
 		label: "Owner",
-		bg: "bg-[#E4EDE2] dark:bg-emerald-950",
-		text: "text-[#4E7050] dark:text-emerald-300",
-		dot: "bg-[#6B8F6B] dark:bg-emerald-400",
+		bg: "bg-[#e7f0eb] dark:bg-emerald-950",
+		text: "text-[#3d8b63] dark:text-emerald-300",
 	},
 	admin: {
 		label: "Admin",
-		bg: "bg-[#E4EDE2] dark:bg-emerald-950",
-		text: "text-[#4E7050] dark:text-emerald-300",
-		dot: "bg-[#6B8F6B] dark:bg-emerald-400",
+		bg: "bg-[#e7f0eb] dark:bg-emerald-950",
+		text: "text-[#3d8b63] dark:text-emerald-300",
 	},
 	editor: {
 		label: "Editor",
-		bg: "bg-[#F2EBDA] dark:bg-amber-950",
-		text: "text-[#9A7B3C] dark:text-amber-300",
-		dot: "bg-[#C4A04E] dark:bg-amber-400",
+		bg: "bg-[#f5edda] dark:bg-amber-950",
+		text: "text-[#9a7b3c] dark:text-amber-300",
 	},
 	member: {
 		label: "Member",
-		bg: "bg-[#EDEEE9] dark:bg-stone-800",
-		text: "text-[#7D8077] dark:text-stone-400",
-		dot: "bg-[#A3A79C] dark:bg-stone-500",
+		bg: "bg-[#eef0ee] dark:bg-stone-800",
+		text: "text-[#7d8077] dark:text-stone-400",
 	},
 };
 
@@ -62,7 +58,6 @@ const NO_ACCESS_BADGE = {
 	label: "No access",
 	bg: "bg-[#F3E4E6] dark:bg-rose-950",
 	text: "text-[#A35462] dark:text-rose-300",
-	dot: "bg-[#C97080] dark:bg-rose-400",
 };
 
 export default function AgentCard({ agent }: AgentCardProps) {
@@ -103,71 +98,71 @@ export default function AgentCard({ agent }: AgentCardProps) {
 	return (
 		<>
 			<div
-				className={`group flex flex-col gap-4 p-7 rounded-3xl h-full bg-white dark:bg-card transition-all duration-300 ${
+				className={`group flex h-full flex-col rounded-xl border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card p-4 pb-0 transition-[border-color,box-shadow] duration-[130ms] ease-out hover:border-[#cfe0d8] dark:hover:border-white/20 hover:shadow-[0_3px_10px_rgba(30,45,40,0.06)] ${
 					hasAccess ? "cursor-pointer" : "cursor-default"
 				}`}
-				style={{
-					boxShadow: "0 2px 12px rgba(0,0,0,0.06)",
-				}}
-				onMouseEnter={(e) => {
-					if (!hasAccess) return;
-					e.currentTarget.style.transform = "translateY(-6px) scale(1.02)";
-					e.currentTarget.style.boxShadow = `0 20px 40px -12px ${color}30, 0 0 0 2px ${color}20`;
-				}}
-				onMouseLeave={(e) => {
-					e.currentTarget.style.transform = "";
-					e.currentTarget.style.boxShadow = "0 2px 12px rgba(0,0,0,0.06)";
-				}}
 				onClick={() => hasAccess && setOpen(true)}
 			>
-				<div className="flex items-center gap-3.5 min-w-0">
-					<div
-						style={{
-							background: agentColorBackground(color),
-							border: `1.5px solid ${color}18`,
-						}}
-						className="flex items-center justify-center shrink-0 w-[52px] h-[52px] rounded-full text-[26px] transition-transform duration-300 group-hover:rotate-[-8deg] group-hover:scale-110"
+				{/* Head: tile · name/handle · role */}
+				<div className="mb-2.5 flex min-w-0 items-center gap-[11px]">
+					<span
+						style={{ background: pastel.pill }}
+						className="flex size-[38px] shrink-0 items-center justify-center rounded-[10px] text-[19px]"
 					>
 						{agent.emoji || "🤖"}
-					</div>
-					<div className="min-w-0">
-						<h2 className="font-[family-name:var(--font-jakarta-sans)] text-[16px] font-bold text-[#1a1a2e] dark:text-foreground tracking-tight leading-tight truncate">
+					</span>
+					<div className="min-w-0 flex-1">
+						<div className="truncate font-[family-name:var(--font-jakarta-sans)] text-[14.5px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
 							{agent.name}
-						</h2>
-						<p className="font-[family-name:var(--font-dm-sans)] text-[13px] text-[#999] dark:text-muted-foreground font-medium mt-0.5">
+						</div>
+						<div className="mt-px truncate font-mono text-[11px] text-[#94a59d] dark:text-muted-foreground">
 							@{agent.name.toLowerCase().replace(/\s+/g, "_")}
-						</p>
+						</div>
 					</div>
-				</div>
-				<p className="font-[family-name:var(--font-dm-sans)] text-[14px] leading-relaxed text-[#666] dark:text-muted-foreground line-clamp-2 flex-1">
-					{agent.description || "No description provided."}
-				</p>
-				<div className="flex items-center gap-2 flex-wrap mt-auto">
 					{(() => {
 						const badge = agent.currentUserPermission
 							? ROLE_BADGE_CONFIG[agent.currentUserPermission]
 							: NO_ACCESS_BADGE;
 						return (
 							<span
-								className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium shrink-0 ${badge.bg} ${badge.text}`}
+								className={`ml-auto shrink-0 rounded-full px-[9px] py-[3px] text-[10.5px] font-semibold ${badge.bg} ${badge.text}`}
 							>
-								<span
-									className={`w-1.5 h-1.5 rounded-full shrink-0 ${badge.dot}`}
-								/>
 								{badge.label}
 							</span>
 						);
 					})()}
-					{agent.subagents?.length > 0 && (
-						<span
-							style={{ background: pastel.pill, color: pastel.text }}
-							className="font-[family-name:var(--font-dm-sans)] inline-flex items-center gap-1.5 px-3.5 py-1 rounded-full text-xs font-semibold"
-						>
-							<ListTree className="w-3.5 h-3.5" />
-							{agent.subagents.length} subagent{agent.subagents.length > 1 ? "s" : ""}
-						</span>
-					)}
 				</div>
+
+				{/* Description — 2-line clamp, reserves height so rows align */}
+				<p className="mb-3 min-h-[38px] flex-1 font-[family-name:var(--font-dm-sans)] text-[12.5px] leading-[1.5] text-[#5f7068] dark:text-muted-foreground line-clamp-2">
+					{agent.description || "No description provided."}
+				</p>
+
+				{/* Meta — real MCP server icons */}
+				{resolvedServers.length > 0 && (
+					<div className="flex items-center border-t border-[#edf2ef] dark:border-white/5 py-2.5">
+						<div className="flex items-center">
+							{resolvedServers.map((server) => (
+								<span
+									key={server.id}
+									title={server.name}
+									className="-ml-1.5 flex size-5 items-center justify-center overflow-hidden rounded-full border border-[#e1ebe6] bg-surface first:ml-0 dark:border-white/10 dark:bg-white/5"
+								>
+									<Image
+										src={
+											server.iconUrl ??
+											"https://storage.googleapis.com/choose-assets/mcp.png"
+										}
+										alt={server.name}
+										width={20}
+										height={20}
+										className="size-full object-cover"
+									/>
+								</span>
+							))}
+						</div>
+					</div>
+				)}
 			</div>
 
 			{open && createPortal(

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { ArrowRight, Pencil, X } from "lucide-react";
 import { Agent, AgentPermission } from "@/types/agents";
-import { agentColorBackground, PASTEL_MAP } from "@/lib/colors";
+import { agentColorBackground, agentPastel } from "@/lib/colors";
 import { useMcpServersStore } from "@/stores/mcp-servers-store";
 import Image from "next/image";
 
@@ -93,7 +93,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
 	};
 
 	const color = agent.color || "#9E9E9E";
-	const pastel = PASTEL_MAP[color] || PASTEL_MAP["#9E9E9E"];
+	const pastel = agentPastel(color);
 
 	return (
 		<>

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -149,6 +149,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
 									className="-ml-1.5 flex size-5 items-center justify-center overflow-hidden rounded-full border border-[#e1ebe6] bg-surface first:ml-0 dark:border-white/10 dark:bg-white/5"
 								>
 									<Image
+										unoptimized
 										src={
 											server.iconUrl ??
 											"https://storage.googleapis.com/choose-assets/mcp.png"
@@ -220,6 +221,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
 								<div className="flex flex-wrap gap-2">
 									{resolvedServers.map((server) => (
 										<Image
+											unoptimized
 											key={server.id}
 											src={
 												server.iconUrl ??

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import EmojiPicker, { EmojiClickData, Theme } from "emoji-picker-react";
-import { AGENT_COLORS, PASTEL_MAP } from "@/lib/colors";
+import { AGENT_COLORS, agentPastel } from "@/lib/colors";
 import { useTheme } from "next-themes";
 import { ShieldCheck, ArrowRight, ArchiveIcon, History } from "lucide-react";
 import { Agent } from "@/types/agents";
@@ -190,7 +190,7 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 						<div
 							onClick={() => setShowEmojiPicker(!showEmojiPicker)}
 							style={{
-								background: (PASTEL_MAP[color] || PASTEL_MAP["#9E9E9E"]).pill,
+								background: agentPastel(color).pill,
 							}}
 							className="flex items-center justify-center shrink-0 size-[46px] rounded-[13px] text-[23px] cursor-pointer transition-opacity hover:opacity-80"
 						>

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import EmojiPicker, { EmojiClickData, Theme } from "emoji-picker-react";
-import { AGENT_COLORS, agentColorBackground } from "@/lib/colors";
+import { AGENT_COLORS, PASTEL_MAP } from "@/lib/colors";
 import { useTheme } from "next-themes";
 import { ShieldCheck, ArrowRight, ArchiveIcon, History } from "lucide-react";
 import { Agent } from "@/types/agents";
@@ -190,10 +190,9 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 						<div
 							onClick={() => setShowEmojiPicker(!showEmojiPicker)}
 							style={{
-								background: agentColorBackground(color),
-								border: `1.5px solid ${color}18`,
+								background: (PASTEL_MAP[color] || PASTEL_MAP["#9E9E9E"]).pill,
 							}}
-							className="flex items-center justify-center shrink-0 w-14 h-14 rounded-full text-[28px] cursor-pointer transition-colors hover:opacity-80"
+							className="flex items-center justify-center shrink-0 size-[46px] rounded-[13px] text-[23px] cursor-pointer transition-opacity hover:opacity-80"
 						>
 							{emoji}
 						</div>
@@ -230,9 +229,9 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 							value={name}
 							onChange={(e) => setName(e.target.value)}
 							placeholder="Agent name"
-							className="font-[family-name:var(--font-jakarta-sans)] text-[24px] font-extrabold text-[#1E2D28] dark:text-foreground leading-tight tracking-[-0.03em] truncate w-full bg-transparent border-none focus:outline-none focus:ring-0 p-0"
+							className="font-[family-name:var(--font-jakarta-sans)] text-[22px] font-bold text-[#1E2D28] dark:text-foreground leading-tight tracking-[-0.025em] truncate w-full bg-transparent border-none focus:outline-none focus:ring-0 p-0"
 						/>
-						<p className="text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium mt-0.5 truncate w-full">
+						<p className="font-mono text-[11.5px] text-[#94a59d] dark:text-muted-foreground mt-0.5 truncate w-full">
 							@{name.toLowerCase().replace(/\s+/g, "_") || "agent_name"}
 						</p>
 					</div>
@@ -288,14 +287,14 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 				<div className="h-full w-full md:flex-1 flex flex-col min-w-0 animate-in fade-in slide-in-from-bottom-3 duration-400" style={{ animationDelay: "50ms", animationFillMode: "both" }}>
 					<div className="shrink-0 mb-7">
 						<div className="flex items-center min-h-[34px] mb-2.5">
-							<label className="text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+							<label className="text-[10.5px] font-bold text-[#94a59d] dark:text-muted-foreground uppercase tracking-[0.12em]">
 								Description
 							</label>
 						</div>
 						<input
 							type="text"
 							maxLength={255}
-							className="w-full px-5 py-3.5 rounded-[18px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none focus:border-[#4CA882] transition-colors"
+							className="w-full px-[17px] py-[15px] rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card text-[13.5px] font-medium text-[#1E2D28] dark:text-white leading-[1.5] placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 shadow-[0_1px_3px_rgba(33,36,31,0.04)] focus:outline-none focus:border-[#4CA882] transition-colors"
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
 							placeholder="A short description of your agent..."
@@ -308,11 +307,11 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 					</div>
 
 					<div className="flex-1 flex flex-col min-h-0">
-						<label className="block text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-2.5">
+						<label className="block text-[10.5px] font-bold text-[#94a59d] dark:text-muted-foreground uppercase tracking-[0.12em] mb-2.5">
 							Instructions
 						</label>
 						<textarea
-							className="flex-1 w-full h-full px-5 py-4.5 rounded-[22px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium text-[#1E2D28] dark:text-white leading-relaxed placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 resize-vertical focus:outline-none focus:border-[#4CA882] transition-colors [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+							className="flex-1 w-full h-full p-5 rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card text-[13px] font-medium text-[#1E2D28] dark:text-white leading-[1.65] placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 resize-none shadow-[0_1px_3px_rgba(33,36,31,0.04)] focus:outline-none focus:border-[#4CA882] transition-colors [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 							value={instructions}
 							onChange={(e) => setInstructions(e.target.value)}
 							placeholder="Enter instructions for your agent..."

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -99,7 +99,9 @@ function AgentSection({
 				<div className="flex-1 h-px bg-[#E8EFE9] dark:bg-white/10" />
 				{hasMore && (
 					<button
-						onClick={() => setExpanded((v) => !v)}
+						onClick={() => {
+						setExpanded((v) => !v);
+					}}
 						className="flex items-center gap-1 font-[family-name:var(--font-dm-sans)] text-[13px] font-medium text-[#8FA89E] dark:text-muted-foreground whitespace-nowrap cursor-pointer transition-colors hover:text-[#1E2D28] dark:hover:text-foreground"
 					>
 						{expanded ? "Show less" : "See all"}

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -110,7 +110,7 @@ function AgentSection({
 
 			{note}
 
-			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 				{shown.map((agent, i) => (
 					<div
 						key={agent.id}

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -1,21 +1,23 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Compass, Info, Plus, Search, Users, Zap } from "lucide-react";
+import { ArrowRight, Info, Plus, Search, Zap } from "lucide-react";
 import { Agent } from "@/types/agents";
 import AgentCard from "@/app/(protected)/agents/components/agent-card";
 import { api } from "@/lib/api/client";
-import { SearchBar } from "@/components/ui/search-bar";
 
-const TABS = [
+// Stacked sections, top to bottom. "Discover" (agents not shared with the
+// user) only renders when it actually has agents, so the common view stays
+// "yours + shared", matching the page's description.
+const GROUPS = [
 	{
 		key: "mine",
-		label: "My agents",
+		label: "Your agents",
 		filter: (a: Agent) => a.currentUserPermission === "owner",
 	},
 	{
 		key: "shared",
-		label: "Shared with me",
+		label: "Shared with you",
 		filter: (a: Agent) =>
 			a.currentUserPermission === "admin" ||
 			a.currentUserPermission === "editor" ||
@@ -27,6 +29,9 @@ const TABS = [
 		filter: (a: Agent) => !a.currentUserPermission,
 	},
 ];
+
+// How many cards a section shows before "See all" reveals the rest.
+const SECTION_CAP = 6;
 
 function EmptyState({
 	icon,
@@ -69,14 +74,69 @@ function EmptyState({
 	);
 }
 
+function AgentSection({
+	label,
+	agents,
+	note,
+}: {
+	label: string;
+	agents: Agent[];
+	note?: React.ReactNode;
+}) {
+	const [expanded, setExpanded] = useState(false);
+	const hasMore = agents.length > SECTION_CAP;
+	const shown = expanded ? agents : agents.slice(0, SECTION_CAP);
+
+	return (
+		<section className="mb-10 last:mb-0 animate-in fade-in duration-300">
+			<div className="flex items-center gap-3 mb-5">
+				<h2 className="font-[family-name:var(--font-jakarta-sans)] text-[15px] font-bold tracking-[-0.01em] text-[#1E2D28] dark:text-foreground whitespace-nowrap">
+					{label}
+				</h2>
+				<span className="font-[family-name:var(--font-dm-sans)] text-[13px] font-medium text-[#B8C8C0] dark:text-muted-foreground">
+					{agents.length}
+				</span>
+				<div className="flex-1 h-px bg-[#E8EFE9] dark:bg-white/10" />
+				{hasMore && (
+					<button
+						onClick={() => setExpanded((v) => !v)}
+						className="flex items-center gap-1 font-[family-name:var(--font-dm-sans)] text-[13px] font-medium text-[#8FA89E] dark:text-muted-foreground whitespace-nowrap cursor-pointer transition-colors hover:text-[#1E2D28] dark:hover:text-foreground"
+					>
+						{expanded ? "Show less" : "See all"}
+						<ArrowRight className="size-3.5" />
+					</button>
+				)}
+			</div>
+
+			{note}
+
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				{shown.map((agent, i) => (
+					<div
+						key={agent.id}
+						className="h-full animate-in fade-in slide-in-from-bottom-3 duration-400"
+						style={{ animationDelay: `${i * 40}ms`, animationFillMode: "both" }}
+					>
+						<AgentCard agent={agent} />
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}
+
 interface AgentListProps {
+	search: string;
+	onClearSearch?: () => void;
 	onCreateAgent?: () => void;
 }
 
-export default function AgentList({ onCreateAgent }: AgentListProps) {
+export default function AgentList({
+	search,
+	onClearSearch,
+	onCreateAgent,
+}: AgentListProps) {
 	const [agents, setAgents] = useState<Agent[]>([]);
-	const [activeTab, setActiveTab] = useState("mine");
-	const [search, setSearch] = useState("");
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
@@ -87,139 +147,81 @@ export default function AgentList({ onCreateAgent }: AgentListProps) {
 			.finally(() => setIsLoading(false));
 	}, []);
 
-	const currentTab = TABS.find((t) => t.key === activeTab)!;
+	const matches = useMemo(() => {
+		if (!search) return agents;
+		const query = search.toLowerCase();
+		return agents.filter((agent) => agent.name.toLowerCase().includes(query));
+	}, [agents, search]);
 
-	const filtered = useMemo(() => {
-		return agents.filter((agent) => {
-			const matchesTab = currentTab.filter(agent);
-			const matchesSearch =
-				!search || agent.name.toLowerCase().includes(search.toLowerCase());
-			return matchesTab && matchesSearch;
-		});
-	}, [agents, search, currentTab]);
-
-	const tabCounts = useMemo(() => {
-		return Object.fromEntries(
-			TABS.map((tab) => [tab.key, agents.filter(tab.filter).length]),
-		);
-	}, [agents]);
+	const sections = useMemo(
+		() =>
+			GROUPS.map((group) => ({
+				...group,
+				items: matches.filter(group.filter),
+			})).filter((group) => group.items.length > 0),
+		[matches],
+	);
 
 	if (isLoading) return null;
 
-	const renderEmptyState = () => {
-		// Search with no results
-		if (search) {
-			return (
-				<EmptyState
-					icon={<Search className="size-[22px] text-[#4CA882]" />}
-					title="No agents found"
-					subtitle="Try adjusting your search or filters to find what you're looking for."
-					action={{
-						label: "Clear search",
-						icon: <Search className="size-[15px] text-[#4CA882]" />,
-						onClick: () => setSearch(""),
-					}}
-				/>
-			);
-		}
-
-		// Empty workspace (no agents at all in "mine" tab)
-		if (activeTab === "mine") {
-			return (
-				<EmptyState
-					icon={<Zap className="size-[22px] text-[#4CA882]" />}
-					title="Create your first agent"
-					subtitle="Agents help your team automate tasks and access your data tools."
-					action={onCreateAgent ? {
-						label: "Create an agent",
-						icon: <Plus className="size-[15px] text-[#4CA882]" />,
-						onClick: onCreateAgent,
-					} : undefined}
-				/>
-			);
-		}
-
-		if (activeTab === "shared") {
-			return (
-				<EmptyState
-					icon={<Users className="size-[22px] text-[#4CA882]" />}
-					title="Nothing shared yet"
-					subtitle="When someone shares an agent with you, it will appear here."
-				/>
-			);
-		}
-
-		// Discover
+	// Search returned nothing.
+	if (search && sections.length === 0) {
 		return (
 			<EmptyState
-				icon={<Compass className="size-[22px] text-[#4CA882]" />}
-				title="Nothing to discover"
-				subtitle="All workspace agents are already shared with you."
+				icon={<Search className="size-[22px] text-[#4CA882]" />}
+				title="No agents found"
+				subtitle="Try adjusting your search to find what you're looking for."
+				action={
+					onClearSearch
+						? {
+								label: "Clear search",
+								icon: <Search className="size-[15px] text-[#4CA882]" />,
+								onClick: onClearSearch,
+							}
+						: undefined
+				}
 			/>
 		);
-	};
+	}
+
+	// Empty workspace — no agents at all.
+	if (sections.length === 0) {
+		return (
+			<EmptyState
+				icon={<Zap className="size-[22px] text-[#4CA882]" />}
+				title="Create your first agent"
+				subtitle="Agents help your team automate tasks and access your data tools."
+				action={
+					onCreateAgent
+						? {
+								label: "Create an agent",
+								icon: <Plus className="size-[15px] text-[#4CA882]" />,
+								onClick: onCreateAgent,
+							}
+						: undefined
+				}
+			/>
+		);
+	}
 
 	return (
-		<div className="w-full mx-auto animate-in fade-in duration-300">
-			<div className="w-full flex items-center justify-between mb-7 overflow-x-auto">
-				<div className="flex gap-1.5 bg-[#F5F8F6] dark:bg-white/5 rounded-full p-1">
-					{TABS.map((tab) => {
-						const isActive = activeTab === tab.key;
-						return (
-							<button
-								key={tab.key}
-								onClick={() => setActiveTab(tab.key)}
-								className={`flex items-center gap-1.5 px-4.5 py-2 rounded-full text-[13.5px] font-[family-name:var(--font-dm-sans)] cursor-pointer transition-all whitespace-nowrap ${
-									isActive
-										? "bg-white dark:bg-white/10 text-[#1E2D28] dark:text-white font-semibold shadow-[0_1px_4px_rgba(0,0,0,0.06)]"
-										: "bg-transparent text-[#8FA89E] dark:text-white/40 font-medium hover:text-[#6B7F76] dark:hover:text-white/60"
-								}`}
-							>
-								{tab.label}
-								<span
-									className={`text-[11.5px] font-semibold px-1.5 py-0.5 rounded-full transition-colors ${
-										isActive
-											? "bg-[#EDF4F0] dark:bg-white/10 text-[#3D8B63] dark:text-emerald-400"
-											: "text-[#B8C8C0] dark:text-white/30"
-									}`}
-								>
-									{tabCounts[tab.key]}
-								</span>
-							</button>
-						);
-					})}
-				</div>
-				<SearchBar
-					placeholder="Search agents..."
-					value={search}
-					onChange={setSearch}
-					className="w-64 shrink-0"
+		<div className="w-full animate-in fade-in duration-300">
+			{sections.map((group) => (
+				<AgentSection
+					key={group.key}
+					label={group.label}
+					agents={group.items}
+					note={
+						group.key === "discover" ? (
+							<div className="flex items-center gap-2.5 px-4 py-3 mb-5 rounded-xl bg-primary/10 text-primary text-[13.5px]">
+								<Info className="size-4 shrink-0" />
+								These agents exist in your workspace but haven&apos;t been shared
+								with you yet. Contact the owner to request access.
+							</div>
+						) : undefined
+					}
 				/>
-			</div>
-
-			{activeTab === "discover" && filtered.length > 0 && (
-				<div className="flex items-center gap-2.5 px-4 py-3 mb-6 rounded-xl bg-primary/10 text-primary text-[13.5px]">
-					<Info className="size-4 shrink-0" />
-					These agents exist in your workspace but haven&apos;t been shared with
-					you yet. Contact the owner to request access.
-				</div>
-			)}
-
-			{filtered.length > 0 ? (
-				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-					{filtered.map((agent, i) => (
-						<div
-							key={agent.id}
-							className="h-full animate-in fade-in slide-in-from-bottom-3 duration-400"
-							style={{ animationDelay: `${i * 50}ms`, animationFillMode: "both" }}
-						>
-							<AgentCard agent={agent} />
-						</div>
-					))}
-				</div>
-			) : (
-				renderEmptyState()
-			)}
+			))}
 		</div>
 	);
 }

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -153,19 +153,39 @@ export default function AgentList({
 		return agents.filter((agent) => agent.name.toLowerCase().includes(query));
 	}, [agents, search]);
 
-	const sections = useMemo(
+	const grouped = useMemo(
 		() =>
 			GROUPS.map((group) => ({
 				...group,
 				items: matches.filter(group.filter),
-			})).filter((group) => group.items.length > 0),
+			})),
 		[matches],
 	);
 
 	if (isLoading) return null;
 
+	// Empty workspace — no agents at all.
+	if (agents.length === 0) {
+		return (
+			<EmptyState
+				icon={<Zap className="size-[22px] text-[#4CA882]" />}
+				title="Create your first agent"
+				subtitle="Agents help your team automate tasks and access your data tools."
+				action={
+					onCreateAgent
+						? {
+								label: "Create an agent",
+								icon: <Plus className="size-[15px] text-[#4CA882]" />,
+								onClick: onCreateAgent,
+							}
+						: undefined
+				}
+			/>
+		);
+	}
+
 	// Search returned nothing.
-	if (search && sections.length === 0) {
+	if (search && matches.length === 0) {
 		return (
 			<EmptyState
 				icon={<Search className="size-[22px] text-[#4CA882]" />}
@@ -184,25 +204,13 @@ export default function AgentList({
 		);
 	}
 
-	// Empty workspace — no agents at all.
-	if (sections.length === 0) {
-		return (
-			<EmptyState
-				icon={<Zap className="size-[22px] text-[#4CA882]" />}
-				title="Create your first agent"
-				subtitle="Agents help your team automate tasks and access your data tools."
-				action={
-					onCreateAgent
-						? {
-								label: "Create an agent",
-								icon: <Plus className="size-[15px] text-[#4CA882]" />,
-								onClick: onCreateAgent,
-							}
-						: undefined
-				}
-			/>
-		);
-	}
+	// "Your agents" / "Shared with you" always render so the page structure
+	// stays consistent even at zero; "Discover" only appears when it has agents.
+	// While searching, drop empty sections so only matches show.
+	const sections = grouped.filter(
+		(group) =>
+			group.items.length > 0 || (!search && group.key !== "discover"),
+	);
 
 	return (
 		<div className="w-full animate-in fade-in duration-300">

--- a/web/src/app/(protected)/agents/page.tsx
+++ b/web/src/app/(protected)/agents/page.tsx
@@ -57,7 +57,7 @@ export default function AgentsPage() {
 				title="Insufficient privileges"
 				message="You need at least editor permissions to create agents."
 			/>
-			<div className="flex items-center justify-between mb-7">
+			<div className="flex items-center justify-between my-8 mb-7">
 				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
 					Agents
 				</h1>

--- a/web/src/app/(protected)/agents/page.tsx
+++ b/web/src/app/(protected)/agents/page.tsx
@@ -90,7 +90,9 @@ export default function AgentsPage() {
 			</div>
 			<AgentList
 				search={search}
-				onClearSearch={() => setSearch("")}
+				onClearSearch={() => {
+					setSearch("");
+				}}
 				onCreateAgent={handleCreateAgent}
 			/>
 		</PageContainer>

--- a/web/src/app/(protected)/agents/page.tsx
+++ b/web/src/app/(protected)/agents/page.tsx
@@ -6,6 +6,7 @@ import { Plus } from "lucide-react";
 import AgentList from "@/app/(protected)/agents/components/agent-list";
 import ForbiddenErrorDialog from "@/components/forbidden-error-dialog";
 import { Button } from "@/components/ui/button";
+import { SearchBar } from "@/components/ui/search-bar";
 import { api } from "@/lib/api/client";
 import { randomAgentColor } from "@/lib/colors";
 import { PageContainer } from "@/components/layout/page-container";
@@ -19,6 +20,7 @@ export default function AgentsPage() {
 	const addAgent = useAgentsStore((state) => state.addAgent);
 	const [isCreating, setIsCreating] = useState(false);
 	const [errorDialogOpen, setErrorDialogOpen] = useState(false);
+	const [search, setSearch] = useState("");
 
 	const handleCreateAgent = async () => {
 		if (!user) return;
@@ -57,21 +59,40 @@ export default function AgentsPage() {
 				title="Insufficient privileges"
 				message="You need at least editor permissions to create agents."
 			/>
-			<div className="flex items-center justify-between my-8 mb-7">
-				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
-					Agents
-				</h1>
+			<div className="flex flex-col gap-5 my-8 sm:flex-row sm:items-start sm:justify-between">
+				<div className="min-w-0">
+					<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
+						Agents
+					</h1>
+					<p className="mt-1.5 font-[family-name:var(--font-dm-sans)] text-[15px] font-medium text-[#6B7F76] dark:text-muted-foreground">
+						Everything you can chat with — yours, and what the team shares with
+						you.
+					</p>
+				</div>
 
-				<Button
-					className="flex items-center gap-2 px-6! py-3! h-auto! bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none"
-					onClick={handleCreateAgent}
-					disabled={isCreating}
-				>
-					<Plus className="w-4 h-4" />
-					{isCreating ? "Creating..." : "Create an agent"}
-				</Button>
+				<div className="flex items-center gap-3 shrink-0">
+					<SearchBar
+						placeholder="Search agents..."
+						value={search}
+						onChange={setSearch}
+						hint="⌘K"
+						className="w-full sm:w-72"
+					/>
+					<Button
+						className="flex items-center gap-2 px-6! py-3! h-auto! bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none whitespace-nowrap"
+						onClick={handleCreateAgent}
+						disabled={isCreating}
+					>
+						<Plus className="w-4 h-4" />
+						{isCreating ? "Creating..." : "Create an agent"}
+					</Button>
+				</div>
 			</div>
-			<AgentList onCreateAgent={handleCreateAgent} />
+			<AgentList
+				search={search}
+				onClearSearch={() => setSearch("")}
+				onCreateAgent={handleCreateAgent}
+			/>
 		</PageContainer>
 	);
 }

--- a/web/src/app/(protected)/agents/page.tsx
+++ b/web/src/app/(protected)/agents/page.tsx
@@ -57,7 +57,7 @@ export default function AgentsPage() {
 				title="Insufficient privileges"
 				message="You need at least editor permissions to create agents."
 			/>
-			<div className="flex items-center justify-between my-8 mb-7">
+			<div className="flex items-center justify-between mb-7">
 				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
 					Agents
 				</h1>

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -1,9 +1,9 @@
 import { cookies } from "next/headers";
 
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { StoreInitializer } from "@/components/providers/store-initializer";
-import { ChatHeader } from "@/components/layout/chat-header";
+import { PageShell } from "@/components/layout/page-shell";
 
 export default async function ProtectedLayout({
 	children,
@@ -17,17 +17,7 @@ export default async function ProtectedLayout({
 		<SidebarProvider defaultOpen={defaultOpen} className="bg-surface">
 			<StoreInitializer />
 			<AppSidebar />
-			<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
-				<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
-					<div className="flex items-center gap-2 px-5 h-14 shrink-0 border-b border-border">
-						<SidebarTrigger className="cursor-pointer" />
-						<ChatHeader />
-					</div>
-					<div className="flex flex-1 flex-col gap-4 lg:px-8 px-4 py-5 min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-						{children}
-					</div>
-				</div>
-			</main>
+			<PageShell>{children}</PageShell>
 		</SidebarProvider>
 	);
 }

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -14,16 +14,18 @@ export default async function ProtectedLayout({
 	const defaultOpen = cookieStore.get("sidebar_state")?.value === "true";
 
 	return (
-		<SidebarProvider defaultOpen={defaultOpen}>
+		<SidebarProvider defaultOpen={defaultOpen} className="bg-surface">
 			<StoreInitializer />
 			<AppSidebar />
-			<main className="flex-1 flex flex-col h-screen w-full">
-				<div className="flex items-center gap-2 p-4 shrink-0">
-					<SidebarTrigger className="cursor-pointer" />
-					<ChatHeader />
-				</div>
-				<div className="flex flex-1 flex-col gap-4 lg:px-8 px-4 py-4 pt-0 min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-					{children}
+			<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
+				<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
+					<div className="flex items-center gap-2 px-5 h-14 shrink-0 border-b border-border">
+						<SidebarTrigger className="cursor-pointer" />
+						<ChatHeader />
+					</div>
+					<div className="flex flex-1 flex-col gap-4 lg:px-8 px-4 py-5 min-h-0 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+						{children}
+					</div>
 				</div>
 			</main>
 		</SidebarProvider>

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
@@ -18,6 +18,7 @@ export default function MCPServerCard({ server, onClick }: MCPServerCardProps) {
 			<div className="flex min-w-0 items-center gap-3">
 				<span className="flex size-[42px] shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-white/10 shadow-[0_2px_6px_rgba(30,45,40,0.14)]">
 					<Image
+						unoptimized
 						src={
 							server.iconUrl ??
 							"https://storage.googleapis.com/choose-assets/mcp.png"

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
@@ -11,35 +11,35 @@ export interface MCPServerCardProps {
 export default function MCPServerCard({ server, onClick }: MCPServerCardProps) {
 	return (
 		<div
-			className="group flex h-full flex-col rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card p-4 cursor-pointer transition-[border-color,box-shadow,transform] duration-[130ms] ease-out hover:-translate-y-px hover:border-[#cfe0d8] dark:hover:border-white/20 hover:shadow-[0_6px_18px_rgba(30,45,40,0.08)]"
+			className="group flex h-full flex-col rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card p-5 cursor-pointer transition-[border-color,box-shadow,transform] duration-[130ms] ease-out hover:-translate-y-px hover:border-[#cfe0d8] dark:hover:border-white/20 hover:shadow-[0_6px_18px_rgba(30,45,40,0.08)]"
 			onClick={onClick}
 		>
 			{/* Head: logo tile · name / URL */}
-			<div className="flex min-w-0 items-center gap-3">
-				<span className="flex size-[42px] shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-white/10 shadow-[0_2px_6px_rgba(30,45,40,0.14)]">
+			<div className="flex min-w-0 items-center gap-3.5">
+				<span className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-white/10 shadow-[0_2px_6px_rgba(30,45,40,0.14)]">
 					<Image
 						src={
 							server.iconUrl ??
 							"https://storage.googleapis.com/choose-assets/mcp.png"
 						}
 						alt={server.name}
-						width={42}
-						height={42}
+						width={48}
+						height={48}
 						className="size-full object-cover"
 					/>
 				</span>
 				<div className="min-w-0 flex-1">
-					<div className="truncate font-[family-name:var(--font-jakarta-sans)] text-[15px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
+					<div className="truncate font-[family-name:var(--font-jakarta-sans)] text-[16px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
 						{server.name}
 					</div>
-					<div className="mt-px truncate font-mono text-[10.5px] text-[#94a59d] dark:text-muted-foreground">
+					<div className="mt-0.5 truncate font-mono text-[11px] text-[#94a59d] dark:text-muted-foreground">
 						{server.url}
 					</div>
 				</div>
 			</div>
 
 			{/* Description — 2-line clamp, reserves height so rows align */}
-			<p className="mt-3 min-h-[38px] flex-1 font-[family-name:var(--font-dm-sans)] text-[12.5px] leading-[1.5] text-[#5f7068] dark:text-muted-foreground line-clamp-2">
+			<p className="mt-4 min-h-[44px] flex-1 font-[family-name:var(--font-dm-sans)] text-[13.5px] leading-relaxed text-[#5f7068] dark:text-muted-foreground line-clamp-2">
 				{server.description || "No description provided."}
 			</p>
 		</div>

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
@@ -15,31 +15,31 @@ export default function MCPServerCard({ server, onClick }: MCPServerCardProps) {
 			onClick={onClick}
 		>
 			{/* Head: logo tile · name / URL */}
-			<div className="flex min-w-0 items-center gap-3.5">
-				<span className="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-white/10 shadow-[0_2px_6px_rgba(30,45,40,0.14)]">
+			<div className="flex min-w-0 items-center gap-3">
+				<span className="flex size-[42px] shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-white/10 shadow-[0_2px_6px_rgba(30,45,40,0.14)]">
 					<Image
 						src={
 							server.iconUrl ??
 							"https://storage.googleapis.com/choose-assets/mcp.png"
 						}
 						alt={server.name}
-						width={48}
-						height={48}
+						width={42}
+						height={42}
 						className="size-full object-cover"
 					/>
 				</span>
 				<div className="min-w-0 flex-1">
-					<div className="truncate font-[family-name:var(--font-jakarta-sans)] text-[16px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
+					<div className="truncate font-[family-name:var(--font-jakarta-sans)] text-[15px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
 						{server.name}
 					</div>
-					<div className="mt-0.5 truncate font-mono text-[11px] text-[#94a59d] dark:text-muted-foreground">
+					<div className="mt-px truncate font-mono text-[10.5px] text-[#94a59d] dark:text-muted-foreground">
 						{server.url}
 					</div>
 				</div>
 			</div>
 
 			{/* Description — 2-line clamp, reserves height so rows align */}
-			<p className="mt-4 min-h-[44px] flex-1 font-[family-name:var(--font-dm-sans)] text-[13.5px] leading-relaxed text-[#5f7068] dark:text-muted-foreground line-clamp-2">
+			<p className="mt-4 min-h-[42px] flex-1 font-[family-name:var(--font-dm-sans)] text-[13px] leading-[1.55] text-[#5f7068] dark:text-muted-foreground line-clamp-2">
 				{server.description || "No description provided."}
 			</p>
 		</div>

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-card.tsx
@@ -11,40 +11,35 @@ export interface MCPServerCardProps {
 export default function MCPServerCard({ server, onClick }: MCPServerCardProps) {
 	return (
 		<div
-			className="group flex flex-col gap-4 p-7 rounded-3xl h-full bg-white dark:bg-card cursor-pointer transition-all duration-300"
-			style={{ boxShadow: "0 2px 12px rgba(0,0,0,0.06)" }}
-			onMouseEnter={(e) => {
-				e.currentTarget.style.transform = "translateY(-6px) scale(1.02)";
-				e.currentTarget.style.boxShadow =
-					"0 20px 40px -12px rgba(0,0,0,0.08), 0 0 0 2px rgba(0,0,0,0.04)";
-			}}
-			onMouseLeave={(e) => {
-				e.currentTarget.style.transform = "";
-				e.currentTarget.style.boxShadow = "0 2px 12px rgba(0,0,0,0.06)";
-			}}
+			className="group flex h-full flex-col rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card p-4 cursor-pointer transition-[border-color,box-shadow,transform] duration-[130ms] ease-out hover:-translate-y-px hover:border-[#cfe0d8] dark:hover:border-white/20 hover:shadow-[0_6px_18px_rgba(30,45,40,0.08)]"
 			onClick={onClick}
 		>
-			<div className="flex items-center gap-3.5 min-w-0">
-				<Image
-					src={
-						server.iconUrl ??
-						"https://storage.googleapis.com/choose-assets/mcp.png"
-					}
-					alt={server.name}
-					width={48}
-					height={48}
-					className="shrink-0 rounded-xl transition-transform duration-300 group-hover:rotate-[-8deg] group-hover:scale-110"
-				/>
-				<div className="min-w-0">
-					<h3 className="font-[family-name:var(--font-jakarta-sans)] text-[16px] font-bold text-[#1a1a2e] dark:text-foreground tracking-tight leading-tight truncate">
+			{/* Head: logo tile · name / URL */}
+			<div className="flex min-w-0 items-center gap-3">
+				<span className="flex size-[42px] shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white dark:bg-white/10 shadow-[0_2px_6px_rgba(30,45,40,0.14)]">
+					<Image
+						src={
+							server.iconUrl ??
+							"https://storage.googleapis.com/choose-assets/mcp.png"
+						}
+						alt={server.name}
+						width={42}
+						height={42}
+						className="size-full object-cover"
+					/>
+				</span>
+				<div className="min-w-0 flex-1">
+					<div className="truncate font-[family-name:var(--font-jakarta-sans)] text-[15px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
 						{server.name}
-					</h3>
-					<p className="font-[family-name:var(--font-dm-sans)] text-[13px] text-[#999] dark:text-muted-foreground font-medium mt-0.5 truncate">
+					</div>
+					<div className="mt-px truncate font-mono text-[10.5px] text-[#94a59d] dark:text-muted-foreground">
 						{server.url}
-					</p>
+					</div>
 				</div>
 			</div>
-			<p className="font-[family-name:var(--font-dm-sans)] text-[14px] leading-relaxed text-[#666] dark:text-muted-foreground line-clamp-2 flex-1">
+
+			{/* Description — 2-line clamp, reserves height so rows align */}
+			<p className="mt-3 min-h-[38px] flex-1 font-[family-name:var(--font-dm-sans)] text-[12.5px] leading-[1.5] text-[#5f7068] dark:text-muted-foreground line-clamp-2">
 				{server.description || "No description provided."}
 			</p>
 		</div>

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-dialog.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-dialog.tsx
@@ -304,6 +304,7 @@ export default function MCPServerDialog({
 							{selectedOfficial ? (
 								<div className="flex items-center gap-3 rounded-[18px] border-[1.5px] border-[#E0E8E4] dark:border-white/10 px-4 py-3">
 									<Image
+										unoptimized
 										src={selectedOfficial.iconUrl ?? DEFAULT_ICON}
 										alt={selectedOfficial.name}
 										width={24}
@@ -346,6 +347,7 @@ export default function MCPServerDialog({
 												className="flex w-full items-center gap-3 px-4 py-2.5 text-left hover:bg-[#F8FAF9] dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer first:rounded-t-[16px] last:rounded-b-[16px]"
 											>
 												<Image
+													unoptimized
 													src={s.iconUrl ?? DEFAULT_ICON}
 													alt={s.name}
 													width={24}
@@ -373,6 +375,7 @@ export default function MCPServerDialog({
 					{isEditMode && server && (
 						<div className="flex items-center gap-3.5 p-4 rounded-[18px] bg-[#F5F8F6] dark:bg-white/5 mb-7">
 							<Image
+								unoptimized
 								src={server.iconUrl ?? DEFAULT_ICON}
 								alt={server.name}
 								width={44}

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-list.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-list.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMcpServersStore } from "@/stores/mcp-servers-store";
 import { MCPServer } from "@/types/mcp-servers";
 import MCPServerCard from "./mcp-server-card";
 
 interface MCPServerListProps {
+	search?: string;
 	onServerClick?: (server: MCPServer) => void;
 }
 
-export default function MCPServerList({ onServerClick }: MCPServerListProps) {
+export default function MCPServerList({
+	search = "",
+	onServerClick,
+}: MCPServerListProps) {
 	const { mcpServers, fetchMcpServers, isInitialized } = useMcpServersStore();
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
@@ -35,6 +39,16 @@ export default function MCPServerList({ onServerClick }: MCPServerListProps) {
 		loadServers();
 	}, [fetchMcpServers, isInitialized]);
 
+	const filtered = useMemo(() => {
+		if (!search) return mcpServers;
+		const query = search.toLowerCase();
+		return mcpServers.filter(
+			(server) =>
+				server.name.toLowerCase().includes(query) ||
+				server.url.toLowerCase().includes(query),
+		);
+	}, [mcpServers, search]);
+
 	if (loading) return null;
 
 	if (error) {
@@ -49,8 +63,18 @@ export default function MCPServerList({ onServerClick }: MCPServerListProps) {
 		return (
 			<div className="flex items-center justify-center p-12 border border-border rounded-lg animate-in fade-in duration-300">
 				<div className="text-muted-foreground">
-					No MCP servers configured. Click the &quot;Add MCP Server&quot; button
+					No MCP servers configured. Click the &quot;Add MCP server&quot; button
 					to get started.
+				</div>
+			</div>
+		);
+	}
+
+	if (filtered.length === 0) {
+		return (
+			<div className="flex items-center justify-center p-12 animate-in fade-in duration-300">
+				<div className="text-muted-foreground">
+					No servers match your search.
 				</div>
 			</div>
 		);
@@ -58,7 +82,7 @@ export default function MCPServerList({ onServerClick }: MCPServerListProps) {
 
 	return (
 		<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 animate-in fade-in duration-300">
-			{mcpServers.map((server, i) => (
+			{filtered.map((server, i) => (
 				<div
 					key={server.id}
 					className="h-full animate-in fade-in slide-in-from-bottom-3 duration-400"

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-list.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-list.tsx
@@ -57,7 +57,7 @@ export default function MCPServerList({ onServerClick }: MCPServerListProps) {
 	}
 
 	return (
-		<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 animate-in fade-in duration-300">
+		<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 animate-in fade-in duration-300">
 			{mcpServers.map((server, i) => (
 				<div
 					key={server.id}

--- a/web/src/app/(protected)/mcp-servers/components/mcp-server-list.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/mcp-server-list.tsx
@@ -40,8 +40,8 @@ export default function MCPServerList({
 	}, [fetchMcpServers, isInitialized]);
 
 	const filtered = useMemo(() => {
-		if (!search) return mcpServers;
-		const query = search.toLowerCase();
+		const query = search.trim().toLowerCase();
+		if (!query) return mcpServers;
 		return mcpServers.filter(
 			(server) =>
 				server.name.toLowerCase().includes(query) ||

--- a/web/src/app/(protected)/mcp-servers/page.tsx
+++ b/web/src/app/(protected)/mcp-servers/page.tsx
@@ -29,7 +29,7 @@ export default function MCPServersPage() {
 
 	return (
 		<PageContainer>
-			<div className="flex items-center justify-between mb-7">
+			<div className="flex items-center justify-between my-8 mb-7">
 				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
 					MCP servers
 				</h1>

--- a/web/src/app/(protected)/mcp-servers/page.tsx
+++ b/web/src/app/(protected)/mcp-servers/page.tsx
@@ -6,11 +6,13 @@ import MCPServerDialog from "@/app/(protected)/mcp-servers/components/mcp-server
 import { MCPServer } from "@/types/mcp-servers";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SearchBar } from "@/components/ui/search-bar";
 import { PageContainer } from "@/components/layout/page-container";
 
 export default function MCPServersPage() {
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [editServer, setEditServer] = useState<MCPServer | null>(null);
+	const [search, setSearch] = useState("");
 
 	const handleAddServer = () => {
 		setEditServer(null);
@@ -29,19 +31,34 @@ export default function MCPServersPage() {
 
 	return (
 		<PageContainer>
-			<div className="flex items-center justify-between my-8 mb-7">
-				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
-					MCP servers
-				</h1>
-				<Button
-					onClick={handleAddServer}
-					className="flex items-center gap-2 !px-6 !py-3 !h-auto bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none"
-				>
-					<Plus className="w-4 h-4" />
-					Add MCP Server
-				</Button>
+			<div className="flex flex-col gap-5 my-8 sm:flex-row sm:items-start sm:justify-between">
+				<div className="min-w-0">
+					<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
+						MCP servers
+					</h1>
+					<p className="mt-1.5 font-[family-name:var(--font-dm-sans)] text-[15px] font-medium text-[#6B7F76] dark:text-muted-foreground">
+						Remote Model Context Protocol endpoints wired into your workspace.
+					</p>
+				</div>
+
+				<div className="flex items-center gap-3 shrink-0">
+					<SearchBar
+						placeholder="Search servers..."
+						value={search}
+						onChange={setSearch}
+						hint="⌘K"
+						className="w-full sm:w-72"
+					/>
+					<Button
+						onClick={handleAddServer}
+						className="flex items-center gap-2 px-6! py-3! h-auto! bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none whitespace-nowrap"
+					>
+						<Plus className="w-4 h-4" />
+						Add MCP server
+					</Button>
+				</div>
 			</div>
-			<MCPServerList onServerClick={handleEditServer} />
+			<MCPServerList search={search} onServerClick={handleEditServer} />
 
 			<MCPServerDialog
 				open={dialogOpen}

--- a/web/src/app/(protected)/mcp-servers/page.tsx
+++ b/web/src/app/(protected)/mcp-servers/page.tsx
@@ -29,7 +29,7 @@ export default function MCPServersPage() {
 
 	return (
 		<PageContainer>
-			<div className="flex items-center justify-between my-8 mb-7">
+			<div className="flex items-center justify-between mb-7">
 				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
 					MCP servers
 				</h1>

--- a/web/src/app/(protected)/settings/page.tsx
+++ b/web/src/app/(protected)/settings/page.tsx
@@ -103,7 +103,7 @@ export default function SettingsPage() {
 				}
 			/>
 
-			<div className="flex items-center justify-between my-8">
+			<div className="flex items-center justify-between mb-8">
 				<h1 className="font-primary font-extrabold text-2xl md:text-4xl tracking-tighter text-[#2A2F2D] dark:text-white">
 					Settings
 				</h1>

--- a/web/src/app/(protected)/settings/page.tsx
+++ b/web/src/app/(protected)/settings/page.tsx
@@ -103,7 +103,7 @@ export default function SettingsPage() {
 				}
 			/>
 
-			<div className="flex items-center justify-between mb-8">
+			<div className="flex items-center justify-between my-8">
 				<h1 className="font-primary font-extrabold text-2xl md:text-4xl tracking-tighter text-[#2A2F2D] dark:text-white">
 					Settings
 				</h1>

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -400,7 +400,10 @@ export default function UsersPage() {
 										{/* Status pill */}
 										<span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[#fbf2da] px-2.5 py-1 text-[11px] font-semibold text-[#9a7b14] dark:bg-amber-950 dark:text-amber-300">
 											<span className="size-[5px] rounded-full bg-[#d4a017]" />
-											{ROLE_LABELS[invite.role as Role] ?? invite.role} invite
+											{invite.role in ROLE_LABELS
+												? ROLE_LABELS[invite.role as Role]
+												: invite.role}{" "}
+											invite
 										</span>
 
 										{/* Actions */}

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -267,11 +267,11 @@ export default function UsersPage() {
 
 					{/* Member list panel */}
 					<div className="overflow-hidden rounded-[14px] border border-[#e1ebe6] bg-white dark:border-white/10 dark:bg-card">
-						<div className="grid grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] dark:border-white/5">
+						<div className="grid grid-cols-[1fr_auto_34px] md:grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] dark:border-white/5">
 							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
 								Name
 							</span>
-							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
+							<span className="hidden md:block text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
 								Email
 							</span>
 							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
@@ -292,25 +292,33 @@ export default function UsersPage() {
 								return (
 									<div
 										key={user.id}
-										className="group grid grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] transition-colors duration-[110ms] last:border-b-0 hover:bg-[#eff4f1] dark:border-white/5 dark:hover:bg-white/5"
+										className="group grid grid-cols-[1fr_auto_34px] md:grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] transition-colors duration-[110ms] last:border-b-0 hover:bg-[#eff4f1] dark:border-white/5 dark:hover:bg-white/5"
 									>
 										{/* Identity */}
 										<div className="flex min-w-0 items-center gap-3">
 											<span className="flex size-[34px] shrink-0 items-center justify-center rounded-full bg-[#e7f0eb] font-[family-name:var(--font-jakarta-sans)] text-[11.5px] font-bold text-[#3d8b63] dark:bg-emerald-950 dark:text-emerald-300">
 												{getInitials(user.name)}
 											</span>
-											<span className="truncate font-[family-name:var(--font-jakarta-sans)] text-[13.5px] font-semibold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
-												{user.name || "Unnamed"}
-											</span>
-											{isCurrentUser && (
-												<span className="shrink-0 rounded-[5px] bg-[#e7f0eb] px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-[0.06em] text-[#3d8b63] dark:bg-emerald-950 dark:text-emerald-300">
-													You
+											<div className="min-w-0">
+												<div className="flex min-w-0 items-center gap-2">
+													<span className="truncate font-[family-name:var(--font-jakarta-sans)] text-[13.5px] font-semibold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
+														{user.name || "Unnamed"}
+													</span>
+													{isCurrentUser && (
+														<span className="shrink-0 rounded-[5px] bg-[#e7f0eb] px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-[0.06em] text-[#3d8b63] dark:bg-emerald-950 dark:text-emerald-300">
+															You
+														</span>
+													)}
+												</div>
+												{/* Email folds under the name on mobile; own column on md+ */}
+												<span className="block truncate font-mono text-[11px] text-[#94a59d] dark:text-muted-foreground md:hidden">
+													{user.email}
 												</span>
-											)}
+											</div>
 										</div>
 
-										{/* Email */}
-										<span className="truncate font-mono text-[12px] text-[#5f7068] dark:text-muted-foreground">
+										{/* Email (column on md+) */}
+										<span className="hidden truncate font-mono text-[12px] text-[#5f7068] md:block dark:text-muted-foreground">
 											{user.email}
 										</span>
 
@@ -349,7 +357,7 @@ export default function UsersPage() {
 										<div className="flex justify-center">
 											{!isCurrentUser && (
 												<button
-													className="flex size-7 items-center justify-center rounded-[7px] text-[#94a59d] opacity-0 transition-all group-hover:opacity-100 hover:bg-[#fbe5e3] hover:text-[#b03a30] cursor-pointer dark:hover:bg-rose-950"
+													className="flex size-7 items-center justify-center rounded-[7px] text-[#94a59d] opacity-100 transition-all hover:bg-[#fbe5e3] hover:text-[#b03a30] cursor-pointer md:opacity-0 md:group-hover:opacity-100 dark:hover:bg-rose-950"
 													onClick={() => handleRemoveUser(user.id, user.name)}
 												>
 													<Trash2 className="size-[15px]" />
@@ -379,7 +387,7 @@ export default function UsersPage() {
 								{invites.map((invite) => (
 									<div
 										key={invite.id}
-										className="grid grid-cols-[1fr_140px_auto] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] last:border-b-0 dark:border-white/5"
+										className="flex flex-col gap-3 border-b border-[#edf2ef] px-[18px] py-[11px] last:border-b-0 md:grid md:grid-cols-[1fr_140px_auto] md:items-center md:gap-4 dark:border-white/5"
 									>
 										{/* Envelope + email + meta */}
 										<div className="flex min-w-0 items-center gap-3">

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -249,7 +249,9 @@ export default function UsersPage() {
 							return (
 								<button
 									key={filter.key}
-									onClick={() => setRoleFilter(filter.key)}
+									onClick={() => {
+									setRoleFilter(filter.key);
+								}}
 									className={`inline-flex items-center gap-2 rounded-full px-[13px] py-1.5 text-[12px] font-[family-name:var(--font-dm-sans)] cursor-pointer transition-colors ${
 										active
 											? "bg-[#e7f0eb] text-[#3d8b63] font-semibold dark:bg-emerald-950 dark:text-emerald-300"

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -37,6 +37,20 @@ const ROLE_LABELS: Record<Role, string> = {
 	member: "Member",
 };
 
+// Only the dot is tinted; the role-control chrome stays neutral.
+const ROLE_DOT: Record<Role, string> = {
+	admin: "#2f6f4e",
+	editor: "#9a7b3c",
+	member: "#6f7670",
+};
+
+const ROLE_FILTERS: { key: "all" | Role; label: string }[] = [
+	{ key: "all", label: "All" },
+	{ key: "admin", label: "Admins" },
+	{ key: "editor", label: "Editors" },
+	{ key: "member", label: "Members" },
+];
+
 function getInitials(name: string | null | undefined): string {
 	if (!name) return "U";
 	const parts = name.trim().split(" ");
@@ -68,6 +82,7 @@ export default function UsersPage() {
 	const [users, setUsers] = useState<User[]>([]);
 	const [invites, setInvites] = useState<Invite[]>([]);
 	const [search, setSearch] = useState("");
+	const [roleFilter, setRoleFilter] = useState<"all" | Role>("all");
 	const [isLoading, setIsLoading] = useState(true);
 	const [errorDialogOpen, setErrorDialogOpen] = useState(false);
 	const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
@@ -119,15 +134,29 @@ export default function UsersPage() {
 		}
 	};
 
+	const roleCounts = useMemo(
+		() => ({
+			all: users.length,
+			admin: users.filter((u) => u.role === "admin").length,
+			editor: users.filter((u) => u.role === "editor").length,
+			member: users.filter((u) => u.role === "member").length,
+		}),
+		[users],
+	);
+
 	const filteredUsers = useMemo(() => {
-		if (!search.trim()) return users;
-		const query = search.toLowerCase();
-		return users.filter(
-			(user) =>
-				user.name?.toLowerCase().includes(query) ||
-				user.email?.toLowerCase().includes(query),
-		);
-	}, [users, search]);
+		let list = users;
+		if (roleFilter !== "all") list = list.filter((u) => u.role === roleFilter);
+		const query = search.trim().toLowerCase();
+		if (query) {
+			list = list.filter(
+				(user) =>
+					user.name?.toLowerCase().includes(query) ||
+					user.email?.toLowerCase().includes(query),
+			);
+		}
+		return list;
+	}, [users, search, roleFilter]);
 
 	const handleRoleChange = async (userId: string, newRole: Role) => {
 		try {
@@ -183,180 +212,224 @@ export default function UsersPage() {
 				onOpenChange={setInviteDialogOpen}
 				onInviteCreated={(invite) => setInvites((prev) => [...prev, invite])}
 			/>
-			<div className="flex items-center justify-between my-8 mb-7">
-				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
-					Users
-				</h1>
-				<Button
-					className="flex items-center gap-2 !px-6 !py-3 !h-auto bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none"
-					onClick={() => setInviteDialogOpen(true)}
-				>
-					<Plus className="w-4 h-4" />
-					Invite user
-				</Button>
+			<div className="flex flex-col gap-5 my-8 sm:flex-row sm:items-start sm:justify-between">
+				<div className="min-w-0">
+					<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
+						Users
+					</h1>
+					<p className="mt-1.5 font-[family-name:var(--font-dm-sans)] text-[15px] font-medium text-[#6B7F76] dark:text-muted-foreground">
+						Manage who&apos;s in your workspace and what they can do.
+					</p>
+				</div>
+
+				<div className="flex items-center gap-3 shrink-0">
+					<SearchBar
+						placeholder="Search users..."
+						value={search}
+						onChange={setSearch}
+						hint="⌘K"
+						className="w-full sm:w-72"
+					/>
+					<Button
+						className="flex items-center gap-2 px-6! py-3! h-auto! bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none whitespace-nowrap"
+						onClick={() => setInviteDialogOpen(true)}
+					>
+						<Plus className="w-4 h-4" />
+						Invite user
+					</Button>
+				</div>
 			</div>
 
-			{isLoading ? null : (<>
-			<SearchBar
-				placeholder="Search users..."
-				value={search}
-				onChange={setSearch}
-				className="mb-6 md:max-w-xs w-full"
-			/>
-
-			{/* Table header */}
-			<div className="flex items-center py-3 pl-[76px] pr-5 mb-1 font-[family-name:var(--font-dm-sans)] animate-in fade-in duration-300">
-				<div className="flex-1 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
-					Name
-				</div>
-				<div className="flex-[1.2] text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
-					Email
-				</div>
-				<div className="min-w-[100px] text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
-					Role
-				</div>
-				<div className="w-[52px]" />
-			</div>
-
-			{/* User rows */}
-			<div>
-				{filteredUsers.length === 0 ? (
-					<div className="text-center py-12 text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium">
-						{search ? "No users match your search" : "No members in this workspace."}
-					</div>
-				) : (
-					filteredUsers.map((user, i) => {
-						const isCurrentUser = user.id === currentUser?.id;
-
-						return (
-							<div
-								key={user.id}
-								className="group flex items-center py-3.5 px-5 rounded-[18px] mb-1 transition-all duration-200 hover:bg-[#F8FAF9] dark:hover:bg-white/5 hover:translate-x-1 animate-in fade-in slide-in-from-bottom-3 duration-400"
-								style={{ animationDelay: `${i * 40}ms`, animationFillMode: "both" }}
-							>
-								{/* Avatar */}
-								<div className="shrink-0 w-[42px] h-[42px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[13.5px] font-bold text-[#6B7F76] dark:text-muted-foreground transition-transform duration-300 group-hover:scale-105">
-									{getInitials(user.name)}
-								</div>
-
-								{/* Name */}
-								<div className="flex-1 min-w-0 ml-3.5 font-[family-name:var(--font-dm-sans)]">
-									<div className="flex items-center gap-2 text-[14.5px] font-semibold text-[#1E2D28] dark:text-foreground">
-										<span className="truncate">{user.name || "Unnamed"}</span>
-										{isCurrentUser && (
-											<span className="shrink-0 text-[10px] font-bold text-[#8FB5A3] bg-[#EDF4F0] dark:bg-white/10 dark:text-emerald-400 px-2 py-0.5 rounded-full uppercase tracking-[0.04em]">
-												You
-											</span>
-										)}
-									</div>
-								</div>
-
-								{/* Email */}
-								<div className="flex-[1.2] min-w-0 font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#8FA89E] dark:text-muted-foreground font-medium truncate">
-									{user.email}
-								</div>
-
-								{/* Role */}
-								<div className="min-w-[100px]">
-									{isCurrentUser ? (
-										<span className="font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#6B7F76] dark:text-muted-foreground px-4 py-1.5">
-											{ROLE_LABELS[user.role]}
-										</span>
-									) : (
-										<SageDropdownMenu
-											trigger={
-												<button className="w-[116px] rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent text-[13px] font-semibold font-[family-name:var(--font-dm-sans)] text-[#1E2D28] dark:text-foreground h-auto py-1.5 px-4 flex items-center justify-between gap-1 cursor-pointer hover:border-[#A3B5AD] transition-colors">
-													<span>{ROLE_LABELS[user.role]}</span>
-													<ChevronDown className="size-3.5 text-[#8FA89E] shrink-0" />
-												</button>
-											}
-											items={[
-												{ label: "Admin", onClick: () => handleRoleChange(user.id, "admin"), active: user.role === "admin" },
-												{ label: "Editor", onClick: () => handleRoleChange(user.id, "editor"), active: user.role === "editor" },
-												{ label: "Member", onClick: () => handleRoleChange(user.id, "member"), active: user.role === "member" },
-											]}
-										/>
-									)}
-								</div>
-
-								{/* Delete */}
-								<div className="w-[52px] flex justify-center">
-									{!isCurrentUser && (
-										<button
-											className="w-9 h-9 rounded-xl flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all duration-200 hover:bg-[#F0F3F2] dark:hover:bg-white/10 cursor-pointer"
-											onClick={() => handleRemoveUser(user.id, user.name)}
-										>
-											<Trash2 className="h-[15px] w-[15px] text-[#A3B5AD]" />
-										</button>
-									)}
-								</div>
-							</div>
-						);
-					})
-				)}
-			</div>
-
-			{invites.length > 0 && (
-				<div className="py-10">
-					<h2 className="font-[family-name:var(--font-jakarta-sans)] font-bold text-lg tracking-tight text-[#111111] dark:text-white mb-2">
-						Pending invites
-					</h2>
-					<div>
-						{invites.map((invite) => (
-							<div
-								key={invite.id}
-								className="group flex items-center py-3.5 px-5 rounded-[18px] mb-1 transition-all duration-200 hover:bg-[#F8FAF9] dark:hover:bg-white/5 hover:translate-x-1"
-							>
-								{/* Mail icon avatar */}
-								<div className="shrink-0 w-[42px] h-[42px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-dashed border-[#E0E8E4] dark:border-white/10 flex items-center justify-center">
-									<Mail className="h-4 w-4 text-[#A3B5AD]" />
-								</div>
-
-								{/* Email + meta */}
-								<div className="flex-1 min-w-0 ml-3.5 font-[family-name:var(--font-dm-sans)]">
-									<div className="text-[14.5px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
-										{invite.email}
-									</div>
-									<div className="text-[12px] text-[#B8C8C0] dark:text-muted-foreground font-medium mt-0.5">
-										Invited by {getInviterShortName(invite.invitedByName)} · {timeAgo(invite.createdAt)}
-									</div>
-								</div>
-
-								{/* Role */}
-								<span className="shrink-0 font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#6B7F76] dark:text-muted-foreground border-[1.5px] border-[#E0E8E4] dark:border-white/10 rounded-full px-4 py-1.5 text-center min-w-[80px]">
-									{ROLE_LABELS[invite.role as Role] ?? invite.role}
-								</span>
-
-								{/* Copy link */}
+			{isLoading ? null : (
+				<>
+					{/* Role filter chips */}
+					<div className="flex flex-wrap items-center gap-2 mb-5">
+						{ROLE_FILTERS.map((filter) => {
+							const active = roleFilter === filter.key;
+							return (
 								<button
-									className={`shrink-0 flex items-center gap-1.5 ml-2.5 px-4 py-1.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold cursor-pointer transition-all duration-200 ${
-										copiedInviteId === invite.id
-											? "bg-[#EDF4F0] dark:bg-white/10 text-[#3D8B63] dark:text-emerald-400 border-[#3D8B63]/20"
-											: "bg-white dark:bg-transparent text-[#6B7F76] dark:text-muted-foreground hover:border-[#A3B5AD]"
+									key={filter.key}
+									onClick={() => setRoleFilter(filter.key)}
+									className={`inline-flex items-center gap-2 rounded-full px-[13px] py-1.5 text-[12px] font-[family-name:var(--font-dm-sans)] cursor-pointer transition-colors ${
+										active
+											? "bg-[#e7f0eb] text-[#3d8b63] font-semibold dark:bg-emerald-950 dark:text-emerald-300"
+											: "border border-[#e1ebe6] text-[#5f7068] hover:bg-[#f8faf9] dark:border-white/10 dark:text-muted-foreground dark:hover:bg-white/5"
 									}`}
-									onClick={() => handleCopyInviteLink(invite)}
 								>
-									{copiedInviteId === invite.id ? (
-										<Check className="h-3.5 w-3.5" />
-									) : (
-										<Copy className="h-3.5 w-3.5" />
-									)}
-									{copiedInviteId === invite.id ? "Copied!" : "Copy link"}
+									{filter.label}
+									<span className="font-mono text-[10.5px] opacity-70">
+										{roleCounts[filter.key]}
+									</span>
 								</button>
-
-								{/* Delete invite */}
-								<button
-									className="w-9 h-9 rounded-xl flex items-center justify-center ml-2 opacity-0 group-hover:opacity-100 transition-all duration-200 hover:bg-[#F0F3F2] dark:hover:bg-white/10 cursor-pointer"
-									onClick={() => handleDeleteInvite(invite.id)}
-								>
-									<Trash2 className="h-[15px] w-[15px] text-[#A3B5AD]" />
-								</button>
-							</div>
-						))}
+							);
+						})}
 					</div>
-				</div>
+
+					{/* Member list panel */}
+					<div className="overflow-hidden rounded-[14px] border border-[#e1ebe6] bg-white dark:border-white/10 dark:bg-card">
+						<div className="grid grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] dark:border-white/5">
+							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
+								Name
+							</span>
+							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
+								Email
+							</span>
+							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
+								Role
+							</span>
+							<span />
+						</div>
+
+						{filteredUsers.length === 0 ? (
+							<div className="px-[18px] py-12 text-center text-[14px] font-medium text-[#A3B5AD] dark:text-muted-foreground">
+								{search || roleFilter !== "all"
+									? "No users match your filters."
+									: "No members in this workspace."}
+							</div>
+						) : (
+							filteredUsers.map((user) => {
+								const isCurrentUser = user.id === currentUser?.id;
+								return (
+									<div
+										key={user.id}
+										className="group grid grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] transition-colors duration-[110ms] last:border-b-0 hover:bg-[#eff4f1] dark:border-white/5 dark:hover:bg-white/5"
+									>
+										{/* Identity */}
+										<div className="flex min-w-0 items-center gap-3">
+											<span className="flex size-[34px] shrink-0 items-center justify-center rounded-full bg-[#e7f0eb] font-[family-name:var(--font-jakarta-sans)] text-[11.5px] font-bold text-[#3d8b63] dark:bg-emerald-950 dark:text-emerald-300">
+												{getInitials(user.name)}
+											</span>
+											<span className="truncate font-[family-name:var(--font-jakarta-sans)] text-[13.5px] font-semibold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
+												{user.name || "Unnamed"}
+											</span>
+											{isCurrentUser && (
+												<span className="shrink-0 rounded-[5px] bg-[#e7f0eb] px-1.5 py-0.5 text-[9.5px] font-bold uppercase tracking-[0.06em] text-[#3d8b63] dark:bg-emerald-950 dark:text-emerald-300">
+													You
+												</span>
+											)}
+										</div>
+
+										{/* Email */}
+										<span className="truncate font-mono text-[12px] text-[#5f7068] dark:text-muted-foreground">
+											{user.email}
+										</span>
+
+										{/* Role */}
+										<div className="min-w-0">
+											{isCurrentUser ? (
+												<span className="inline-flex items-center gap-2 font-[family-name:var(--font-dm-sans)] text-[13px] font-medium text-[#5f7068] dark:text-muted-foreground">
+													<span
+														className="size-1.5 rounded-full"
+														style={{ background: ROLE_DOT[user.role] }}
+													/>
+													{ROLE_LABELS[user.role]}
+												</span>
+											) : (
+												<SageDropdownMenu
+													trigger={
+														<button className="inline-flex items-center gap-2 rounded-lg border border-[#e1ebe6] bg-white px-2.5 py-[5px] font-[family-name:var(--font-dm-sans)] text-[13px] font-medium text-[#1e2d28] cursor-pointer transition-colors hover:border-[#A3B5AD] dark:border-white/10 dark:bg-transparent dark:text-foreground">
+															<span
+																className="size-1.5 rounded-full"
+																style={{ background: ROLE_DOT[user.role] }}
+															/>
+															{ROLE_LABELS[user.role]}
+															<ChevronDown className="size-3.5 text-[#94a59d]" />
+														</button>
+													}
+													items={[
+														{ label: "Admin", onClick: () => handleRoleChange(user.id, "admin"), active: user.role === "admin" },
+														{ label: "Editor", onClick: () => handleRoleChange(user.id, "editor"), active: user.role === "editor" },
+														{ label: "Member", onClick: () => handleRoleChange(user.id, "member"), active: user.role === "member" },
+													]}
+												/>
+											)}
+										</div>
+
+										{/* Remove */}
+										<div className="flex justify-center">
+											{!isCurrentUser && (
+												<button
+													className="flex size-7 items-center justify-center rounded-[7px] text-[#94a59d] opacity-0 transition-all group-hover:opacity-100 hover:bg-[#fbe5e3] hover:text-[#b03a30] cursor-pointer dark:hover:bg-rose-950"
+													onClick={() => handleRemoveUser(user.id, user.name)}
+												>
+													<Trash2 className="size-[15px]" />
+												</button>
+											)}
+										</div>
+									</div>
+								);
+							})
+						)}
+					</div>
+
+					{/* Pending invites */}
+					{invites.length > 0 && (
+						<>
+							<div className="flex items-baseline gap-2.5 pt-6 pb-3">
+								<span className="font-[family-name:var(--font-jakarta-sans)] text-[14px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
+									Pending invites
+								</span>
+								<span className="text-[11.5px] text-[#94a59d]">
+									{invites.length}
+								</span>
+								<span className="h-px flex-1 self-center bg-[#e1ebe6] dark:bg-white/10" />
+							</div>
+
+							<div className="overflow-hidden rounded-[14px] border border-[#e1ebe6] bg-white dark:border-white/10 dark:bg-card">
+								{invites.map((invite) => (
+									<div
+										key={invite.id}
+										className="grid grid-cols-[1fr_140px_auto] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] last:border-b-0 dark:border-white/5"
+									>
+										{/* Envelope + email + meta */}
+										<div className="flex min-w-0 items-center gap-3">
+											<span className="flex size-[34px] shrink-0 items-center justify-center rounded-full border border-dashed border-[#e1ebe6] bg-surface text-[#94a59d] dark:border-white/10 dark:bg-white/5">
+												<Mail className="size-[15px]" />
+											</span>
+											<div className="min-w-0">
+												<div className="truncate font-mono text-[12.5px] font-medium text-[#1e2d28] dark:text-foreground">
+													{invite.email}
+												</div>
+												<div className="truncate text-[11px] text-[#94a59d] mt-0.5">
+													Invited {timeAgo(invite.createdAt)} · by{" "}
+													{getInviterShortName(invite.invitedByName)}
+												</div>
+											</div>
+										</div>
+
+										{/* Status pill */}
+										<span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[#fbf2da] px-2.5 py-1 text-[11px] font-semibold text-[#9a7b14] dark:bg-amber-950 dark:text-amber-300">
+											<span className="size-[5px] rounded-full bg-[#d4a017]" />
+											{ROLE_LABELS[invite.role as Role] ?? invite.role} invite
+										</span>
+
+										{/* Actions */}
+										<div className="flex items-center gap-1.5">
+											<button
+												className="flex items-center gap-1.5 rounded-lg border border-[#e1ebe6] px-3 py-1.5 font-[family-name:var(--font-dm-sans)] text-[12px] font-medium text-[#5f7068] cursor-pointer transition-colors hover:bg-[#f8faf9] dark:border-white/10 dark:text-muted-foreground dark:hover:bg-white/5"
+												onClick={() => handleCopyInviteLink(invite)}
+											>
+												{copiedInviteId === invite.id ? (
+													<Check className="size-3.5" />
+												) : (
+													<Copy className="size-3.5" />
+												)}
+												{copiedInviteId === invite.id ? "Copied!" : "Copy link"}
+											</button>
+											<button
+												className="rounded-lg border border-[#e1ebe6] px-3 py-1.5 font-[family-name:var(--font-dm-sans)] text-[12px] font-medium text-[#b03a30] cursor-pointer transition-colors hover:bg-[#fbe5e3] dark:border-white/10 dark:hover:bg-rose-950"
+												onClick={() => handleDeleteInvite(invite.id)}
+											>
+												Revoke
+											</button>
+										</div>
+									</div>
+								))}
+							</div>
+						</>
+					)}
+				</>
 			)}
-			</>)}
 		</PageContainer>
 	);
 }

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -183,7 +183,7 @@ export default function UsersPage() {
 				onOpenChange={setInviteDialogOpen}
 				onInviteCreated={(invite) => setInvites((prev) => [...prev, invite])}
 			/>
-			<div className="flex items-center justify-between mb-7">
+			<div className="flex items-center justify-between my-8 mb-7">
 				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
 					Users
 				</h1>

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -183,7 +183,7 @@ export default function UsersPage() {
 				onOpenChange={setInviteDialogOpen}
 				onInviteCreated={(invite) => setInvites((prev) => [...prev, invite])}
 			/>
-			<div className="flex items-center justify-between my-8 mb-7">
+			<div className="flex items-center justify-between mb-7">
 				<h1 className="font-[family-name:var(--font-jakarta-sans)] font-extrabold text-[32px] tracking-[-0.03em] text-[#111111] dark:text-white">
 					Users
 				</h1>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -62,7 +62,7 @@
 
 :root {
 	--radius: 0.625rem;
-	--surface: #f1f6f4;
+	--surface: #f6f9f7;
 	--background: oklch(1 0 0);
 	--foreground: oklch(0.145 0 0);
 	--card: oklch(1 0 0);

--- a/web/src/components/ai-elements/tool.tsx
+++ b/web/src/components/ai-elements/tool.tsx
@@ -134,6 +134,7 @@ export const ToolHeader = ({
 			<div className="flex items-center gap-3">
 				{mcpServerIcon ? (
 					<Image
+						unoptimized
 						src={mcpServerIcon}
 						alt={mcpServerName}
 						width={20}

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -256,7 +256,7 @@ export function AppSidebar() {
 					</SidebarGroup>
 
 					<SidebarGroup className="mt-auto">
-						<SidebarGroupLabel className="font-[family-name:var(--font-dm-sans)] text-[10.5px] font-semibold uppercase tracking-[0.06em] text-sidebar-section-label">
+						<SidebarGroupLabel className="font-[family-name:var(--font-dm-sans)] text-[10.5px] font-semibold uppercase tracking-[0.06em] text-sidebar-section-label group-data-[collapsible=icon]:mt-0">
 							Workspace
 						</SidebarGroupLabel>
 						<SidebarGroupContent>

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -242,7 +242,9 @@ export function AppSidebar() {
 														label: "Delete",
 														icon: <Trash2 />,
 														destructive: true,
-														onClick: () => handleDeleteThread(thread.id),
+														onClick: () => {
+														handleDeleteThread(thread.id);
+													},
 													},
 												]}
 											/>
@@ -326,7 +328,9 @@ export function AppSidebar() {
 									{
 										label: "Settings",
 										icon: <Settings />,
-										onClick: () => router.push("/settings"),
+										onClick: () => {
+											router.push("/settings");
+										},
 									},
 									{
 										label: "Documentation",
@@ -338,8 +342,9 @@ export function AppSidebar() {
 										label:
 											resolvedTheme === "dark" ? "Light mode" : "Dark mode",
 										icon: resolvedTheme === "dark" ? <Sun /> : <Moon />,
-										onClick: () =>
-											setTheme(resolvedTheme === "dark" ? "light" : "dark"),
+										onClick: () => {
+											setTheme(resolvedTheme === "dark" ? "light" : "dark");
+										},
 									},
 									{ separator: true },
 									{

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -182,7 +182,7 @@ export function AppSidebar() {
 											>
 												<Link
 													href={`/agents/${thread.agentId}/chat/${thread.id}`}
-													className="h-full px-3 flex items-center gap-2.5 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center"
+													className="h-full pl-1 pr-3 flex items-center gap-2.5 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center"
 												>
 													<AgentAvatar
 														color={thread.agentColor}

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -252,7 +252,7 @@ export function AppSidebar() {
 						</SidebarGroupContent>
 					</SidebarGroup>
 
-					<SidebarGroup className="mt-auto pt-3">
+					<SidebarGroup className="mt-auto">
 						<SidebarGroupLabel className="font-[family-name:var(--font-dm-sans)] text-[10.5px] font-semibold uppercase tracking-[0.06em] text-sidebar-section-label">
 							Workspace
 						</SidebarGroupLabel>

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -97,9 +97,9 @@ export function AppSidebar() {
 	};
 	return (
 		<>
-			<Sidebar variant="floating">
+			<Sidebar variant="floating" collapsible="icon">
 				<SidebarHeader>
-					<div className="flex items-center gap-1 px-2 py-2">
+					<div className="flex items-center gap-1 px-2 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
 						<div className="flex size-8 items-center justify-center rounded-lg text-primary-foreground">
 							<Image
 								src="/logo.svg"
@@ -116,7 +116,7 @@ export function AppSidebar() {
 								className="hidden dark:block"
 							/>
 						</div>
-						<div className="flex flex-col">
+						<div className="flex flex-col group-data-[collapsible=icon]:hidden">
 							<span className="font-sans text-base font-semibold">auxilia</span>
 						</div>
 					</div>
@@ -124,7 +124,7 @@ export function AppSidebar() {
 
 				<SidebarContent>
 					<SidebarGroup>
-						<div className="px-3">
+						<div className="px-3 group-data-[collapsible=icon]:px-0">
 							<button
 								onClick={() => {
 									if (agents.length > 0) {
@@ -135,10 +135,13 @@ export function AppSidebar() {
 									}
 								}}
 								disabled={agents.length === 0}
-								className="w-full py-2.5 px-4 rounded-full border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-center gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed"
+								title="New thread"
+								className="w-full py-2.5 px-4 rounded-full border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-center gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:size-[38px] group-data-[collapsible=icon]:w-[38px] group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:rounded-[11px] group-data-[collapsible=icon]:mx-auto"
 							>
-								<SquarePen className="size-4" />
-								New thread
+								<SquarePen className="size-4 shrink-0" />
+								<span className="group-data-[collapsible=icon]:hidden">
+									New thread
+								</span>
 							</button>
 						</div>
 					</SidebarGroup>
@@ -159,18 +162,23 @@ export function AppSidebar() {
 												asChild
 												isActive={isActive}
 												tooltip={thread.firstMessageContent}
-												className="h-auto rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent"
+												className="h-auto rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:rounded-full group-data-[collapsible=icon]:hover:translate-x-0 group-data-[collapsible=icon]:data-[active=true]:bg-transparent"
 											>
 												<Link
 													href={`/agents/${thread.agentId}/chat/${thread.id}`}
-													className="px-3 py-2.5 flex items-center gap-2.5"
+													className="px-3 py-2.5 flex items-center gap-2.5 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0 group-data-[collapsible=icon]:justify-center"
 												>
 													<AgentAvatar
 														color={thread.agentColor}
 														emoji={thread.agentEmoji}
 														size="sm"
+														className={
+															isActive
+																? "group-data-[collapsible=icon]:ring-2 group-data-[collapsible=icon]:ring-sidebar-primary"
+																: undefined
+														}
 													/>
-													<div className="flex-1 min-w-0 text-left">
+													<div className="flex-1 min-w-0 text-left group-data-[collapsible=icon]:hidden">
 														<div
 															className={`font-[family-name:var(--font-dm-sans)] text-[14px] truncate leading-[1.45] ${isActive ? "font-semibold" : "font-medium"} text-sidebar-foreground`}
 														>
@@ -188,7 +196,7 @@ export function AppSidebar() {
 															alt="Slack"
 															height={16}
 															width={16}
-															className="h-4 w-4 shrink-0"
+															className="h-4 w-4 shrink-0 group-data-[collapsible=icon]:hidden"
 															title="Thread initiated in Slack"
 														/>
 													)}
@@ -243,7 +251,7 @@ export function AppSidebar() {
 														size={17}
 													/>
 													<span
-														className={`font-[family-name:var(--font-dm-sans)] text-[13.5px] ${isNavActive ? "font-semibold text-sidebar-foreground" : "font-medium text-sidebar-muted"}`}
+														className={`font-[family-name:var(--font-dm-sans)] text-[13.5px] group-data-[collapsible=icon]:hidden ${isNavActive ? "font-semibold text-sidebar-foreground" : "font-medium text-sidebar-muted"}`}
 													>
 														{item.title}
 													</span>
@@ -264,14 +272,15 @@ export function AppSidebar() {
 								trigger={
 									<SidebarMenuButton
 										size="lg"
-										className="rounded-[18px] bg-sidebar-hover data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer px-3 py-2.5"
+										tooltip={user?.name || "User"}
+										className="rounded-[18px] bg-sidebar-hover data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer px-3 py-2.5 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto"
 									>
 										<Avatar className="h-9 w-9 rounded-full">
 											<AvatarFallback className="rounded-full bg-[#111111] dark:bg-white text-white dark:text-[#111111] text-xs font-bold">
 												{getInitials(user?.name ?? undefined)}
 											</AvatarFallback>
 										</Avatar>
-										<div className="grid flex-1 text-left leading-tight min-w-0">
+										<div className="grid flex-1 text-left leading-tight min-w-0 group-data-[collapsible=icon]:hidden">
 											<span className="font-[family-name:var(--font-dm-sans)] truncate text-[13px] font-semibold text-sidebar-foreground">
 												{user?.name || "User"}
 											</span>

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -255,7 +255,7 @@ export function AppSidebar() {
 												asChild
 												isActive={isNavActive}
 												tooltip={item.title}
-												className="rounded-[14px] pl-3 transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:mx-auto"
+												className="rounded-[14px] pl-3 transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:w-full! group-data-[collapsible=icon]:pl-3! group-data-[collapsible=icon]:hover:translate-x-0"
 											>
 												<Link href={item.href}>
 													<item.icon
@@ -281,7 +281,7 @@ export function AppSidebar() {
 					</SidebarGroup>
 				</SidebarContent>
 
-				<SidebarFooter className="px-3 pb-3">
+				<SidebarFooter className="px-2 pb-3">
 					<SidebarMenu>
 						<SidebarMenuItem>
 							<SageDropdownMenu
@@ -289,7 +289,7 @@ export function AppSidebar() {
 									<SidebarMenuButton
 										size="lg"
 										tooltip={user?.name || "User"}
-										className="rounded-[18px] bg-sidebar-hover data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer px-3 py-2.5 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto"
+										className="rounded-[18px] bg-sidebar-hover data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer pl-0.5 pr-3 group-data-[collapsible=icon]:bg-transparent group-data-[collapsible=icon]:w-full! group-data-[collapsible=icon]:h-12! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:pl-0.5!"
 									>
 										<Avatar className="h-9 w-9 rounded-full">
 											<AvatarFallback className="rounded-full bg-[#111111] dark:bg-white text-white dark:text-[#111111] text-xs font-bold">

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -103,7 +103,7 @@ export function AppSidebar() {
 		<>
 			<Sidebar variant="floating" collapsible="icon">
 				<SidebarHeader>
-					<div className="flex items-center gap-2 px-2 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+					<div className="flex h-10 items-center gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
 						<button
 							onClick={toggleSidebar}
 							title="Toggle sidebar"
@@ -152,7 +152,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full py-2.5 px-4 rounded-full border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-center gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:size-[38px] group-data-[collapsible=icon]:w-[38px] group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:rounded-[11px] group-data-[collapsible=icon]:mx-auto"
+								className="w-full h-10 px-4 rounded-full border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-center gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">
@@ -178,11 +178,11 @@ export function AppSidebar() {
 												asChild
 												isActive={isActive}
 												tooltip={thread.firstMessageContent}
-												className="h-auto rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:size-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:rounded-full group-data-[collapsible=icon]:hover:translate-x-0 group-data-[collapsible=icon]:data-[active=true]:bg-transparent"
+												className="h-12! rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:w-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:hover:translate-x-0 group-data-[collapsible=icon]:data-[active=true]:bg-transparent"
 											>
 												<Link
 													href={`/agents/${thread.agentId}/chat/${thread.id}`}
-													className="px-3 py-2.5 flex items-center gap-2.5 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0 group-data-[collapsible=icon]:justify-center"
+													className="h-full px-3 flex items-center gap-2.5 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center"
 												>
 													<AgentAvatar
 														color={thread.agentColor}

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -103,7 +103,7 @@ export function AppSidebar() {
 		<>
 			<Sidebar variant="floating" collapsible="icon">
 				<SidebarHeader>
-					<div className="flex h-10 items-center gap-2 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+					<div className="flex h-10 items-center gap-2 px-2">
 						<button
 							onClick={toggleSidebar}
 							title="Toggle sidebar"
@@ -133,7 +133,7 @@ export function AppSidebar() {
 						</button>
 						<span
 							className="font-sans text-base font-semibold group-data-[collapsible=icon]:hidden animate-in fade-in duration-200"
-							style={{ animationDelay: "250ms", animationFillMode: "both" }}
+							style={{ animationDelay: "100ms", animationFillMode: "both" }}
 						>
 							auxilia
 						</span>

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -17,6 +17,7 @@ import {
 	Users,
 	Moon,
 	Sun,
+	PanelLeftOpen,
 } from "lucide-react";
 import {
 	Sidebar,
@@ -30,6 +31,8 @@ import {
 	SidebarMenuButton,
 	SidebarMenuItem,
 	SidebarMenuAction,
+	SidebarTrigger,
+	useSidebar,
 } from "@/components/ui/sidebar";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { SageDropdownMenu } from "@/components/ui/sage-dropdown-menu";
@@ -74,6 +77,7 @@ export function AppSidebar() {
 	const { threads, fetchThreads, removeThread } = useThreadsStore();
 	const { user, fetchUser, logout } = useUserStore();
 	const { resolvedTheme, setTheme } = useTheme();
+	const { toggleSidebar } = useSidebar();
 
 	useEffect(() => {
 		fetchUser();
@@ -99,26 +103,38 @@ export function AppSidebar() {
 		<>
 			<Sidebar variant="floating" collapsible="icon">
 				<SidebarHeader>
-					<div className="flex items-center gap-1 px-2 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
-						<div className="flex size-8 items-center justify-center rounded-lg text-primary-foreground">
-							<Image
-								src="/logo.svg"
-								alt="auxilia"
-								height={24}
-								width={24}
-								className="dark:hidden"
-							/>
-							<Image
-								src="/logo-dark.svg"
-								alt="auxilia"
-								height={24}
-								width={24}
-								className="hidden dark:block"
-							/>
-						</div>
-						<div className="flex flex-col group-data-[collapsible=icon]:hidden">
-							<span className="font-sans text-base font-semibold">auxilia</span>
-						</div>
+					<div className="flex items-center gap-2 px-2 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+						<button
+							onClick={toggleSidebar}
+							title="Toggle sidebar"
+							className="group/brand relative size-[26px] shrink-0 cursor-pointer"
+						>
+							{/* Logo at rest; fades out on hover only when collapsed. */}
+							<span className="absolute inset-0 grid place-items-center rounded-md transition-opacity duration-[140ms] group-data-[collapsible=icon]:group-hover/brand:opacity-0">
+								<Image
+									src="/logo.svg"
+									alt="auxilia"
+									height={24}
+									width={24}
+									className="dark:hidden"
+								/>
+								<Image
+									src="/logo-dark.svg"
+									alt="auxilia"
+									height={24}
+									width={24}
+									className="hidden dark:block"
+								/>
+							</span>
+							{/* Expand glyph; revealed on hover only when collapsed. */}
+							<span className="absolute inset-0 grid place-items-center rounded-md bg-sidebar-accent text-sidebar-active-icon opacity-0 transition-opacity duration-[140ms] group-data-[collapsible=icon]:group-hover/brand:opacity-100">
+								<PanelLeftOpen className="size-4" />
+							</span>
+						</button>
+						<span className="font-sans text-base font-semibold group-data-[collapsible=icon]:hidden">
+							auxilia
+						</span>
+						<SidebarTrigger className="ml-auto cursor-pointer group-data-[collapsible=icon]:hidden" />
 					</div>
 				</SidebarHeader>
 

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -140,7 +140,7 @@ export function AppSidebar() {
 
 				<SidebarContent>
 					<SidebarGroup>
-						<div className="px-0">
+						<div className="px-1 group-data-[collapsible=icon]:px-0">
 							<button
 								onClick={() => {
 									if (agents.length > 0) {
@@ -152,7 +152,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full h-10 pl-1 pr-3 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-fit group-data-[collapsible=icon]:pr-1"
+								className="w-full h-10 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">
@@ -178,11 +178,11 @@ export function AppSidebar() {
 												asChild
 												isActive={isActive}
 												tooltip={thread.firstMessageContent}
-												className="h-12! rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:h-12! group-data-[collapsible=icon]:w-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:hover:translate-x-0 group-data-[collapsible=icon]:data-[active=true]:bg-transparent"
+												className="h-12! rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:h-12! group-data-[collapsible=icon]:w-full! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:hover:translate-x-0 group-data-[collapsible=icon]:data-[active=true]:bg-transparent"
 											>
 												<Link
 													href={`/agents/${thread.agentId}/chat/${thread.id}`}
-													className="h-full pl-1 pr-3 flex items-center gap-2.5 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center"
+													className="h-full pl-1 pr-3 flex items-center gap-2.5 group-data-[collapsible=icon]:pl-1!"
 												>
 													<AgentAvatar
 														color={thread.agentColor}
@@ -255,7 +255,7 @@ export function AppSidebar() {
 												asChild
 												isActive={isNavActive}
 												tooltip={item.title}
-												className="rounded-[14px] pl-1 transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:pl-1!"
+												className="rounded-[14px] pl-3 transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:mx-auto"
 											>
 												<Link href={item.href}>
 													<item.icon

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -152,7 +152,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full h-10 px-4 rounded-full border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-center gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto"
+								className="w-full h-10 px-4 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-center gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">
@@ -178,7 +178,7 @@ export function AppSidebar() {
 												asChild
 												isActive={isActive}
 												tooltip={thread.firstMessageContent}
-												className="h-12! rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:w-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:hover:translate-x-0 group-data-[collapsible=icon]:data-[active=true]:bg-transparent"
+												className="h-12! rounded-2xl transition-all duration-200 hover:translate-x-1 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:h-12! group-data-[collapsible=icon]:w-10! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:hover:translate-x-0 group-data-[collapsible=icon]:data-[active=true]:bg-transparent"
 											>
 												<Link
 													href={`/agents/${thread.agentId}/chat/${thread.id}`}

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -152,7 +152,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full h-10 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed"
+								className="w-full h-8 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">
@@ -182,7 +182,7 @@ export function AppSidebar() {
 											>
 												<Link
 													href={`/agents/${thread.agentId}/chat/${thread.id}`}
-													className="h-full pl-1 pr-3 flex items-center gap-2.5 group-data-[collapsible=icon]:pl-1!"
+													className="h-full pl-[3px] pr-3 flex items-center gap-2.5 group-data-[collapsible=icon]:pl-[3px]!"
 												>
 													<AgentAvatar
 														color={thread.agentColor}

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -140,7 +140,7 @@ export function AppSidebar() {
 
 				<SidebarContent>
 					<SidebarGroup>
-						<div className="px-3 group-data-[collapsible=icon]:px-0">
+						<div className="px-1 group-data-[collapsible=icon]:px-0">
 							<button
 								onClick={() => {
 									if (agents.length > 0) {
@@ -152,7 +152,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full h-10 px-4 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-center gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto"
+								className="w-full h-10 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">
@@ -255,7 +255,7 @@ export function AppSidebar() {
 												asChild
 												isActive={isNavActive}
 												tooltip={item.title}
-												className="rounded-[14px] transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent"
+												className="rounded-[14px] pl-3 transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:mx-auto"
 											>
 												<Link href={item.href}>
 													<item.icon

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -140,7 +140,7 @@ export function AppSidebar() {
 
 				<SidebarContent>
 					<SidebarGroup>
-						<div className="px-1 group-data-[collapsible=icon]:px-0">
+						<div className="px-1">
 							<button
 								onClick={() => {
 									if (agents.length > 0) {
@@ -152,7 +152,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full h-10 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
+								className="w-full h-10 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -140,7 +140,7 @@ export function AppSidebar() {
 
 				<SidebarContent>
 					<SidebarGroup>
-						<div className="px-1 group-data-[collapsible=icon]:px-0">
+						<div className="px-0">
 							<button
 								onClick={() => {
 									if (agents.length > 0) {
@@ -152,7 +152,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full h-10 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
+								className="w-full h-10 pl-1 pr-3 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed group-data-[collapsible=icon]:w-fit group-data-[collapsible=icon]:pr-1"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">
@@ -255,7 +255,7 @@ export function AppSidebar() {
 												asChild
 												isActive={isNavActive}
 												tooltip={item.title}
-												className="rounded-[14px] pl-3 transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:mx-auto"
+												className="rounded-[14px] pl-1 transition-all duration-200 hover:translate-x-0.5 hover:bg-sidebar-hover data-[active=true]:bg-sidebar-accent group-data-[collapsible=icon]:pl-1!"
 											>
 												<Link href={item.href}>
 													<item.icon

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -107,6 +107,7 @@ export function AppSidebar() {
 						<button
 							onClick={toggleSidebar}
 							title="Toggle sidebar"
+							aria-label="Toggle sidebar"
 							className="group/brand relative size-[26px] shrink-0 cursor-pointer"
 						>
 							{/* Logo at rest; fades out on hover only when collapsed. */}

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -131,7 +131,10 @@ export function AppSidebar() {
 								<PanelLeftOpen className="size-4" />
 							</span>
 						</button>
-						<span className="font-sans text-base font-semibold group-data-[collapsible=icon]:hidden">
+						<span
+							className="font-sans text-base font-semibold group-data-[collapsible=icon]:hidden animate-in fade-in duration-200"
+							style={{ animationDelay: "250ms", animationFillMode: "both" }}
+						>
 							auxilia
 						</span>
 						<SidebarTrigger className="ml-auto cursor-pointer group-data-[collapsible=icon]:hidden" />
@@ -152,7 +155,7 @@ export function AppSidebar() {
 								}}
 								disabled={agents.length === 0}
 								title="New thread"
-								className="w-full h-8 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-2 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed"
+								className="w-full h-8 px-2 rounded-xl border-none bg-[#111111] dark:bg-white text-[13.5px] font-semibold font-(family-name:--font-dm-sans) text-white dark:text-[#111111] flex items-center justify-start gap-4 cursor-pointer hover:opacity-90 transition-all shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] disabled:opacity-50 disabled:cursor-not-allowed"
 							>
 								<SquarePen className="size-4 shrink-0" />
 								<span className="group-data-[collapsible=icon]:hidden">
@@ -172,7 +175,10 @@ export function AppSidebar() {
 										<SidebarMenuItem
 											key={thread.id}
 											className="animate-in fade-in slide-in-from-bottom-3 duration-400"
-											style={{ animationDelay: `${i * 50}ms`, animationFillMode: "both" }}
+											style={{
+												animationDelay: `${i * 50}ms`,
+												animationFillMode: "both",
+											}}
 										>
 											<SidebarMenuButton
 												asChild
@@ -231,7 +237,12 @@ export function AppSidebar() {
 												side="right"
 												align="start"
 												items={[
-													{ label: "Delete", icon: <Trash2 />, destructive: true, onClick: () => handleDeleteThread(thread.id) },
+													{
+														label: "Delete",
+														icon: <Trash2 />,
+														destructive: true,
+														onClick: () => handleDeleteThread(thread.id),
+													},
 												]}
 											/>
 										</SidebarMenuItem>
@@ -311,11 +322,31 @@ export function AppSidebar() {
 								sideOffset={4}
 								className="w-(--radix-dropdown-menu-trigger-width) min-w-56"
 								items={[
-									{ label: "Settings", icon: <Settings />, onClick: () => router.push("/settings") },
-									{ label: "Documentation", icon: <BookOpen />, onClick: () => window.open("https://auxilia-docs.vercel.app/", "_blank") },
-									{ label: resolvedTheme === "dark" ? "Light mode" : "Dark mode", icon: resolvedTheme === "dark" ? <Sun /> : <Moon />, onClick: () => setTheme(resolvedTheme === "dark" ? "light" : "dark") },
+									{
+										label: "Settings",
+										icon: <Settings />,
+										onClick: () => router.push("/settings"),
+									},
+									{
+										label: "Documentation",
+										icon: <BookOpen />,
+										onClick: () =>
+											window.open("https://auxilia-docs.vercel.app/", "_blank"),
+									},
+									{
+										label:
+											resolvedTheme === "dark" ? "Light mode" : "Dark mode",
+										icon: resolvedTheme === "dark" ? <Sun /> : <Moon />,
+										onClick: () =>
+											setTheme(resolvedTheme === "dark" ? "light" : "dark"),
+									},
 									{ separator: true },
-									{ label: "Log out", icon: <LogOut />, destructive: true, onClick: handleLogout },
+									{
+										label: "Log out",
+										icon: <LogOut />,
+										destructive: true,
+										onClick: handleLogout,
+									},
 								]}
 							/>
 						</SidebarMenuItem>

--- a/web/src/components/layout/chat-header.tsx
+++ b/web/src/components/layout/chat-header.tsx
@@ -9,7 +9,7 @@ export function ChatHeader() {
 	if (!agentName) return null;
 
 	return (
-		<div className="w-full flex items-center justify-center gap-2">
+		<div className="flex h-14 shrink-0 items-center justify-center gap-2 border-b border-border px-5">
 			<AgentAvatar color={agentColor} emoji={agentEmoji} size="xs" />
 			<span className="font-[family-name:var(--font-dm-sans)] font-semibold text-[14px] text-[#1E2D28] dark:text-foreground">
 				{agentName}

--- a/web/src/components/layout/chat-header.tsx
+++ b/web/src/components/layout/chat-header.tsx
@@ -9,7 +9,7 @@ export function ChatHeader() {
 	if (!agentName) return null;
 
 	return (
-		<div className="flex h-14 shrink-0 items-center justify-center gap-2 border-b border-border px-5">
+		<div className="flex h-14 shrink-0 items-center justify-center gap-2 px-5">
 			<AgentAvatar color={agentColor} emoji={agentEmoji} size="xs" />
 			<span className="font-[family-name:var(--font-dm-sans)] font-semibold text-[14px] text-[#1E2D28] dark:text-foreground">
 				{agentName}

--- a/web/src/components/layout/page-container.tsx
+++ b/web/src/components/layout/page-container.tsx
@@ -9,7 +9,7 @@ export function PageContainer({ children, className }: PageContainerProps) {
 	return (
 		<div
 			className={cn(
-				"mx-auto w-full max-w-5xl px-4 pb-12 @min-screen-md/layout:px-8 @min-screen-xl/layout:max-w-6xl",
+				"mx-auto w-full max-w-5xl @min-screen-xl/layout:max-w-6xl",
 				className,
 			)}
 		>

--- a/web/src/components/layout/page-container.tsx
+++ b/web/src/components/layout/page-container.tsx
@@ -9,7 +9,7 @@ export function PageContainer({ children, className }: PageContainerProps) {
 	return (
 		<div
 			className={cn(
-				"mx-auto w-full max-w-5xl @min-screen-xl/layout:max-w-6xl",
+				"mx-auto w-full @min-screen-xl/layout:max-w-6xl",
 				className,
 			)}
 		>

--- a/web/src/components/layout/page-shell.tsx
+++ b/web/src/components/layout/page-shell.tsx
@@ -9,41 +9,32 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 // route renders straight onto the sage canvas with the shared content padding.
 const CHAT_ROUTE = /^\/agents\/[^/]+\/chat(\/|$)/;
 
-// On desktop the collapse control lives in the sidebar, but below md the
-// sidebar is an off-canvas sheet that needs an out-of-sheet control to reopen
-// it. This slim bar is hidden on desktop, so the desktop layout is unchanged.
-function MobileBar() {
-	return (
-		<div className="md:hidden flex h-12 shrink-0 items-center border-b border-border px-3">
-			<SidebarTrigger className="cursor-pointer" />
-		</div>
-	);
-}
-
 export function PageShell({ children }: { children: React.ReactNode }) {
 	const pathname = usePathname();
 	const isChat = CHAT_ROUTE.test(pathname);
 
-	if (isChat) {
-		return (
-			<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
-				<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
-					<MobileBar />
-					<ChatHeader />
-					<div className="flex flex-1 flex-col min-h-0 overflow-hidden">
-						{children}
-					</div>
-				</div>
-			</main>
-		);
-	}
-
 	return (
-		<main className="flex-1 min-w-0 flex flex-col h-svh">
-			<MobileBar />
-			<div className="flex-1 min-h-0 overflow-y-auto pt-6 px-4 pb-6 sm:px-6 lg:px-8 lg:pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-				{children}
-			</div>
-		</main>
+		<>
+			{/* On desktop the collapse control lives in the sidebar; below md the
+			    sidebar is an off-canvas sheet that needs an out-of-sheet control to
+			    reopen it. This floating chip is hidden on desktop, so the desktop
+			    layout is unchanged. */}
+			<SidebarTrigger className="md:hidden fixed left-3 top-3 z-50 size-9 rounded-lg border border-sidebar-border bg-sidebar shadow-[0_1px_3px_rgba(30,45,40,0.05)] cursor-pointer" />
+
+			{isChat ? (
+				<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
+					<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
+						<ChatHeader />
+						<div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+							{children}
+						</div>
+					</div>
+				</main>
+			) : (
+				<main className="flex-1 min-w-0 h-svh overflow-y-auto pt-16 px-4 pb-6 sm:px-6 md:pt-6 lg:px-8 lg:pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+					{children}
+				</main>
+			)}
+		</>
 	);
 }

--- a/web/src/components/layout/page-shell.tsx
+++ b/web/src/components/layout/page-shell.tsx
@@ -3,10 +3,22 @@
 import { usePathname } from "next/navigation";
 
 import { ChatHeader } from "@/components/layout/chat-header";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
 // Chat is the only surface that keeps the floating white card; every other
 // route renders straight onto the sage canvas with the shared content padding.
 const CHAT_ROUTE = /^\/agents\/[^/]+\/chat(\/|$)/;
+
+// On desktop the collapse control lives in the sidebar, but below md the
+// sidebar is an off-canvas sheet that needs an out-of-sheet control to reopen
+// it. This slim bar is hidden on desktop, so the desktop layout is unchanged.
+function MobileBar() {
+	return (
+		<div className="md:hidden flex h-12 shrink-0 items-center border-b border-border px-3">
+			<SidebarTrigger className="cursor-pointer" />
+		</div>
+	);
+}
 
 export function PageShell({ children }: { children: React.ReactNode }) {
 	const pathname = usePathname();
@@ -16,6 +28,7 @@ export function PageShell({ children }: { children: React.ReactNode }) {
 		return (
 			<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
 				<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
+					<MobileBar />
 					<ChatHeader />
 					<div className="flex flex-1 flex-col min-h-0 overflow-hidden">
 						{children}
@@ -26,8 +39,11 @@ export function PageShell({ children }: { children: React.ReactNode }) {
 	}
 
 	return (
-		<main className="flex-1 min-w-0 h-svh overflow-y-auto pt-6 px-4 pb-6 sm:px-6 lg:px-8 lg:pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-			{children}
+		<main className="flex-1 min-w-0 flex flex-col h-svh">
+			<MobileBar />
+			<div className="flex-1 min-h-0 overflow-y-auto pt-6 px-4 pb-6 sm:px-6 lg:px-8 lg:pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+				{children}
+			</div>
 		</main>
 	);
 }

--- a/web/src/components/layout/page-shell.tsx
+++ b/web/src/components/layout/page-shell.tsx
@@ -3,7 +3,6 @@
 import { usePathname } from "next/navigation";
 
 import { ChatHeader } from "@/components/layout/chat-header";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 
 // Chat is the only surface that keeps the floating white card; every other
 // route renders straight onto the sage canvas with the shared content padding.
@@ -17,12 +16,6 @@ export function PageShell({ children }: { children: React.ReactNode }) {
 		return (
 			<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
 				<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
-					{/* Mobile-only: the desktop trigger lives in the sidebar, but on
-					    mobile the sidebar is an off-canvas sheet that needs an
-					    out-of-sheet control to reopen it. */}
-					<div className="md:hidden flex h-12 shrink-0 items-center border-b border-border px-2">
-						<SidebarTrigger className="cursor-pointer" />
-					</div>
 					<ChatHeader />
 					<div className="flex flex-1 flex-col min-h-0 overflow-hidden">
 						{children}
@@ -33,8 +26,7 @@ export function PageShell({ children }: { children: React.ReactNode }) {
 	}
 
 	return (
-		<main className="flex-1 min-w-0 h-svh overflow-y-auto pt-4 px-4 pb-6 sm:px-6 lg:px-8 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-			<SidebarTrigger className="md:hidden mb-2 cursor-pointer" />
+		<main className="flex-1 min-w-0 h-svh overflow-y-auto pt-6 px-4 pb-6 sm:px-6 lg:px-8 lg:pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 			{children}
 		</main>
 	);

--- a/web/src/components/layout/page-shell.tsx
+++ b/web/src/components/layout/page-shell.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 
 import { ChatHeader } from "@/components/layout/chat-header";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
 // Chat is the only surface that keeps the floating white card; every other
 // route renders straight onto the sage canvas with the shared content padding.
@@ -16,6 +17,12 @@ export function PageShell({ children }: { children: React.ReactNode }) {
 		return (
 			<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
 				<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
+					{/* Mobile-only: the desktop trigger lives in the sidebar, but on
+					    mobile the sidebar is an off-canvas sheet that needs an
+					    out-of-sheet control to reopen it. */}
+					<div className="md:hidden flex h-12 shrink-0 items-center border-b border-border px-2">
+						<SidebarTrigger className="cursor-pointer" />
+					</div>
 					<ChatHeader />
 					<div className="flex flex-1 flex-col min-h-0 overflow-hidden">
 						{children}
@@ -26,7 +33,8 @@ export function PageShell({ children }: { children: React.ReactNode }) {
 	}
 
 	return (
-		<main className="flex-1 min-w-0 h-svh overflow-y-auto pt-6 px-4 pb-6 sm:px-6 lg:px-8 lg:pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+		<main className="flex-1 min-w-0 h-svh overflow-y-auto pt-4 px-4 pb-6 sm:px-6 lg:px-8 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<SidebarTrigger className="md:hidden mb-2 cursor-pointer" />
 			{children}
 		</main>
 	);

--- a/web/src/components/layout/page-shell.tsx
+++ b/web/src/components/layout/page-shell.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { ChatHeader } from "@/components/layout/chat-header";
+
+// Chat is the only surface that keeps the floating white card; every other
+// route renders straight onto the sage canvas with the shared content padding.
+const CHAT_ROUTE = /^\/agents\/[^/]+\/chat(\/|$)/;
+
+export function PageShell({ children }: { children: React.ReactNode }) {
+	const pathname = usePathname();
+	const isChat = CHAT_ROUTE.test(pathname);
+
+	if (isChat) {
+		return (
+			<main className="flex-1 min-w-0 flex h-svh p-2 pl-0">
+				<div className="flex-1 min-w-0 flex flex-col rounded-2xl border border-border bg-card shadow-[0_1px_3px_rgba(30,45,40,0.05)] overflow-hidden">
+					<ChatHeader />
+					<div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+						{children}
+					</div>
+				</div>
+			</main>
+		);
+	}
+
+	return (
+		<main className="flex-1 min-w-0 h-svh overflow-y-auto pt-6 px-4 pb-6 sm:px-6 lg:px-8 lg:pb-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			{children}
+		</main>
+	);
+}

--- a/web/src/components/ui/search-bar.tsx
+++ b/web/src/components/ui/search-bar.tsx
@@ -5,6 +5,7 @@ interface SearchBarProps {
 	value: string;
 	onChange: (value: string) => void;
 	className?: string;
+	hint?: string;
 }
 
 export function SearchBar({
@@ -12,6 +13,7 @@ export function SearchBar({
 	value,
 	onChange,
 	className = "",
+	hint,
 }: SearchBarProps) {
 	return (
 		<div className={`relative ${className}`}>
@@ -21,8 +23,13 @@ export function SearchBar({
 				placeholder={placeholder}
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
-				className="w-full pl-10 pr-4 py-2.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium font-[family-name:var(--font-dm-sans)] text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none focus:border-[#4CA882] transition-colors"
+				className={`w-full pl-10 ${hint ? "pr-14" : "pr-4"} py-2.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 text-[14px] font-medium font-[family-name:var(--font-dm-sans)] text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none focus:border-[#4CA882] transition-colors`}
 			/>
+			{hint && (
+				<kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 rounded-md border border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-white/5 px-1.5 py-0.5 font-[family-name:var(--font-geist-mono)] text-[11px] font-medium text-[#A3B5AD] dark:text-white/30">
+					{hint}
+				</kbd>
+			)}
 		</div>
 	);
 }

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -496,4 +496,5 @@ export {
 	SidebarMenuItem,
 	SidebarProvider,
 	SidebarTrigger,
+	useSidebar,
 };

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -215,7 +215,7 @@ function Sidebar({
 			<div
 				data-slot="sidebar-gap"
 				className={cn(
-					"relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+					"relative w-(--sidebar-width) bg-transparent transition-[width] duration-300 ease-in-out",
 					"group-data-[collapsible=offcanvas]:w-0",
 					"group-data-[side=right]:rotate-180",
 					variant === "floating" || variant === "inset"
@@ -226,7 +226,7 @@ function Sidebar({
 			<div
 				data-slot="sidebar-container"
 				className={cn(
-					"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+					"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-300 ease-in-out md:flex",
 					side === "left"
 						? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
 						: "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -26,7 +26,7 @@ const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "20rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_WIDTH_ICON = "3.5rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
 type SidebarContextProps = {
@@ -232,7 +232,7 @@ function Sidebar({
 						: "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
 					// Adjust the padding for floating and inset variants.
 					variant === "floating" || variant === "inset"
-						? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+						? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
 						: "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
 					className,
 				)}
@@ -241,7 +241,7 @@ function Sidebar({
 				<div
 					data-sidebar="sidebar"
 					data-slot="sidebar-inner"
-					className="bg-sidebar flex h-full w-full flex-col group-data-[variant=floating]:rounded-r-[28px] group-data-[variant=floating]:border-[1.5px] group-data-[variant=floating]:border-[#E6ECE9] group-data-[variant=floating]:dark:border-white/10"
+					className="bg-sidebar flex h-full w-full flex-col group-data-[variant=floating]:rounded-2xl group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-[0_1px_3px_rgba(30,45,40,0.05)]"
 				>
 					{children}
 				</div>

--- a/web/src/lib/colors.ts
+++ b/web/src/lib/colors.ts
@@ -10,11 +10,19 @@ export const PASTEL_MAP: Record<string, { pill: string; text: string }> = {
 
 export const AGENT_COLORS = Object.keys(PASTEL_MAP);
 
+// Map-based lookup so callers don't index the object with a dynamic key.
+const PASTELS = new Map(Object.entries(PASTEL_MAP));
+const DEFAULT_PASTEL = PASTEL_MAP["#9E9E9E"];
+
+export function agentPastel(color?: string | null): { pill: string; text: string } {
+	return (color ? PASTELS.get(color) : undefined) ?? DEFAULT_PASTEL;
+}
+
 export function randomAgentColor(): string {
 	return AGENT_COLORS[Math.floor(Math.random() * AGENT_COLORS.length)];
 }
 
 export function agentColorBackground(color: string): string {
-	const accent = PASTEL_MAP[color]?.text ?? color;
+	const accent = (color ? PASTELS.get(color) : undefined)?.text ?? color;
 	return `linear-gradient(145deg, ${color}14, ${accent}10)`;
 }


### PR DESCRIPTION
## Summary

A full visual pass over the web Studio shell and its core pages, plus a polished sidebar collapse interaction.

### Shell & layout
- Floating sidebar on a sage canvas with an **icon-rail collapse** (replaces off-canvas); chat keeps a white inset card, every other route renders bare on the surface via a new `PageShell`.
- Mobile: a floating `md:hidden` trigger reopens the off-canvas sheet.
- Lighter "whisper-tint" sage surface (`--surface` `#f6f9f7`).

### Page redesigns (per spec)
- **Agents**: header with description + search (⌘K) + create; stacked `Your agents` / `Shared with you` sections with counts and "See all"; 4-column grid.
- **Agent card**: flat card, pastel emoji tile, role pill, real MCP server icons (no tool count / thread count / last-used).
- **MCP servers**: matching header; card with logo tile, name/URL, description (no status pill / footer / tags); 4-column grid.
- **Users**: header + role filter chips; single floating member panel (avatar · name/You · email · inline role control · hover-remove); pending-invites panel.
- **Agent editor**: raised-vs-recessed surfaces, 46px pastel emoji tile, raised Description/Instructions, eyebrow labels, "Add tool" pill.

### Sidebar collapse polish
- Constant item heights and a fixed icon column so the brand, New thread, thread avatars, nav icons and profile avatar **hold their position** (no horizontal/vertical travel) through collapse.
- Square collapsed New thread button; centered avatars.
- Smoother width transition (`duration-300 ease-in-out`).
- Wordmark fades in after the sidebar finishes opening; logo stays left-aligned.

## Test plan
- `eslint` clean on touched files; `tsc` clean (only a pre-existing `node_modules` type error).
- Manual: expand/collapse the sidebar (desktop + mobile sheet); review Agents / MCP / Users / Agent editor / Chat in light & dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the Studio shell with a floating icon‑rail sidebar and a new `PageShell` that keeps chat in a card while other pages render on a light sage surface. Updates Agents, MCP servers, and Users to the new specs, smooths sidebar collapse, fixes custom‑host MCP icon rendering, whitespace‑only server search, mobile Users layouts, sidebar toggle accessibility, and keeps the “Workspace” label space when collapsed so nav items stay anchored.

- **New Features**
  - Floating sidebar (`collapsible="icon"`) plus mobile `SidebarTrigger`; `PageShell` renders chat in a card with `ChatHeader`, all other routes on `--surface` (`#f6f9f7`).
  - Agents: header + description, search with ⌘K hint, stacked sections (Your/Shared/Discover) with counts and “See all” (6‑item cap), 4‑column grid; card shows pastel emoji tile, role badge, real MCP server icons, and a 2‑line clamp.
  - MCP servers: header + description, search by name/URL with no‑results state, 4‑column grid; card with real icon tile, name/URL, and clamped description.
  - Users: role filter chips with counts, single member panel with inline role control and hover‑remove, pending invites panel with copy/revoke.

- **Refactors**
  - Sidebar collapse polish: fixed icon column and equal item heights; New thread/nav/profile icons and thread avatars don’t move; wordmark fades in after expand; smoother `duration-300 ease-in-out`; icon rail width 3.5rem; floating sidebar uses token border/shadow; keeps “Workspace” label space when collapsed so nav doesn’t shift.
  - Layout/tokens: `PageContainer` padding moves to layout; `SearchBar` supports optional `hint`.
  - Editor and panels: agent editor and tools/subagents restyled with raised surfaces, pastel emoji tile, eyebrow labels, and updated “Add …” pills.
  - Safety/lint: replace dynamic `PASTEL_MAP` indexing with `agentPastel()` (Map‑based); guard invite role labels; wrap void‑returning arrow handlers in braces.
  - MCP server icons: render via `unoptimized` `next/image` to support arbitrary hosts; MCP servers search trims whitespace so blank/whitespace input shows all servers.
  - Users responsiveness: member and invite tables adapt on mobile (email folds under name, compact grid), and the remove button is accessible on touch.
  - Accessibility: the sidebar toggle button now has an explicit `aria-label` (“Toggle sidebar”).

<sup>Written for commit 70c4e386f3ccc67fb71f47fbffdf3fe26f124ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

