### PR TITLE
docs: create-an-agent tutorial + n8n MCP server guide

### DIFF
--- a/docs/content/deploy/mcp-servers/examples/_meta.js
+++ b/docs/content/deploy/mcp-servers/examples/_meta.js
@@ -1,5 +1,6 @@
 export default {
   hubspot: 'HubSpot',
   github: 'GitHub',
-  bigquery: 'BigQuery'
+  bigquery: 'BigQuery',
+  n8n: 'n8n'
 }

--- a/docs/content/deploy/mcp-servers/examples/n8n.mdx
+++ b/docs/content/deploy/mcp-servers/examples/n8n.mdx
@@ -1,0 +1,88 @@
+# n8n MCP Server
+
+This guide connects an [n8n](https://n8n.io/) workflow to **auxilia** as an MCP server. Once connected, an agent can trigger your n8n workflows the same way it calls any other tool.
+
+## Why connect n8n?
+
+n8n already integrates with hundreds of apps (Google Workspace, HubSpot, Stripe, internal HTTP APIs, databases, and more). Rather than building a custom MCP server for each of those, you can:
+
+- **Expose existing automations as agent tools** — wrap a multi-step n8n workflow ("create a Jira ticket, notify the owner in Slack, log it to a sheet") behind a single tool the agent can call
+- **Reuse logic you already trust** — the workflow keeps running in n8n, with its own credentials, retries, and error handling; the agent just decides *when* to fire it
+- **Reach systems that don't have an MCP server yet** — if n8n can talk to it, your agent can too
+
+This is the inverse of the [n8n & Cloud Scheduler tutorial](/docs/tutorials/n8n-cloud-scheduler), where n8n *calls* auxilia. Here, the agent *calls n8n*.
+
+## How it works
+
+n8n's **MCP Server Trigger** node turns a workflow into a remote MCP server. Each **Tool** sub-node you attach to it becomes a tool the agent can discover and call. n8n publishes a stable URL for that server, which you register in **auxilia** as a custom MCP server.
+
+```
+┌──────────┐   tools/call    ┌────────────────────┐   runs    ┌──────────────┐
+│ auxilia  │ ──────────────▶ │ n8n MCP Server      │ ────────▶ │ your apps    │
+│ agent    │                 │ Trigger workflow    │           │ (Slack, CRM) │
+└──────────┘                 └────────────────────┘           └──────────────┘
+```
+
+## 1. Build the MCP server workflow in n8n
+
+1. In n8n, create a new workflow
+2. Add an **MCP Server Trigger** node as the entry point
+3. Attach one or more **Tool** sub-nodes to the trigger — each becomes a tool exposed to the agent. Give every tool a clear **name** and **description**; the agent picks tools based on these, so write them the way you'd describe the action to a teammate.
+4. Build the rest of the workflow downstream (the actual automation)
+
+## 2. Choose the transport and authentication
+
+In the MCP Server Trigger node:
+
+- **Transport** — choose **HTTP Streamable**. **auxilia** speaks the [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport only; the older SSE transport is not supported.
+- **Authentication** — choose **Bearer Auth** (recommended). n8n lets you set a bearer token credential; **auxilia** will send it on every request. You can also use **None** for a quick test, but never leave a write-capable workflow unauthenticated.
+
+Copy two things from the node:
+
+- The **Production URL** (not the Test URL — the test URL only works while you have the n8n editor open with "Listen" active)
+- The **bearer token** you configured
+
+## 3. Activate the workflow
+
+Toggle the workflow to **Active** in n8n. The Production MCP URL only responds when the workflow is active.
+
+## 4. Register the server in auxilia
+
+In **auxilia**, navigate to **MCP Servers** (admin only):
+
+1. Click **Add MCP Server**
+2. Fill in:
+   - **Name** — e.g. `n8n Automations`
+   - **URL** — the Production MCP URL from the trigger node
+   - **Authentication** — **API Key**, and paste the bearer token
+
+   See [Authentication methods](/docs/deploy/mcp-servers/authentication) for how the key is encrypted and sent.
+3. Save
+
+Because n8n uses a shared bearer token (not per-user OAuth), there's no **Connect** step — the workspace shares one key. **auxilia** fetches the tool list from your MCP Server Trigger node immediately.
+
+## 5. Add it to an agent
+
+1. Open an agent's configuration page
+2. Click **Add MCP Server** and pick **n8n Automations**
+3. Review the discovered tools and set [tool settings](/docs/agents/tools). Workflows that write to other systems are good candidates for **needs approval** until you trust the agent's judgment.
+
+If you later add or rename Tool sub-nodes in n8n, click **Sync tools** on the agent-server binding so **auxilia** picks up the changes.
+
+## Troubleshooting
+
+### No tools appear after adding the server
+
+- Confirm the workflow is **Active** and you used the **Production URL**, not the Test URL
+- Confirm the transport is **HTTP Streamable**, not SSE
+- Confirm each Tool sub-node has a name and description
+
+### "Unauthorized" or 401
+
+The bearer token in **auxilia** must match the one configured on the MCP Server Trigger node. Re-copy it and re-save the server.
+
+### Intermittent failures behind a load balancer
+
+If you self-host n8n in **queue mode** with multiple webhook replicas, MCP connections must be routed to a single dedicated webhook replica — Streamable HTTP relies on persistent connections to one instance. A single webhook replica works without any extra routing.
+
+Sources: [MCP Server Trigger node — n8n Docs](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger/)

--- a/docs/content/deploy/mcp-servers/index.mdx
+++ b/docs/content/deploy/mcp-servers/index.mdx
@@ -42,4 +42,4 @@ API-key servers share a single encrypted key across the workspace.
 
 - [Official vs Custom servers](/docs/deploy/mcp-servers/official-vs-custom)
 - [Authentication methods](/docs/deploy/mcp-servers/authentication)
-- Setup examples: [HubSpot](/docs/deploy/mcp-servers/examples/hubspot) · [GitHub](/docs/deploy/mcp-servers/examples/github) · [BigQuery](/docs/deploy/mcp-servers/examples/bigquery)
+- Setup examples: [HubSpot](/docs/deploy/mcp-servers/examples/hubspot) · [GitHub](/docs/deploy/mcp-servers/examples/github) · [BigQuery](/docs/deploy/mcp-servers/examples/bigquery) · [n8n](/docs/deploy/mcp-servers/examples/n8n)

--- a/docs/content/tutorials/_meta.js
+++ b/docs/content/tutorials/_meta.js
@@ -1,5 +1,6 @@
 export default {
   index: 'Overview',
+  'create-an-agent': 'Create your first agent',
   'http-invoke': 'Trigger agents over HTTP',
   slack: 'Trigger agents from Slack',
   'embed-custom-ui': 'Embed an agent in a custom UI',

--- a/docs/content/tutorials/create-an-agent.mdx
+++ b/docs/content/tutorials/create-an-agent.mdx
@@ -1,0 +1,169 @@
+# Create your first agent
+
+This tutorial walks through building an **auxilia** agent end to end — from naming it to chatting with it. We'll build a concrete example: a **Sales Research Assistant** that looks up CRM records and drafts outreach. The same steps apply to any agent you want to build.
+
+You don't need to be a developer to follow along, but an admin may need to register MCP servers for you first (see [MCP Servers](/docs/deploy/mcp-servers)).
+
+## What you'll build
+
+An agent that can:
+
+- Look up contacts, companies, and deals in HubSpot
+- Research a prospect's company on the web
+- Draft a short, personalized outreach email for a human to review
+
+By the end you'll understand the four things that define every agent: **identity**, **tools**, **permissions**, and **instructions**.
+
+## Before you start
+
+- You need the **editor** or **admin** role. The person who creates an agent becomes its **owner**.
+- At least one MCP server should be registered in your workspace. For this example we'll use **HubSpot** (see the [HubSpot setup guide](/docs/deploy/mcp-servers/examples/hubspot)) and a web-search server.
+
+## Step 1 — Create the agent and give it an identity
+
+Navigate to **Agents** in the sidebar and click **Create Agent**.
+
+![Create agent dialog](https://pub-7a6e8912b3c448b8a8bfa47a0363f7bc.r2.dev/docs/agent_create.png)
+
+Fill in the identity fields:
+
+- **Name** — what users see in the agent list. Keep it short and descriptive: `Sales Research Assistant`.
+- **Emoji** — pick one from the emoji picker. It becomes the agent's avatar in the sidebar and chat header. A 🔭 or 💼 works well here.
+- **Avatar background color** — choose a hex color for the badge behind the emoji. Pick a color that helps users tell this agent apart from others at a glance — give each team's agents a consistent color, for example.
+- **Description** — one sentence shown on the agent card. Users pick agents by skimming this, so make it concrete: *"Researches prospects and drafts outreach using HubSpot and the web."*
+
+The name, emoji, color, and description are all editable later — none of them affect how the agent behaves, only how people find and recognize it.
+
+Save the agent. You'll land on its configuration page, where the real work happens.
+
+## Step 2 — Add MCP servers
+
+Tools are what turn a chatbot into an agent. They come from **MCP servers** bound to the agent.
+
+On the configuration page, click **Add MCP Server** and pick a server from the workspace catalog. For our example, add two:
+
+- **HubSpot** — for CRM lookups
+- A **web-search** server — for company research
+
+![Add MCP server to agent](https://pub-7a6e8912b3c448b8a8bfa47a0363f7bc.r2.dev/docs/agent_add_mcp_server.png)
+
+When you add a server, **auxilia** fetches its tool list and attaches it to the agent.
+
+### Connect OAuth servers once
+
+Some MCP servers — HubSpot, Notion, Linear, Google services, and most other account-based integrations — require **OAuth**. Registering the server at the workspace level is not enough: **each user must connect their own account once** before the agent can use those tools on their behalf.
+
+If you see a **Connect** prompt on the server card:
+
+1. Click **Connect**
+2. You're redirected to the provider's consent screen
+3. Approve the requested permissions
+4. You're redirected back to **auxilia**, and the card shows as connected
+
+![Connect an OAuth MCP server](https://pub-7a6e8912b3c448b8a8bfa47a0363f7bc.r2.dev/docs/agent_connect_oauth.png)
+
+Your tokens are stored privately and scoped to you — a teammate using the same agent connects with their own account. API-key servers (and bearer-token servers like [n8n](/docs/deploy/mcp-servers/examples/n8n)) skip this step because they share one workspace credential. See [MCP Server Authentication](/docs/deploy/mcp-servers/authentication) for the full picture.
+
+## Step 3 — Select and configure tools
+
+Just because a server exposes 30 tools doesn't mean your agent should have all 30. A focused toolset makes the agent faster, cheaper, and more predictable.
+
+Expand each bound server to see its tools. Every tool has one of three states:
+
+| State | Icon | Behavior | Use for |
+| --- | --- | --- | --- |
+| **Always allow** | ✓ | Runs instantly when the agent calls it | Read-only and low-risk tools |
+| **Needs approval** | ⏸ | Pauses and asks a human before running | Writes and anything with side effects |
+| **Disabled** | ✗ | Hidden from the agent entirely | Off-topic or risky tools |
+
+![Tool settings on an agent](https://pub-7a6e8912b3c448b8a8bfa47a0363f7bc.r2.dev/docs/agent_tool_settings.png)
+
+For the Sales Research Assistant, a sensible setup:
+
+- HubSpot **read** tools (get contact, search deals, get company) → **Always allow**
+- HubSpot **write** tools (create note, update contact) → **Needs approval** — we want a human to see exactly what gets written to the CRM
+- HubSpot tools the agent doesn't need (bulk delete, admin settings) → **Disabled**
+- Web-search tool → **Always allow**
+
+> When you first bind a server, every tool defaults to **Always allow**. Always review the list and tighten writes before sharing the agent — this is the single most important safety step. See [Tools & Permissions](/docs/agents/tools) for the full model.
+
+Tool settings live on the agent–server binding, so the *same* HubSpot server can be read-only on this agent and fully writable on an automation agent. You're not configuring HubSpot globally — only what *this* agent can do with it.
+
+## Step 4 — Write the instructions
+
+The **instructions** are the system prompt sent on every message. This is where you turn a generic model with tools into *your* assistant. Good instructions cover four things: who the agent is, which tools to use when, how to format output, and what to do when something fails.
+
+Here's a complete example for our agent:
+
+```text
+You are a Sales Research Assistant for the revenue team. Your job is to research
+prospects and draft outreach — not to send anything yourself.
+
+Tools:
+- Use the HubSpot tools to look up contacts, companies, and deals. Always start
+  from HubSpot before searching the web, so you don't contradict the CRM.
+- Use web search to enrich what HubSpot doesn't have: recent company news,
+  funding, headcount, product launches.
+
+When researching a prospect, gather: the contact's role, the company's industry
+and size, the current deal stage (if any), and one recent, specific hook from
+the web (a launch, a hire, a press mention).
+
+When drafting outreach:
+- Keep it under 120 words, friendly and specific. Reference the hook you found.
+- Never invent facts. If you can't verify something, leave it out.
+- Present the draft for review. Do not create or send anything until a human
+  approves the write.
+
+Formatting: always cite the HubSpot contact ID you used. Format deal values with
+a currency symbol.
+
+If a HubSpot record can't be found, say so plainly and ask for the correct name
+or ID — don't guess.
+```
+
+Notice what this does:
+
+- **Sets boundaries** — "research and draft, don't send" keeps the agent in a safe lane, reinforced by the **needs approval** setting on writes.
+- **Orders the tools** — HubSpot first, web second, so the agent doesn't drift.
+- **Defines done** — exactly what a good research result contains.
+- **Handles failure** — what to do when a lookup comes up empty, so the model doesn't hallucinate.
+
+Save your instructions. Changes take effect on the next message; existing chat threads aren't recomputed. See [Configuration](/docs/agents/configuration) for more prompt-writing tips.
+
+## Step 5 — Test the agent in Chat
+
+Open a chat with the agent (the **Chat** button on the agent, or pick it from the **Agents** list) and try a realistic request:
+
+```text
+Research Maria Gomez at Northwind Logistics and draft a follow-up email.
+```
+
+![Chatting with the agent](https://pub-7a6e8912b3c448b8a8bfa47a0363f7bc.r2.dev/docs/agent_chat.png)
+
+Watch what happens:
+
+- **Tool calls appear inline** as expandable blocks showing the tool name, the arguments the agent passed, and the result it got back. This is how you verify the agent is reaching for the *right* tools with the *right* inputs.
+- **Approval cards** appear for any **needs approval** tool. When the agent tries to write a note back to HubSpot, you'll get an **Approve / Reject** card showing the exact payload — approve it and the run continues, reject it and the agent adapts.
+- **Pick a model** for the thread from the model selector. Different models trade off cost, speed, and reasoning depth.
+
+### Iterate
+
+Testing in Chat is where you tune the agent. Common adjustments:
+
+- The agent used a tool you didn't expect → set it to **needs approval** or **disabled** in Step 3.
+- The agent guessed instead of asking → tighten the failure-handling line in the instructions.
+- The drafts are too long or off-tone → add a concrete formatting rule and re-test.
+- The agent ignored HubSpot and went straight to the web → make the tool ordering explicit in the prompt.
+
+Each change takes effect on your next message, so the loop is fast: chat, observe the tool calls, adjust, chat again.
+
+## You're done
+
+You now have a working agent. From here you can:
+
+- **[Share it with your workspace](/docs/agents/permissions)** — grant teammates `user`, `editor`, or `admin` access
+- **[Trigger it over HTTP](/docs/tutorials/http-invoke)** — call it from scripts, webhooks, or spreadsheets
+- **[Trigger it from Slack](/docs/tutorials/slack)** — let the team talk to it in threads
+- **[Run it on a schedule](/docs/tutorials/n8n-cloud-scheduler)** — daily digests and recurring reports
+- **[Add subagents](/docs/agents/subagents)** or the **[sandbox](/docs/agents/sandbox)** for more advanced agents

--- a/docs/content/tutorials/index.mdx
+++ b/docs/content/tutorials/index.mdx
@@ -6,6 +6,7 @@ These are designed to be accessible: you don't need to be a developer to follow 
 
 ## Available tutorials
 
+- **[Create your first agent](/docs/tutorials/create-an-agent)** — a full walkthrough from naming an agent to chatting with it: identity, MCP servers, tool permissions, and instructions
 - **[Trigger agents over HTTP](/docs/tutorials/http-invoke)** — call an **auxilia** agent from any tool that can make a web request, without writing custom code
 - **[Trigger agents from Slack](/docs/tutorials/slack)** — give your team a familiar way to talk to agents directly in Slack threads
 - **[Embed an agent in a custom UI](/docs/tutorials/embed-custom-ui)** — put an **auxilia** agent inside your customer-support console, back-office dashboard, or Google Sheets add-on


### PR DESCRIPTION
## Summary

Adds two new documentation pages and wires them into navigation.

### `tutorials/create-an-agent.mdx` — "Create your first agent"
End-to-end walkthrough built around a concrete *Sales Research Assistant* example:
- **Identity** — name, emoji, avatar background color, description
- **Add MCP servers** — including a "Connect OAuth servers once" section (per-user OAuth vs. shared API-key/bearer)
- **Select & configure tools** — always allow / needs approval / disabled, with a recommended setup and the *why*
- **Write instructions** — a complete, annotated system-prompt example
- **Test in Chat** — reading inline tool calls, approval cards, model selection, and an iterate loop

Includes 5 screenshot placeholders using the existing R2 URL convention (`agent_create.png`, `agent_add_mcp_server.png`, `agent_connect_oauth.png`, `agent_tool_settings.png`, `agent_chat.png`) for the author to fill in.

### `deploy/mcp-servers/examples/n8n.mdx` — "n8n MCP Server"
How to connect n8n *as an MCP server* (agent → n8n), the inverse of the existing n8n & Cloud Scheduler tutorial. Covers the MCP Server Trigger node, HTTP Streamable transport (SSE not supported), bearer auth, the Production URL, registration as a custom API-key server, and troubleshooting. Verified against the [n8n docs](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger/).

### Wiring
Both pages added to their `_meta.js` files, the tutorials index, and the MCP-servers index "Setup examples" line.

## Notes
- The "call an agent over HTTP" request is already covered by the existing `http-invoke.mdx`; the new tutorial links to it rather than duplicating.

## Test plan
- [x] `npm run build` passes (32 pages indexed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two docs: a “Create your first agent” tutorial and an “n8n MCP Server” setup guide, plus nav updates. This helps users build a first agent end to end and connect `n8n` as a custom MCP server.

- **New Features**
  - `tutorials/create-an-agent.mdx`: end-to-end Sales Research Assistant example covering identity, adding MCP servers (incl. per-user OAuth connect-once), tool permissions (allow/approve/disable), writing instructions, and testing in Chat; includes 5 screenshot placeholders.
  - `deploy/mcp-servers/examples/n8n.mdx`: connect `n8n` via the MCP Server Trigger using HTTP Streamable + bearer auth; use the Production URL, register as an API-key server, and follow troubleshooting tips.
  - Navigation wired: added to tutorials index and MCP servers examples; `_meta.js` updated and “n8n” linked in Setup examples.

<sup>Written for commit b8f9153188c416375619d93b1050219024b803de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

