### PR TITLE
chore: surface refactor commits for backend 0.4.1 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,20 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     "backend": {
       "release-type": "python",


### PR DESCRIPTION
release-as alone skipped the backend release ('No user facing commits found') because `refactor:` is non-user-facing by default. This un-hides `refactor` in changelog-sections so #122 (MCP tool-error native handling) counts as a releasable commit and is documented. Paired with the existing `release-as: 0.4.1` pin. Both the pin and (optionally) this visibility change are reverted in a follow-up after the tag is cut.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unhides `refactor` commits in `release-please` changelog sections so the backend 0.4.1 release is cut and the MCP tool-error native handling change (#122) is documented. Paired with the existing `release-as: 0.4.1` pin; this visibility tweak will be reverted after the tag is published.

<sup>Written for commit 6518b032f02a275f428c754ed3541ab3d5ceebf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

