### PR TITLE
chore: remove backend release-as pin after 0.4.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,8 +20,7 @@
     "backend": {
       "release-type": "python",
       "package-name": "auxilia-backend",
-      "component": "backend",
-      "release-as": "0.4.1"
+      "component": "backend"
     },
     "web": {
       "release-type": "node",


### PR DESCRIPTION
Removes the one-time `release-as: 0.4.1` pin now that backend-v0.4.1 is tagged; leaving it would block future backend version bumps. Keeps refactor visible in changelog-sections per decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the one-time backend `release-as: 0.4.1` pin in `release-please-config.json` so future backend releases auto-bump as normal. Refactor entries remain included in changelogs.

<sup>Written for commit e7e7ed46a28854cfba73d3f3d9012c9932a686a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

