### PR TITLE
chore: force backend 0.4.1 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
     "backend": {
       "release-type": "python",
       "package-name": "auxilia-backend",
-      "component": "backend"
+      "component": "backend",
+      "release-as": "0.4.1"
     },
     "web": {
       "release-type": "node",


### PR DESCRIPTION
Adds `release-as: 0.4.1` to the backend package so release-please cuts a patch release including the MCP tool-error refactor (#122), which as a `refactor:` commit didn't trigger a bump on its own. The pin is removed in a follow-up once the release is tagged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force a `auxilia-backend` 0.4.1 release by adding `release-as: 0.4.1` to the `backend` config so release-please ships a patch that includes the MCP tool-error refactor (#122). The pin will be removed after the tag is published.

<sup>Written for commit 1c1ee4806b612c8c83c77d178de8ec39c2ef5761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

