### PR TITLE
fix(mcp): render Metabase interactive visualize_query MCP App

### DIFF
--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -1,5 +1,5 @@
 import logging
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from uuid import uuid4
 
@@ -36,7 +36,7 @@ from app.agents.structured_output import (
     is_structured_output_artifact,
 )
 from app.agents.tool_errors import RepairInvalidToolCallsMiddleware, ToolErrorMiddleware
-from app.agents.toolset import Toolset, sanitize_tool_name
+from app.agents.toolset import PreparedToolset, Toolset, sanitize_tool_name
 from app.database import get_checkpointer
 from app.exceptions import DomainValidationError
 from app.integrations.langfuse.callback import langfuse_callback_handler
@@ -71,10 +71,16 @@ async def get_regeneration_checkpoint_id(agent, config: dict) -> str | None:
 
 @dataclass
 class ResolvedAgent:
-    """An agent config with its resolved toolset. Used for both parent and subagents."""
+    """An agent config with its prepared toolset. Used for both parent and subagents.
+
+    ``prepared`` is built at request scope (all DB work). ``live`` is populated
+    inside the streaming scope (``Agent._setup``) with tools bound to a persistent
+    per-server MCP session, and is the toolset actually handed to the LLM.
+    """
 
     config: AgentResponse
-    toolset: Toolset
+    prepared: PreparedToolset
+    live: Toolset | None = None
 
     @classmethod
     async def resolve(
@@ -86,10 +92,10 @@ class ResolvedAgent:
         is_parent: bool = False,
     ) -> "ResolvedAgent":
         config = await AgentService(db).get(agent_id, include_archived=True)
-        toolset = await Toolset.resolve(config.mcp_servers, db, user_id)
-        if is_parent:
-            toolset.apply_ui_metadata()
-        return cls(config=config, toolset=toolset)
+        prepared = await Toolset.prepare(
+            config.mcp_servers, db, user_id, apply_ui=is_parent
+        )
+        return cls(config=config, prepared=prepared)
 
     def compile(self, model) -> CompiledSubAgent:
         """Compile into a CompiledSubAgent runnable (for subagent use).
@@ -106,7 +112,7 @@ class ResolvedAgent:
             sandbox_tools = create_sandbox_tools(lazy_backend)
             runnable = create_deep_agent(
                 model=model,
-                tools=[*self.toolset.all, *sandbox_tools],
+                tools=[*self.live.all, *sandbox_tools],
                 system_prompt=self.config.instructions or "",
                 backend=lazy_backend,
                 middleware=[ToolErrorMiddleware()],
@@ -114,7 +120,7 @@ class ResolvedAgent:
         else:
             runnable = create_agent(
                 model=model,
-                tools=self.toolset.all,
+                tools=self.live.all,
                 system_prompt=SystemMessage(
                     content=[{"type": "text", "text": self.config.instructions or ""}]
                 ),
@@ -204,7 +210,7 @@ class Agent:
             ),
             RepairInvalidToolCallsMiddleware(),
             HumanInTheLoopMiddleware(
-                interrupt_on=agent.toolset.interrupt_on,
+                interrupt_on=agent.prepared.interrupt_on,
                 description_prefix="Tool execution pending approval",
             ),
         ]
@@ -249,7 +255,7 @@ class Agent:
 
         return create_agent(
             model=self.model,
-            tools=self.agent.toolset.all,
+            tools=self.agent.live.all,
             system_prompt=SystemMessage(self.agent.config.instructions),
             checkpointer=checkpointer,
             middleware=middleware,
@@ -292,11 +298,18 @@ class Agent:
     ):
         """Open a checkpointer scope and yield (agent, resolved_input, config).
 
-        Shared scaffolding for `stream` and `invoke`: opens the AsyncPostgresSaver,
-        builds the LangGraph agent against it, and resolves the request input and
+        Shared scaffolding for `stream` and `invoke`: opens one persistent MCP
+        session per server (parent + subagents) on an AsyncExitStack that lives for
+        the whole astream/ainvoke loop, opens the AsyncPostgresSaver, builds the
+        LangGraph agent against the live tools, and resolves the request input and
         run config in one place.
         """
-        async with get_checkpointer() as checkpointer:
+        async with AsyncExitStack() as stack, get_checkpointer() as checkpointer:
+            self.agent.live = await stack.enter_async_context(
+                Toolset.open(self.agent.prepared)
+            )
+            for sub in self.subagents:
+                sub.live = await stack.enter_async_context(Toolset.open(sub.prepared))
             agent = self._build_agent(checkpointer, output_schema)
             resolved_input = self._resolve_input(agent_input, command)
             config = await self._resolve_config(agent, trigger, config_overrides)
@@ -427,7 +440,7 @@ class Agent:
 
         return create_deep_agent(
             model=self.model,
-            tools=[*self.agent.toolset.all, *sandbox_tools],
+            tools=[*self.agent.live.all, *sandbox_tools],
             system_prompt=self.agent.config.instructions or "",
             backend=lazy_backend,
             middleware=[*extra_middleware, ToolErrorMiddleware()],

--- a/backend/app/agents/toolset.py
+++ b/backend/app/agents/toolset.py
@@ -1,10 +1,12 @@
 import asyncio
 import logging
 import re
+from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 
 from langchain_core.tools import Tool
 from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -125,6 +127,68 @@ class AgentTool:
     ui_metadata: dict[str, str] | None = None
 
 
+@dataclass
+class PreparedToolset:
+    """DB-derived spec needed to (re)bind MCP tools onto a live session.
+
+    Built at agent-build time (request scope, with the request DB), it carries
+    everything required to open sessions and assemble tools later during the
+    streaming response — without touching the DB. ``interrupt_on`` is computed
+    here so HITL middleware can be wired at build time.
+    """
+
+    client: MultiServerMCPClient | None
+    server_names: list[str]  # config keys (== MCP server names), in a fixed order
+    tool_settings: dict[str, dict]
+    server_id_by_name: dict[str, str]
+    interrupt_on: dict[str, bool]  # sanitized tool name -> True
+    apply_ui: bool
+
+
+def _assemble_agent_tools(
+    tools_by_server: list[tuple[str, list[Tool]]],
+    tool_settings: dict[str, dict],
+    server_id_by_name: dict[str, str],
+) -> list[AgentTool]:
+    """Filter -> build UI metadata -> sanitize, shared by prepare() and open().
+
+    ``tools_by_server`` must be in the SAME server order (and each server's tools
+    in the SAME order) across both call sites: ``_sanitize_tools_in_place`` is
+    order-sensitive (dedup suffixes), so identical ordering is what guarantees the
+    sanitized names computed at build (for ``interrupt_on``) match the names of the
+    live tools opened at stream time.
+    """
+    server_names = list(server_id_by_name.keys())
+    agent_tools: list[AgentTool] = []
+    for server_id, lc_tools in tools_by_server:
+        settings = tool_settings.get(str(server_id), {})
+        allowed_names = {
+            server_id + "_" + t
+            for t, status in settings.items()
+            if status == "always_allow"
+        }
+        approval_names = {
+            server_id + "_" + t
+            for t, status in settings.items()
+            if status == "needs_approval"
+        }
+        for tool in lc_tools:
+            if tool.name in allowed_names:
+                agent_tools.append(AgentTool(tool=tool, requires_approval=False))
+            elif tool.name in approval_names:
+                agent_tools.append(AgentTool(tool=tool, requires_approval=True))
+            # disabled or unknown tools are excluded
+
+    # Build UI metadata before sanitization (uses original prefixed names).
+    for at in agent_tools:
+        at.ui_metadata = _build_tool_ui_metadata(
+            at.tool, server_id_by_name, server_names
+        )
+
+    _sanitize_tools_in_place([at.tool for at in agent_tools])
+    return agent_tools
+
+
 class Toolset:
     """Resolved, ready-to-use tools from MCP servers."""
 
@@ -140,15 +204,31 @@ class Toolset:
         return {t.tool.name: True for t in self.tools if t.requires_approval}
 
     @classmethod
-    async def resolve(
+    async def prepare(
         cls,
         agent_mcp_servers: list[AgentMCPServerResponse],
         db: AsyncSession,
         user_id: str,
-    ) -> "Toolset":
-        """Full pipeline: DB lookup -> MCP config -> fetch -> filter -> sanitize -> build metadata."""
+        *,
+        apply_ui: bool,
+    ) -> PreparedToolset:
+        """Build-time phase: DB lookup -> configs -> discover tools -> interrupt_on.
+
+        All DB access happens here (request scope). Tools are fetched once to learn
+        their names/approval flags/UI metadata so ``interrupt_on`` is known at build
+        time; the discovered tool objects are discarded — execution uses the
+        persistent session opened by :meth:`open`.
+        """
+        empty = PreparedToolset(
+            client=None,
+            server_names=[],
+            tool_settings={},
+            server_id_by_name={},
+            interrupt_on={},
+            apply_ui=apply_ui,
+        )
         if not agent_mcp_servers:
-            return cls(tools=[])
+            return empty
 
         # 1. Load MCP server records from DB
         server_ids = [s.mcp_server_id for s in agent_mcp_servers]
@@ -157,7 +237,9 @@ class Toolset:
         )
         mcp_servers = list(result.scalars().all())
 
-        # 2. Build MCP client configs
+        # 2. Build MCP client configs (resolves auth to Redis/header values — no
+        #    live SQL handle is retained, so the client is safe to use later during
+        #    streaming, after the request DB session has closed).
         mcp_factory = MCPClientConfigFactory(db=db, user_id=user_id)
         configs = {
             server.name: await mcp_factory.build(server) for server in mcp_servers
@@ -169,57 +251,58 @@ class Toolset:
             for b in agent_mcp_servers
         }
 
-        # 4. Fetch & filter tools per server, building AgentTool objects
+        server_id_by_name = {server.name: str(server.id) for server in mcp_servers}
+        server_names = list(configs.keys())
+
+        # 4. Discover tools (one session per server, just to learn names/metadata).
         client = MultiServerMCPClient(configs, tool_name_prefix=True)
-
-        async def fetch_and_wrap(server_id: str) -> list[AgentTool]:
-            lc_tools = await client.get_tools(server_name=server_id)
-
-            settings = tool_settings.get(str(server_id))
-            allowed_names = {
-                server_id + "_" + t
-                for t, status in settings.items()
-                if status == "always_allow"
-            }
-            approval_names = {
-                server_id + "_" + t
-                for t, status in settings.items()
-                if status == "needs_approval"
-            }
-
-            agent_tools = []
-            for tool in lc_tools:
-                if tool.name in allowed_names:
-                    agent_tools.append(AgentTool(tool=tool, requires_approval=False))
-                elif tool.name in approval_names:
-                    agent_tools.append(AgentTool(tool=tool, requires_approval=True))
-                # disabled or unknown tools are excluded
-            return agent_tools
-
         results = await asyncio.gather(
-            *[fetch_and_wrap(sid) for sid in configs.keys()]
+            *[client.get_tools(server_name=name) for name in server_names]
+        )
+        tools_by_server = list(zip(server_names, results, strict=True))
+        agent_tools = _assemble_agent_tools(
+            tools_by_server, tool_settings, server_id_by_name
         )
 
-        agent_tools = [at for batch in results for at in batch]
+        return PreparedToolset(
+            client=client,
+            server_names=server_names,
+            tool_settings=tool_settings,
+            server_id_by_name=server_id_by_name,
+            interrupt_on={
+                at.tool.name: True for at in agent_tools if at.requires_approval
+            },
+            apply_ui=apply_ui,
+        )
 
-        # 5. Sanitize tool names
-        all_lc_tools = [at.tool for at in agent_tools]
-        server_id_by_name = {server.name: str(server.id) for server in mcp_servers}
-        server_names = list(server_id_by_name.keys())
+    @classmethod
+    @asynccontextmanager
+    async def open(cls, prepared: PreparedToolset):
+        """Stream-time phase: hold ONE live session per server and bind tools to it.
 
-        # Build UI metadata before sanitization (uses original names for prefix matching)
-        for at in agent_tools:
-            at.ui_metadata = _build_tool_ui_metadata(
-                at.tool, server_id_by_name, server_names
+        The sessions stay open for the whole ``async with`` block, so a handle
+        minted by one tool call (e.g. Metabase ``construct_query``'s
+        ``query_handle``) survives to the next call (``visualize_query``). MCP tool
+        execution errors (isError=True) are surfaced as ToolMessage(status="error")
+        natively by langchain-mcp-adapters; transport/protocol failures raise and
+        are caught globally by ToolErrorMiddleware.
+        """
+        async with AsyncExitStack() as stack:
+            tools_by_server: list[tuple[str, list[Tool]]] = []
+            for name in prepared.server_names:
+                session = await stack.enter_async_context(prepared.client.session(name))
+                lc_tools = await load_mcp_tools(
+                    session, server_name=name, tool_name_prefix=True
+                )
+                tools_by_server.append((name, lc_tools))
+
+            agent_tools = _assemble_agent_tools(
+                tools_by_server, prepared.tool_settings, prepared.server_id_by_name
             )
-
-        _sanitize_tools_in_place(all_lc_tools)
-
-        # MCP tool execution errors (isError=True) are surfaced as
-        # ToolMessage(status="error") natively by langchain-mcp-adapters>=0.3.0
-        # (handle_tool_errors defaults to True). Transport/protocol failures still
-        # raise and are caught globally by ToolErrorMiddleware.
-        return cls(tools=agent_tools)
+            toolset = cls(tools=agent_tools)
+            if prepared.apply_ui:
+                toolset.apply_ui_metadata()
+            yield toolset
 
     def apply_ui_metadata(self) -> None:
         """Inject UI metadata into tool coroutines.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.integrations.slack.router import router as slack_router
 from app.invites.router import router as invites_router
 from app.mcp.apps.router import router as mcp_apps_router
 from app.mcp.client.exceptions import OAuthAuthorizationRequired
+from app.mcp.client.initialize import apply_mcp_client_patches
 from app.mcp.router import auxilia_mcp
 from app.mcp.servers.router import router as mcp_servers_router
 from app.model_providers.router import router as model_providers_router
@@ -38,6 +39,8 @@ logging.getLogger("app").setLevel(app_settings.log_level.upper())
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    apply_mcp_client_patches()
+
     redis_client = redis.Redis(
         host=app_settings.redis_host, port=app_settings.redis_port, password=app_settings.redis_password, decode_responses=True)
     app.state.redis = redis_client

--- a/backend/app/mcp/apps/router.py
+++ b/backend/app/mcp/apps/router.py
@@ -36,7 +36,12 @@ async def read_mcp_app_resource(
     service: MCPServerService = Depends(get_mcp_server_service),
 ):
     mcp_server = await service.get_or_404(server_id)
-    async with connect_to_server(mcp_server, str(current_user.id), db) as (session, _):
+    # terminate_on_close=False: the resource HTML embeds a sessionToken bound to
+    # this MCP session; DELETEing the session would kill the token before the
+    # browser uses it. Let the server expire it by TTL instead.
+    async with connect_to_server(
+        mcp_server, str(current_user.id), db, terminate_on_close=False
+    ) as (session, _):
         return await session.read_resource(body.uri)
 
 
@@ -49,5 +54,9 @@ async def call_mcp_app_tool(
     service: MCPServerService = Depends(get_mcp_server_service),
 ):
     mcp_server = await service.get_or_404(server_id)
-    async with connect_to_server(mcp_server, str(current_user.id), db) as (session, _):
+    # terminate_on_close=False: keep the session alive for the App's follow-up
+    # data requests; it expires by the server's TTL.
+    async with connect_to_server(
+        mcp_server, str(current_user.id), db, terminate_on_close=False
+    ) as (session, _):
         return await session.call_tool(body.tool_name, body.arguments)

--- a/backend/app/mcp/client/initialize.py
+++ b/backend/app/mcp/client/initialize.py
@@ -1,0 +1,135 @@
+"""Runtime patches to ``mcp.ClientSession`` for MCP Apps interoperability.
+
+The bundled MCP Python SDK doesn't expose two things we need to render
+interactive MCP Apps (e.g. Metabase's ``visualize_query`` chart):
+
+1. **UI capability negotiation.** Servers gate UI-bearing tools behind the
+   client capability ``io.modelcontextprotocol/ui`` advertised during
+   ``initialize``. ``ClientSession.initialize`` hardcodes the capability set
+   (``experimental=None``) and offers no hook to add it.
+2. **Lenient output validation.** ``ClientSession.call_tool`` validates a
+   result's ``structuredContent`` against the tool's ``outputSchema`` and
+   *raises* ``RuntimeError`` on mismatch. Metabase's declared schema doesn't
+   match what it returns, so the call dies before we ever see the result.
+
+``apply_mcp_client_patches()`` is idempotent and applied once at app startup
+(see ``app/main.py``). It patches the class, so it covers both the raw
+``connect_to_server`` path and the langchain-mcp-adapters path (both use
+``ClientSession`` underneath).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mcp.client.session as mcp_session
+import mcp.types as types
+from mcp.client.session import ClientSession
+
+
+logger = logging.getLogger(__name__)
+
+# MCP Apps extension identifier and the capability payload a host advertises.
+# https://github.com/modelcontextprotocol/ext-apps (spec 2026-01-26).
+UI_EXTENSION = "io.modelcontextprotocol/ui"
+UI_CAPABILITY = {"mimeTypes": ["text/html;profile=mcp-app"]}
+
+_PATCHED = False
+
+
+async def _initialize_with_ui_capability(self: ClientSession) -> types.InitializeResult:
+    """Drop-in for ``ClientSession.initialize`` that advertises MCP Apps support.
+
+    Mirrors the upstream method but injects the ``io.modelcontextprotocol/ui``
+    capability. We advertise it under both ``extensions`` (where the MCP Apps
+    spec puts it) and ``experimental`` (belt-and-suspenders for servers reading
+    the older location). ``ClientCapabilities`` allows extra fields, so the
+    ``extensions`` key serializes onto the wire.
+
+    Defensive: if the upstream shape drifts, fall back to the original
+    ``initialize`` so startup never breaks — we just lose UI tools and log it.
+    """
+    sampling = (
+        (self._sampling_capabilities or types.SamplingCapability())
+        if self._sampling_callback is not mcp_session._default_sampling_callback
+        else None
+    )
+    elicitation = (
+        types.ElicitationCapability(
+            form=types.FormElicitationCapability(),
+            url=types.UrlElicitationCapability(),
+        )
+        if self._elicitation_callback is not mcp_session._default_elicitation_callback
+        else None
+    )
+    roots = (
+        types.RootsCapability(listChanged=True)
+        if self._list_roots_callback is not mcp_session._default_list_roots_callback
+        else None
+    )
+
+    capabilities = types.ClientCapabilities(
+        sampling=sampling,
+        elicitation=elicitation,
+        experimental={UI_EXTENSION: UI_CAPABILITY},
+        roots=roots,
+        tasks=self._task_handlers.build_capability(),
+        extensions={UI_EXTENSION: UI_CAPABILITY},
+    )
+
+    result = await self.send_request(
+        types.ClientRequest(
+            types.InitializeRequest(
+                params=types.InitializeRequestParams(
+                    protocolVersion=types.LATEST_PROTOCOL_VERSION,
+                    capabilities=capabilities,
+                    clientInfo=self._client_info,
+                ),
+            )
+        ),
+        types.InitializeResult,
+    )
+
+    if result.protocolVersion not in mcp_session.SUPPORTED_PROTOCOL_VERSIONS:
+        raise RuntimeError(
+            f"Unsupported protocol version from the server: {result.protocolVersion}"
+        )
+
+    self._server_capabilities = result.capabilities
+    await self.send_notification(
+        types.ClientNotification(types.InitializedNotification())
+    )
+    return result
+
+
+def _make_lenient_validate(original):
+    async def _lenient_validate_tool_result(
+        self: ClientSession, name: str, result: types.CallToolResult
+    ) -> None:
+        """Log output-schema mismatches instead of raising.
+
+        Some servers (e.g. Metabase) return ``structuredContent`` that doesn't
+        match their declared ``outputSchema``. Upstream raises ``RuntimeError``,
+        which kills the tool call; we'd rather hand the result to the model.
+        """
+        try:
+            await original(self, name, result)
+        except Exception as exc:  # noqa: BLE001 - intentionally lenient
+            logger.warning(
+                "Ignoring MCP output validation error for tool %s: %s", name, exc
+            )
+
+    return _lenient_validate_tool_result
+
+
+def apply_mcp_client_patches() -> None:
+    """Patch ``ClientSession`` for MCP Apps. Idempotent; call once at startup."""
+    global _PATCHED
+    if _PATCHED:
+        return
+    ClientSession.initialize = _initialize_with_ui_capability
+    ClientSession._validate_tool_result = _make_lenient_validate(
+        ClientSession._validate_tool_result
+    )
+    _PATCHED = True
+    logger.info("Applied MCP client patches (UI capability + lenient validation)")

--- a/backend/app/mcp/client/initialize.py
+++ b/backend/app/mcp/client/initialize.py
@@ -21,6 +21,7 @@ interactive MCP Apps (e.g. Metabase's ``visualize_query`` chart):
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 
 import mcp.client.session as mcp_session
 import mcp.types as types
@@ -34,20 +35,21 @@ logger = logging.getLogger(__name__)
 UI_EXTENSION = "io.modelcontextprotocol/ui"
 UI_CAPABILITY = {"mimeTypes": ["text/html;profile=mcp-app"]}
 
+# The original ``ClientSession.initialize``, captured before we patch it so the
+# UI-capability variant can fall back to it if the SDK's internals drift.
+_InitializeMethod = Callable[[ClientSession], Awaitable[types.InitializeResult]]
+_original_initialize: _InitializeMethod | None = None
+
 _PATCHED = False
 
 
-async def _initialize_with_ui_capability(self: ClientSession) -> types.InitializeResult:
-    """Drop-in for ``ClientSession.initialize`` that advertises MCP Apps support.
+def _build_ui_capabilities(self: ClientSession) -> types.ClientCapabilities:
+    """Reconstruct ``ClientSession``'s capability set with the MCP Apps UI
+    capability added.
 
-    Mirrors the upstream method but injects the ``io.modelcontextprotocol/ui``
-    capability. We advertise it under both ``extensions`` (where the MCP Apps
-    spec puts it) and ``experimental`` (belt-and-suspenders for servers reading
-    the older location). ``ClientCapabilities`` allows extra fields, so the
-    ``extensions`` key serializes onto the wire.
-
-    Defensive: if the upstream shape drifts, fall back to the original
-    ``initialize`` so startup never breaks — we just lose UI tools and log it.
+    This mirrors the upstream ``initialize``'s private capability assembly, so it
+    is the part most likely to break if the SDK's internals drift. The caller runs
+    it inside a ``try`` and falls back to the original ``initialize`` if it raises.
     """
     sampling = (
         (self._sampling_capabilities or types.SamplingCapability())
@@ -67,8 +69,7 @@ async def _initialize_with_ui_capability(self: ClientSession) -> types.Initializ
         if self._list_roots_callback is not mcp_session._default_list_roots_callback
         else None
     )
-
-    capabilities = types.ClientCapabilities(
+    return types.ClientCapabilities(
         sampling=sampling,
         elicitation=elicitation,
         experimental={UI_EXTENSION: UI_CAPABILITY},
@@ -77,18 +78,45 @@ async def _initialize_with_ui_capability(self: ClientSession) -> types.Initializ
         extensions={UI_EXTENSION: UI_CAPABILITY},
     )
 
-    result = await self.send_request(
-        types.ClientRequest(
+
+async def _initialize_with_ui_capability(self: ClientSession) -> types.InitializeResult:
+    """Drop-in for ``ClientSession.initialize`` that advertises MCP Apps support.
+
+    Mirrors the upstream method but injects the ``io.modelcontextprotocol/ui``
+    capability. We advertise it under both ``extensions`` (where the MCP Apps
+    spec puts it) and ``experimental`` (belt-and-suspenders for servers reading
+    the older location). ``ClientCapabilities`` allows extra fields, so the
+    ``extensions`` key serializes onto the wire.
+
+    Defensive: this patch replaces ``initialize`` for *every* MCP connection, so
+    if the upstream shape drifts and we can't assemble our request, we fall back
+    to the original ``initialize`` — connections still work, we just lose UI tools
+    and log it. The fallback is scoped to request assembly (before any send) so a
+    genuine handshake error (e.g. unsupported protocol version) still surfaces.
+    """
+    try:
+        request = types.ClientRequest(
             types.InitializeRequest(
                 params=types.InitializeRequestParams(
                     protocolVersion=types.LATEST_PROTOCOL_VERSION,
-                    capabilities=capabilities,
+                    capabilities=_build_ui_capabilities(self),
                     clientInfo=self._client_info,
                 ),
             )
-        ),
-        types.InitializeResult,
-    )
+        )
+    except Exception:  # noqa: BLE001 - any drift in the mirrored SDK internals
+        original = _original_initialize
+        if original is None:  # patches not applied; nothing to fall back to
+            raise
+        logger.warning(
+            "Could not assemble the MCP Apps initialize request (the MCP SDK's "
+            "internals likely drifted); falling back to the default initialize. "
+            "UI-bearing tools will be unavailable.",
+            exc_info=True,
+        )
+        return await original(self)
+
+    result = await self.send_request(request, types.InitializeResult)
 
     if result.protocolVersion not in mcp_session.SUPPORTED_PROTOCOL_VERSIONS:
         raise RuntimeError(
@@ -124,9 +152,10 @@ def _make_lenient_validate(original):
 
 def apply_mcp_client_patches() -> None:
     """Patch ``ClientSession`` for MCP Apps. Idempotent; call once at startup."""
-    global _PATCHED
+    global _PATCHED, _original_initialize
     if _PATCHED:
         return
+    _original_initialize = ClientSession.initialize
     ClientSession.initialize = _initialize_with_ui_capability
     ClientSession._validate_tool_result = _make_lenient_validate(
         ClientSession._validate_tool_result

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -128,7 +128,13 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
 
 
 @asynccontextmanager
-async def connect_to_server(mcp_server: MCPServerDB, user_id: str, db: AsyncSession):
+async def connect_to_server(
+    mcp_server: MCPServerDB,
+    user_id: str,
+    db: AsyncSession,
+    *,
+    terminate_on_close: bool = True,
+):
     """Connect to an MCP server and initialize session.
 
     Similar to the pattern from https://modelcontextprotocol.info/docs/tutorials/building-a-client/
@@ -138,6 +144,10 @@ async def connect_to_server(mcp_server: MCPServerDB, user_id: str, db: AsyncSess
         mcp_server: MCP server configuration
         user_id: The current user's ID
         db: Database session
+        terminate_on_close: When False, the session is NOT DELETEd on exit and is
+            left to expire by the server's TTL. MCP App paths need this because
+            Metabase binds artifacts (the embedded ``sessionToken``) to the MCP
+            session — DELETEing it kills the token before the browser uses it.
 
     Yields:
         tuple: (session, tools) - Initialized session and available tools
@@ -189,14 +199,21 @@ async def connect_to_server(mcp_server: MCPServerDB, user_id: str, db: AsyncSess
     else:
         client_args = {"url": mcp_server.url}
 
-    async with streamablehttp_client(**client_args) as (read, write, _):
+    async with streamablehttp_client(
+        **client_args, terminate_on_close=terminate_on_close
+    ) as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
 
             try:
-                response = await session.list_tools()
-
-                tools = response.tools
+                tools = []
+                cursor: str | None = None
+                while True:
+                    response = await session.list_tools(cursor=cursor)
+                    tools.extend(response.tools)
+                    cursor = response.nextCursor
+                    if not cursor:
+                        break
 
                 if mcp_server.url == "https://bigquery.googleapis.com/mcp":
                     await session.call_tool("list_dataset_ids", {"project_id": os.getenv("GCLOUD_PROJECT")})

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -127,6 +127,37 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
             return [{"name": tool.name, "description": tool.description} for tool in tools]
 
 
+# Safety bound for tools/list pagination. A well-behaved server eventually returns
+# a falsy nextCursor; this caps a misbehaving one that emits endless new cursors.
+MAX_TOOL_LIST_PAGES = 1000
+
+
+async def _list_all_tools(session: ClientSession) -> list:
+    """Page through ``tools/list``, guarding against a server that never ends
+    pagination. A repeated or cyclic ``nextCursor`` is detected and a runaway page
+    count is capped — otherwise the loop would spin forever, accumulating tools.
+    """
+    tools = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    for _ in range(MAX_TOOL_LIST_PAGES):
+        response = await session.list_tools(cursor=cursor)
+        tools.extend(response.tools)
+        cursor = response.nextCursor
+        if not cursor:
+            return tools
+        if cursor in seen_cursors:
+            raise DomainError(
+                "MCP server returned a repeated tools/list cursor; "
+                "aborting to avoid an infinite pagination loop."
+            )
+        seen_cursors.add(cursor)
+    raise DomainError(
+        f"MCP server exceeded {MAX_TOOL_LIST_PAGES} tools/list pages; "
+        "aborting to avoid an unbounded pagination loop."
+    )
+
+
 @asynccontextmanager
 async def connect_to_server(
     mcp_server: MCPServerDB,
@@ -206,14 +237,7 @@ async def connect_to_server(
             await session.initialize()
 
             try:
-                tools = []
-                cursor: str | None = None
-                while True:
-                    response = await session.list_tools(cursor=cursor)
-                    tools.extend(response.tools)
-                    cursor = response.nextCursor
-                    if not cursor:
-                        break
+                tools = await _list_all_tools(session)
 
                 if mcp_server.url == "https://bigquery.googleapis.com/mcp":
                     await session.call_tool("list_dataset_ids", {"project_id": os.getenv("GCLOUD_PROJECT")})

--- a/backend/tests/agents/test_runtime.py
+++ b/backend/tests/agents/test_runtime.py
@@ -8,7 +8,7 @@ def _make_agent() -> Agent:
     resolved = MagicMock()
     resolved.config.has_code_interpreter = False
     resolved.config.instructions = "You are a test agent"
-    resolved.toolset.all = []
+    resolved.live.all = []
     return Agent(
         thread=MagicMock(),
         agent=resolved,

--- a/backend/tests/agents/test_toolset.py
+++ b/backend/tests/agents/test_toolset.py
@@ -309,13 +309,21 @@ class TestApplyUiMetadata:
 
 
 # ---------------------------------------------------------------------------
-# Toolset.resolve — empty bindings
+# Toolset.prepare / open — empty bindings
 # ---------------------------------------------------------------------------
 
 
-class TestToolsetResolveEmpty:
+class TestToolsetPrepareEmpty:
     @pytest.mark.asyncio
-    async def test_empty_bindings_returns_empty_toolset(self):
-        ts = await Toolset.resolve([], db=None, user_id="u1")
-        assert ts.tools == []
-        assert ts.all == []
+    async def test_empty_bindings_prepare(self):
+        prepared = await Toolset.prepare([], db=None, user_id="u1", apply_ui=True)
+        assert prepared.server_names == []
+        assert prepared.interrupt_on == {}
+        assert prepared.client is None
+
+    @pytest.mark.asyncio
+    async def test_empty_bindings_open_yields_empty_toolset(self):
+        prepared = await Toolset.prepare([], db=None, user_id="u1", apply_ui=True)
+        async with Toolset.open(prepared) as ts:
+            assert ts.tools == []
+            assert ts.all == []

--- a/backend/tests/mcp/client/test_initialize.py
+++ b/backend/tests/mcp/client/test_initialize.py
@@ -1,0 +1,71 @@
+"""Tests for the ClientSession MCP Apps patches (app/mcp/client/initialize.py).
+
+Focus on the documented defensive fallback: the patch replaces
+``ClientSession.initialize`` for *every* MCP connection, so if the SDK's private
+internals drift and we can't assemble our UI-capability request, it must fall
+back to the original ``initialize`` rather than break all connections.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.client.session import ClientSession
+
+import app.mcp.client.initialize as initialize
+
+
+async def test_initialize_falls_back_to_original_on_sdk_drift(monkeypatch):
+    """Capability assembly raising (simulated SDK drift) → fall back to original."""
+
+    def _drift(_self):
+        raise AttributeError("ClientSession._sampling_callback renamed upstream")
+
+    monkeypatch.setattr(initialize, "_build_ui_capabilities", _drift)
+
+    calls = []
+
+    async def _fake_original(self):
+        calls.append(self)
+        return "ORIGINAL_RESULT"
+
+    monkeypatch.setattr(initialize, "_original_initialize", _fake_original)
+
+    sentinel_self = object()
+    result = await initialize._initialize_with_ui_capability(sentinel_self)
+
+    assert result == "ORIGINAL_RESULT"
+    assert calls == [sentinel_self]
+
+
+async def test_initialize_reraises_when_no_original_captured(monkeypatch):
+    """If patches weren't applied (no original captured), the drift error propagates
+    instead of being silently swallowed."""
+
+    def _drift(_self):
+        raise AttributeError("drift")
+
+    monkeypatch.setattr(initialize, "_build_ui_capabilities", _drift)
+    monkeypatch.setattr(initialize, "_original_initialize", None)
+
+    with pytest.raises(AttributeError):
+        await initialize._initialize_with_ui_capability(object())
+
+
+def test_apply_captures_original_before_overwriting(monkeypatch):
+    """apply_mcp_client_patches must capture the original initialize *before*
+    replacing it, otherwise there is nothing to fall back to."""
+
+    sentinel_initialize = object()
+    monkeypatch.setattr(ClientSession, "initialize", sentinel_initialize, raising=False)
+    # Stub so apply's lenient-validation wrap targets a throwaway monkeypatch
+    # restores, not the real method.
+    monkeypatch.setattr(
+        ClientSession, "_validate_tool_result", lambda *a, **k: None, raising=False
+    )
+    monkeypatch.setattr(initialize, "_PATCHED", False)
+    monkeypatch.setattr(initialize, "_original_initialize", None)
+
+    initialize.apply_mcp_client_patches()
+
+    assert initialize._original_initialize is sentinel_initialize
+    assert ClientSession.initialize is initialize._initialize_with_ui_capability

--- a/backend/tests/mcp/servers/test_connect_to_server.py
+++ b/backend/tests/mcp/servers/test_connect_to_server.py
@@ -1,0 +1,75 @@
+"""Tests for tools/list pagination in app/mcp/servers/service.py.
+
+`_list_all_tools` must not hang on a misbehaving server: a repeated or cyclic
+`nextCursor` is detected, and a runaway page count is capped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.exceptions import DomainError
+from app.mcp.servers import service
+
+
+class _Resp:
+    def __init__(self, tools, next_cursor):
+        self.tools = tools
+        self.nextCursor = next_cursor
+
+
+class _SeqSession:
+    """Returns queued responses in order, recording the cursors it was given."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.cursors_seen = []
+
+    async def list_tools(self, cursor=None):
+        self.cursors_seen.append(cursor)
+        return self._responses.pop(0)
+
+
+class _CursorSession:
+    """Returns next_cursors from a fixed sequence (one per call)."""
+
+    def __init__(self, next_cursors):
+        self._next_cursors = list(next_cursors)
+        self.call_count = 0
+
+    async def list_tools(self, cursor=None):
+        nxt = self._next_cursors[self.call_count]
+        self.call_count += 1
+        return _Resp([object()], nxt)
+
+
+async def test_collects_all_pages_until_falsy_cursor():
+    session = _SeqSession(
+        [_Resp(["a", "b"], "c1"), _Resp(["c"], "c2"), _Resp(["d"], None)]
+    )
+    tools = await service._list_all_tools(session)
+    assert tools == ["a", "b", "c", "d"]
+    assert session.cursors_seen == [None, "c1", "c2"]
+
+
+async def test_repeated_cursor_raises():
+    # Server keeps handing back the same cursor -> would loop forever.
+    session = _CursorSession(["same", "same", "same"])
+    with pytest.raises(DomainError, match="repeated tools/list cursor"):
+        await service._list_all_tools(session)
+
+
+async def test_cyclic_cursor_raises():
+    # A -> B -> A cycle.
+    session = _CursorSession(["A", "B", "A", "B"])
+    with pytest.raises(DomainError, match="repeated tools/list cursor"):
+        await service._list_all_tools(session)
+
+
+async def test_endless_unique_cursors_are_capped(monkeypatch):
+    monkeypatch.setattr(service, "MAX_TOOL_LIST_PAGES", 3)
+    # Always a brand-new cursor: repeat-detection can't catch it; the cap must.
+    session = _CursorSession([f"c{i}" for i in range(10)])
+    with pytest.raises(DomainError, match="exceeded 3 tools/list pages"):
+        await service._list_all_tools(session)
+    assert session.call_count == 3

--- a/metabase-mcp-app.md
+++ b/metabase-mcp-app.md
@@ -1,0 +1,105 @@
+# auxilia × Metabase MCP — Integration Findings
+
+Why a Metabase "MCP App" (interactive `visualize_query` chart) wouldn't render in auxilia — and the chain of fixes that got it there. Each fix only revealed the next layer.
+
+## TL;DR
+
+Rendering one interactive chart exercised **three independent subsystems**, and auxilia's "proxy everything server-side + render in a `srcdoc` sandbox" model collided with each:
+
+1. **MCP capability negotiation** — servers gate UI tools behind a client capability the bundled SDK doesn't expose.
+2. **MCP session lifetime** — Metabase binds artifacts (`sessionToken`, `query_handle`) to the MCP session; auxilia's per-request / per-call sessions destroyed them.
+3. **Iframe origin** — the embed assumes a real `location.origin`; `srcdoc` gives `"null"`, which breaks its request-URL construction.
+
+Claude Desktop sidesteps all three by holding one long-lived session and rendering on a real dedicated origin (`*.claudemcpcontent.com`).
+
+Legend: **[BE]** backend (Python / MCP client) · **[FE]** frontend (Next.js / `@mcp-ui/client`) · **[MB]** Metabase's bundle/behavior.
+
+## The chain, in the order it unravelled
+
+### 1. [BE] Tool wasn't even listed
+
+- **Symptom:** `visualize_query` absent from `list_tools`.
+- **Cause:** MCP Apps gate UI-bearing tools behind the client capability `io.modelcontextprotocol/ui`. The SDK's `ClientSession.initialize()` hardcodes capabilities — no hook to add it.
+- **Fix:** Monkeypatch `ClientSession.initialize` to advertise the UI capability (under both `extensions` and `experimental`). Also made `connect_to_server` follow `tools/list` pagination.
+- **Files:** `app/mcp/client/initialize.py`, `app/main.py`, `app/mcp/servers/service.py`
+
+### 2. [BE] Tool call crashed on output validation
+
+- **Cause:** Recent MCP SDK validates a result's `structuredContent` against the tool's `outputSchema` and _raises_. Metabase's declared schema (`query`: base64 string) didn't match what came back → the call died.
+- **Fix:** Same patch wraps `_validate_tool_result` to log, not raise.
+- **Files:** `app/mcp/client/initialize.py`
+
+### 3. [FE] App iframe never mounted
+
+- **Cause:** `@mcp-ui/client` 6.1.0 threw an uncaught "Timed out waiting for sandbox proxy frame to be ready" under React StrictMode (Next.js dev double-mount).
+- **Fix:** Bump to `@mcp-ui/client` 7.1.1 (PR #190). v7.0.0 was a no-op major; `AppRenderer` props unchanged.
+- **Files:** `web/package.json`
+
+### 4. [FE] Color parser crash
+
+- **Cause:** `Unable to parse color from string: lab(100% 0 0)` — we passed Tailwind v4 `oklch()` theme vars via `hostContext`; the app's parser can't read CSS Color 4. `getComputedStyle` doesn't downconvert (Chrome re-serializes to `lab()`).
+- **Fix:** Normalize each color through a **canvas 2D** round-trip → guaranteed `rgb()`.
+- **Files:** `web/src/hooks/use-mcp-host-context.ts`
+
+### 5. [BE][FE] App auth — 401 on its bootstrap
+
+- **Cause:** The resource HTML embeds `window.metabaseConfig.sessionToken`, which Metabase binds to the MCP session. Our SDK closed each session with `terminate_on_close=True` → an HTTP `DELETE` that killed the session immediately, so the embedded token was _dead before the browser used it_.
+- **Fix:** Pass `terminate_on_close=False` on the app paths (read-resource / call-tool); let Metabase expire by TTL. Also advertise `hostCapabilities` (`serverTools`/`serverResources`) + `hostInfo` on `AppRenderer`.
+- **Files:** `app/mcp/servers/service.py`, `app/mcp/apps/router.py`, `web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx`
+
+### 6. [BE] `query_handle` expired between tool calls
+
+- **Cause:** The flow is `construct_query` → returns a `query_handle` → `visualize_query(query_handle)`. But `MultiServerMCPClient.get_tools()` opens a **new session per tool call** (confirmed in its docstring) — so the handle, minted in session A, was gone by session B.
+- **Fix:** Persistent session per turn — split `Toolset.prepare()` (all DB work, in request scope) from `Toolset.open()` (one live session per server, held in an `AsyncExitStack` across the whole `astream`/`ainvoke`). HITL middleware moved into `_build_agent`. All DB work kept in `build` so it survives the streaming-response DB-session lifetime.
+- **Files:** `app/agents/toolset.py`, `app/agents/runtime.py`, `app/mcp/client/factory.py`
+
+### 7. [FE] App stuck on the "press Run" draft state
+
+- **Cause:** The widget memoized `toolResult` but not `toolInput`; parent re-renders re-sent `toolInput` after the result arrived, resetting Metabase's app to "edited query — press Run."
+- **Fix:** Memoize `effectiveToolInput` by content hash, like `toolResult`.
+- **Files:** `web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx`
+
+### 8. [FE][MB] "Question introuvable" → the real culprit: `Invalid base URL`
+
+- **Trace:** Verified via Metabase's source (`getMcpDeserializedCard`, `useMcpApp`, `load-question.ts`): the query is fully _resolved_ (db 23, table 7460, fields by id), metadata loads (200). Yet `/api/dataset` never fired.
+- **Cause:** The embed builds requests with `new URL(basename + "/api/dataset", location.origin)`. In a `srcdoc` iframe `location.origin` is the string `"null"`, and `new URL(anything, "null")` **throws regardless of basename** — so the data query can never be constructed.
+- **How Claude works:** Renders the app on a **real dedicated origin** (`*.claudemcpcontent.com`, the spec's `McpUiResourceMeta.domain` field) → valid `location.origin`.
+- **Fix:** Load the app via a `blob:` URL (inherits our origin → valid `location.origin`) instead of `srcdoc`, with a `srcdoc` fallback. _(render confirmed 2026-06-20 — see Status)_
+- **Files:** `web/public/sandbox.html`
+
+### 9. [BE] Surfacing the real errors (debug enablers)
+
+- **Cause:** MCP tool errors came back as block-list `ToolMessage`s; the AI-SDK adapter only shows _string_ error text, so the UI masked everything as "Tool execution failed."
+- **Fix:** Flatten error content to a string + log real MCP errors in `ToolErrorMiddleware`. (Plus temporary `[viz]` logging that let us decode the exact query — **to be removed**.)
+- **Files:** `app/agents/tool_errors.py`, `app/mcp/client/tools.py`
+
+## Three root insights
+
+1. **Capability negotiation.** MCP servers withhold UI tools (and reject their calls) unless the client declares the MCP Apps UI capability during `initialize`. The bundled SDK doesn't expose this — hence the global patch.
+2. **Stateful sessions.** Metabase binds the embed `sessionToken` and the `query_handle` to the MCP session. auxilia's per-request / per-call sessions destroyed them. The fix: one persistent session per turn, and don't `DELETE` sessions the browser still needs.
+3. **Real origin, not `srcdoc`.** The embed assumes a valid `location.origin`. `srcdoc` gives `"null"`, which breaks its request-URL construction. Real hosts assign a dedicated origin; we approximate it with a `blob:` URL.
+
+## Files touched
+
+| File                                                                     | Change                                                                       |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `app/mcp/client/initialize.py` _(new)_                                   | Patch `ClientSession.initialize` (UI capability) + lenient output validation |
+| `app/main.py`                                                            | Apply the patch at startup (lifespan)                                        |
+| `app/mcp/servers/service.py`                                             | `tools/list` pagination; `terminate_on_close` param on `connect_to_server`   |
+| `app/mcp/apps/router.py`                                                 | read-resource / call-tool use `terminate_on_close=False`                     |
+| `app/mcp/client/factory.py`                                              | `terminate_on_close=False` on agent-runtime connections                      |
+| `app/agents/toolset.py`                                                  | Split into `prepare()` (DB) + `open()` (persistent session)                  |
+| `app/agents/runtime.py`                                                  | Open one MCP session per server across the run; HITL moved into build        |
+| `app/agents/tool_errors.py`, `app/mcp/client/tools.py`                   | Surface/flatten real MCP tool errors; diagnostics                            |
+| `web/package.json`                                                       | `@mcp-ui/client` → 7.1.1; pin `@modelcontextprotocol/ext-apps`               |
+| `web/src/hooks/use-mcp-host-context.ts`                                  | oklch → rgb color normalization (canvas)                                     |
+| `web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx` | Advertise `hostCapabilities`/`hostInfo`; memoize `toolInput`                 |
+| `web/public/sandbox.html`                                                | Load app via `blob:` URL (real origin) instead of `srcdoc`                   |
+
+## Status
+
+Steps 1–8 verified working end-to-end (2026-06-20): the `visualize_query` chart renders, data path included — the `blob:`-URL origin fix held.
+
+**One dev-only caveat (not one of the 9):** under React StrictMode (Next dev default), the double-mount makes `@mcp-ui/client` 7.1.1's `AppRenderer` tear down its host↔app transport mid-connect → `protocol.ts "Not connected"` + the app stuck on Metabase's "press Run" placeholder. The chart renders fine in production builds. 7.1.1 is the latest release (no upstream fix yet); the decision (2026-06-20) is to keep StrictMode on and revisit on the next `@mcp-ui/client` release. See the note by `<AppRenderer>` in `mcp-app-widget.tsx`.
+
+Cleanup still owed: remove the temporary `[viz]` logging in `app/mcp/client/tools.py`.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
 				"@ai-sdk/react": "^3.0.3",
 				"@langchain/core": "^1.1.34",
 				"@langchain/langgraph-sdk": "^1.7.5",
-				"@mcp-ui/client": "^6.1.0",
+				"@mcp-ui/client": "^7.1.1",
 				"@radix-ui/react-avatar": "^1.1.11",
 				"@radix-ui/react-checkbox": "^1.3.3",
 				"@radix-ui/react-collapsible": "^1.1.12",
@@ -1000,9 +1000,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.9",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-			"integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.14.1"
@@ -1726,54 +1726,18 @@
 			}
 		},
 		"node_modules/@mcp-ui/client": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@mcp-ui/client/-/client-6.1.0.tgz",
-			"integrity": "sha512-Wk/9uhu8xdOgHjiaEtAq2RbXn4WGstpFeJ6I71JCP7JC7MtvQB/qnEKDVGSbjwyLnIeZYMSILHf5E+57/YCftQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@mcp-ui/client/-/client-7.1.1.tgz",
+			"integrity": "sha512-Yy0q3YFl6WmcHRW0pRwD2F+Fs9Y/TFm1xpBpkuqvS1IRBaGGgc7PvkB0nvrKTqO6QZm+MufObfQM+oxo8mmLFw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@modelcontextprotocol/ext-apps": "^0.3.1",
-				"@modelcontextprotocol/sdk": "^1.24.0",
-				"@quilted/threads": "^3.1.3",
-				"@r2wc/react-to-web-component": "^2.0.4",
-				"@remote-dom/core": "^1.8.0",
-				"@remote-dom/react": "^1.2.2",
+				"@modelcontextprotocol/ext-apps": "^1.2.0",
+				"@modelcontextprotocol/sdk": "^1.27.1",
 				"zod": "^3.23.8"
 			},
 			"peerDependencies": {
 				"react": "^18 || ^19",
 				"react-dom": "^18 || ^19"
-			}
-		},
-		"node_modules/@mcp-ui/client/node_modules/@remote-dom/react": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@remote-dom/react/-/react-1.2.2.tgz",
-			"integrity": "sha512-PkvioODONTr1M0StGDYsR4Ssf5M0Rd4+IlWVvVoK3Zrw8nr7+5mJkgNofaj/z7i8Aep78L28PCW8/WduUt4unA==",
-			"license": "MIT",
-			"dependencies": {
-				"@remote-dom/core": "^1.7.0",
-				"@types/react": "^18.0.0",
-				"htm": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0"
-			},
-			"peerDependenciesMeta": {
-				"react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mcp-ui/client/node_modules/@types/react": {
-			"version": "18.3.28",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/prop-types": "*",
-				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@mcp-ui/client/node_modules/zod": {
@@ -1795,35 +1759,21 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/ext-apps": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-0.3.1.tgz",
-			"integrity": "sha512-Iivz2KwWK8xlRbiWwFB/C4NXqE8VJBoRCbBkJCN98ST2UbQvA6kfyebcLsypiqylJS467XOOaBcI9DeQ3t+zqA==",
-			"hasInstallScript": true,
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+			"integrity": "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==",
 			"license": "MIT",
 			"workspaces": [
 				"examples/*"
 			],
-			"optionalDependencies": {
-				"@oven/bun-darwin-aarch64": "^1.2.21",
-				"@oven/bun-darwin-x64": "^1.2.21",
-				"@oven/bun-darwin-x64-baseline": "^1.2.21",
-				"@oven/bun-linux-aarch64": "^1.2.21",
-				"@oven/bun-linux-aarch64-musl": "^1.2.21",
-				"@oven/bun-linux-x64": "^1.2.21",
-				"@oven/bun-linux-x64-baseline": "^1.2.21",
-				"@oven/bun-linux-x64-musl": "^1.2.21",
-				"@oven/bun-linux-x64-musl-baseline": "^1.2.21",
-				"@oven/bun-windows-x64": "^1.2.21",
-				"@oven/bun-windows-x64-baseline": "^1.2.21",
-				"@rollup/rollup-darwin-arm64": "^4.53.3",
-				"@rollup/rollup-darwin-x64": "^4.53.3",
-				"@rollup/rollup-linux-arm64-gnu": "^4.53.3",
-				"@rollup/rollup-linux-x64-gnu": "^4.53.3",
-				"@rollup/rollup-win32-arm64-msvc": "^4.53.3",
-				"@rollup/rollup-win32-x64-msvc": "^4.53.3"
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=20"
 			},
 			"peerDependencies": {
-				"@modelcontextprotocol/sdk": "^1.24.0",
+				"@modelcontextprotocol/sdk": "^1.29.0",
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"zod": "^3.25.0 || ^4.0.0"
@@ -1838,9 +1788,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-			"integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@hono/node-server": "^1.19.9",
@@ -1878,9 +1828,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -2112,149 +2062,6 @@
 			"engines": {
 				"node": ">=8.0.0"
 			}
-		},
-		"node_modules/@oven/bun-darwin-aarch64": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.9.tgz",
-			"integrity": "sha512-df7smckMWSUfaT5mzwN9Lfpd3ZGkOqo+vmQ8VV2a32gl14v6uZ/qeeo+1RlANXn8M0uzXPWWCkrKZIWSZUR0qw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@oven/bun-darwin-x64": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.9.tgz",
-			"integrity": "sha512-YiLxfsPzQqaVvT2a+nxH9do0YfUjrlxF3tKP0b1DDgvfgCcVKGsrQH3Wa82qHgL4dnT8h2bqi94JxXESEuPmcA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@oven/bun-darwin-x64-baseline": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.9.tgz",
-			"integrity": "sha512-XbhsA2XAFzvFr0vPSV6SNqGxab4xHKdPmVTLqoSHAx9tffrSq/012BDptOskulwnD+YNsrJUx2D2Ve1xvfgGcg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@oven/bun-linux-aarch64": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.9.tgz",
-			"integrity": "sha512-VaNQTu0Up4gnwZLQ6/Hmho6jAlLxTQ1PwxEth8EsXHf82FOXXPV5OCQ6KC9mmmocjKlmWFaIGebThrOy8DUo4g==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oven/bun-linux-aarch64-musl": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.9.tgz",
-			"integrity": "sha512-t8uimCVBTw5f9K2QTZE5wN6UOrFETNrh/Xr7qtXT9nAOzaOnIFvYA+HcHbGfi31fRlCVfTxqm/EiCwJ1gEw9YQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oven/bun-linux-x64": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.3.9.tgz",
-			"integrity": "sha512-oQyAW3+ugulvXTZ+XYeUMmNPR94sJeMokfHQoKwPvVwhVkgRuMhcLGV2ZesHCADVu30Oz2MFXbgdC8x4/o9dRg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oven/bun-linux-x64-baseline": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.9.tgz",
-			"integrity": "sha512-nZ12g22cy7pEOBwAxz2tp0wVqekaCn9QRKuGTHqOdLlyAqR4SCdErDvDhUWd51bIyHTQoCmj72TegGTgG0WNPw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oven/bun-linux-x64-musl": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.9.tgz",
-			"integrity": "sha512-4ZjIUgCxEyKwcKXideB5sX0KJpnHTZtu778w73VNq2uNH2fNpMZv98+DBgJyQ9OfFoRhmKn1bmLmSefvnHzI9w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oven/bun-linux-x64-musl-baseline": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.9.tgz",
-			"integrity": "sha512-3FXQgtYFsT0YOmAdMcJn56pLM5kzSl6y942rJJIl5l2KummB9Ea3J/vMJMzQk7NCAGhleZGWU/pJSS/uXKGa7w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@oven/bun-windows-x64": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.3.9.tgz",
-			"integrity": "sha512-/d6vAmgKvkoYlsGPsRPlPmOK1slPis/F40UG02pYwypTH0wmY0smgzdFqR4YmryxFh17XrW1kITv+U99Oajk9Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@oven/bun-windows-x64-baseline": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.9.tgz",
-			"integrity": "sha512-a/+hSrrDpMD7THyXvE2KJy1skxzAD0cnW4K1WjuI/91VqsphjNzvf5t/ZgxEVL4wb6f+hKrSJ5J3aH47zPr61g==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
 			"version": "0.130.0",
@@ -2928,67 +2735,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@preact/signals-core": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
-			"integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
-			}
-		},
-		"node_modules/@quilted/events": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@quilted/events/-/events-2.1.3.tgz",
-			"integrity": "sha512-4fHaSLND8rmZ+tce9/4FNmG5UWTRpFtM54kOekf3tLON4ZLLnYzjjldELD35efd7+lT5+E3cdkacqc56d+kCrQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@preact/signals-core": "^1.8.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@quilted/threads": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@quilted/threads/-/threads-3.3.1.tgz",
-			"integrity": "sha512-0ASnjTH+hOu1Qwzi9NnsVcsbMhWVx8pEE8SXIHknqcc/1rXAU0QlKw9ARq0W43FAdzyVeuXeXtZN27ZC0iALKg==",
-			"license": "MIT",
-			"dependencies": {
-				"@quilted/events": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"@preact/signals-core": "^1.8.0"
-			},
-			"peerDependenciesMeta": {
-				"@preact/signals-core": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@r2wc/core": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@r2wc/core/-/core-1.3.0.tgz",
-			"integrity": "sha512-aPBnND92Itl+SWWbWyyxdFFF0+RqKB6dptGHEdiPB8ZvnHWHlVzOfEvbEcyUYGtB6HBdsfkVuBiaGYyBFVTzVQ==",
-			"license": "MIT"
-		},
-		"node_modules/@r2wc/react-to-web-component": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@r2wc/react-to-web-component/-/react-to-web-component-2.1.0.tgz",
-			"integrity": "sha512-m/PzgUOEiL1HxmvfP5LgBLqB7sHeRj+d1QAeZklwS4OEI2HUU+xTpT3hhJipH5DQoFInDqDTfe0lNFFKcrqk4w==",
-			"license": "MIT",
-			"dependencies": {
-				"@r2wc/core": "^1.3.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
 		},
 		"node_modules/@radix-ui/number": {
 			"version": "1.1.1",
@@ -6389,39 +6135,6 @@
 			"integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
 			"license": "MIT"
 		},
-		"node_modules/@remote-dom/core": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@remote-dom/core/-/core-1.10.1.tgz",
-			"integrity": "sha512-MlbUOGuHjOrB7uOkaYkIoLUG8lDK8/H1D7MHnGkgqbG6jwjwQSlGPHhbwnD6HYWsTGpAPOP02Byd8wBt9U6TEw==",
-			"license": "MIT",
-			"dependencies": {
-				"@remote-dom/polyfill": "^1.5.1",
-				"htm": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"@preact/signals-core": "^1.3.0"
-			},
-			"peerDependenciesMeta": {
-				"@preact/signals-core": {
-					"optional": true
-				},
-				"preact": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@remote-dom/polyfill": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@remote-dom/polyfill/-/polyfill-1.5.1.tgz",
-			"integrity": "sha512-eaWdIVKZpNfbqspKkRQLVxiFv/7vIw8u0FVA5oy52YANFbO/WVT0GU+PQmRt/QUSijaB36HBAqx7stjo8HGpVQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@rolldown/binding-android-arm64": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
@@ -6704,84 +6417,6 @@
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-			"integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-			"integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-			"integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-			"integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-			"integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-			"integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
@@ -7647,12 +7282,6 @@
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
-		},
-		"node_modules/@types/prop-types": {
-			"version": "15.7.15",
-			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-			"license": "MIT"
 		},
 		"node_modules/@types/react": {
 			"version": "19.2.10",
@@ -8586,9 +8215,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -8969,21 +8598,34 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"debug": "^4.4.3",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.7.0",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.1",
-				"raw-body": "^3.0.1",
-				"type-is": "^2.0.1"
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
 			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -9427,9 +9069,9 @@
 			}
 		},
 		"node_modules/content-disposition": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-			"integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -11225,12 +10867,12 @@
 			}
 		},
 		"node_modules/express-rate-limit": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-			"integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "10.0.1"
+				"ip-address": "^10.2.0"
 			},
 			"engines": {
 				"node": ">= 16"
@@ -11324,9 +10966,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -12161,19 +11803,13 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.11.9",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-			"integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+			"version": "4.12.26",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+			"integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
 			}
-		},
-		"node_modules/htm": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-			"integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-			"license": "Apache-2.0"
 		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "6.0.0",
@@ -12324,9 +11960,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -12879,9 +12515,9 @@
 			}
 		},
 		"node_modules/jose": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-			"integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -15563,9 +15199,9 @@
 			"license": "MIT"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-			"integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -15788,9 +15424,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -17836,17 +17472,34 @@
 			}
 		},
 		"node_modules/type-is": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
 			"license": "MIT",
 			"dependencies": {
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"media-typer": "^1.1.0",
 				"mime-types": "^3.0.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/type-is/node_modules/mime-db": {
@@ -19076,12 +18729,12 @@
 			}
 		},
 		"node_modules/zod-to-json-schema": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-			"integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
 			"license": "ISC",
 			"peerDependencies": {
-				"zod": "^3.25 || ^4"
+				"zod": "^3.25.28 || ^4"
 			}
 		},
 		"node_modules/zod-validation-error": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
 		"@ai-sdk/react": "^3.0.3",
 		"@langchain/core": "^1.1.34",
 		"@langchain/langgraph-sdk": "^1.7.5",
-		"@mcp-ui/client": "^6.1.0",
+		"@mcp-ui/client": "^7.1.1",
 		"@radix-ui/react-avatar": "^1.1.11",
 		"@radix-ui/react-checkbox": "^1.3.3",
 		"@radix-ui/react-collapsible": "^1.1.12",

--- a/web/public/sandbox.html
+++ b/web/public/sandbox.html
@@ -51,6 +51,8 @@
 					frame.contentWindow.postMessage(data, "*");
 				};
 
+				let currentBlobUrl = null;
+
 				const loadResource = (params) => {
 					if (
 						!params ||
@@ -65,6 +67,34 @@
 							? params.sandbox
 							: "allow-scripts allow-same-origin allow-forms";
 					frame.setAttribute("sandbox", sandboxPermissions);
+
+					// Prefer a blob: URL so the app gets a real `location.origin`
+					// (this page's origin). A `srcdoc` iframe reports
+					// `location.origin === "null"`, and `new URL(path, "null")`
+					// throws — which breaks embeds that build request URLs from
+					// `location.origin` (e.g. Metabase's /api/dataset). `allow-
+					// same-origin` (set above) is required for the blob frame to
+					// keep a real origin. Fall back to srcdoc if blob: is
+					// unavailable.
+					try {
+						if (
+							typeof Blob === "function" &&
+							typeof URL !== "undefined" &&
+							URL.createObjectURL
+						) {
+							if (currentBlobUrl) {
+								URL.revokeObjectURL(currentBlobUrl);
+							}
+							currentBlobUrl = URL.createObjectURL(
+								new Blob([params.html], { type: "text/html" }),
+							);
+							frame.removeAttribute("srcdoc");
+							frame.src = currentBlobUrl;
+							return;
+						}
+					} catch (_err) {
+						// fall through to srcdoc
+					}
 					frame.srcdoc = params.html;
 				};
 

--- a/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
@@ -90,6 +90,16 @@ const toCallToolResult = (
 	return result;
 };
 
+// Stable (module-level) references so AppRenderer doesn't re-sync the iframe on
+// every render. Advertise the capabilities the host actually proxies: tool calls
+// (onCallTool), resource reads (onReadResource) and link opening (onOpenLink).
+const HOST_INFO = { name: "auxilia", version: "1.0.0" };
+const HOST_CAPABILITIES = {
+	serverTools: {},
+	serverResources: {},
+	openLinks: {},
+};
+
 export const McpAppWidget = ({
 	input,
 	output,
@@ -123,7 +133,17 @@ export const McpAppWidget = ({
 		[outputKey, errorText, structuredKey],
 	);
 
-	const effectiveToolInput = resultHasView(toolResult) ? undefined : input;
+	// Memoize like toolResult: AppRenderer tracks toolInput by reference identity,
+	// so re-sending a fresh-but-equal object after the result arrives makes apps
+	// (e.g. Metabase) reset to their "edited query — press Run" draft state. Key by
+	// a content hash so parent re-renders can't churn the reference.
+	const hasView = resultHasView(toolResult);
+	const inputKey = input === undefined ? "" : stableKey(input);
+	const effectiveToolInput = useMemo(
+		() => (hasView ? undefined : input),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[inputKey, hasView],
+	);
 
 	const onReadResource = useCallback(
 		async ({ uri }: { uri: string }) => {
@@ -206,6 +226,8 @@ export const McpAppWidget = ({
 				toolResourceUri={appToolInfo.resourceUri}
 				sandbox={sandboxConfig}
 				hostContext={hostContext}
+				hostInfo={HOST_INFO}
+				hostCapabilities={HOST_CAPABILITIES}
 				toolInput={effectiveToolInput}
 				toolResult={toolResult}
 				onReadResource={onReadResource}

--- a/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/mcp-app-widget.tsx
@@ -221,6 +221,11 @@ export const McpAppWidget = ({
 				className,
 			)}
 		>
+			{/* Dev-only gotcha: React StrictMode (Next dev default) double-mounts,
+			    and @mcp-ui/client 7.1.1 can't survive it — AppRenderer tears down its
+			    host↔app transport mid-connect, surfacing protocol.ts "Not connected"
+			    and leaving the app stuck on Metabase's "press Run" state. Renders fine
+			    in production builds; tracked upstream. */}
 			<AppRenderer
 				toolName={toolName}
 				toolResourceUri={appToolInfo.resourceUri}

--- a/web/src/hooks/use-mcp-host-context.ts
+++ b/web/src/hooks/use-mcp-host-context.ts
@@ -72,6 +72,28 @@ function subscribeToTheme(callback: () => void): () => void {
 	return () => observer.disconnect();
 }
 
+// MCP apps embed parsers that can't read CSS Color 4 (`oklch()` / `lab()`), and
+// our Tailwind v4 theme tokens are authored in `oklch()`. `getComputedStyle`
+// doesn't downconvert (Chrome re-serializes to `lab()`), so round-trip each color
+// through a canvas 2D context, which parses CSS Color 4 and serializes back to a
+// legacy `rgb()`/`#hex` every parser understands.
+let _colorCanvasCtx: CanvasRenderingContext2D | null | undefined;
+
+function normalizeColor(value: string): string {
+	if (typeof document === "undefined") return value;
+	if (_colorCanvasCtx === undefined) {
+		_colorCanvasCtx = document.createElement("canvas").getContext("2d");
+	}
+	if (!_colorCanvasCtx) return value;
+	// Assigning an unparseable value leaves fillStyle unchanged; seed a sentinel
+	// so we can detect that and fall back to the original string.
+	const sentinel = "#000001";
+	_colorCanvasCtx.fillStyle = sentinel;
+	_colorCanvasCtx.fillStyle = value;
+	const normalized = _colorCanvasCtx.fillStyle;
+	return normalized === sentinel && value !== sentinel ? value : normalized;
+}
+
 function resolveStyleVariables(): Partial<McpUiStyles> {
 	if (typeof document === "undefined") return {};
 
@@ -81,7 +103,9 @@ function resolveStyleVariables(): Partial<McpUiStyles> {
 	for (const [mcpKey, auxiliaToken] of TOKEN_MAP) {
 		const value = computed.getPropertyValue(auxiliaToken).trim();
 		if (value) {
-			variables[mcpKey] = value;
+			variables[mcpKey] = mcpKey.startsWith("--color-")
+				? normalizeColor(value)
+				: value;
 		}
 	}
 

--- a/web/src/hooks/use-mcp-host-context.ts
+++ b/web/src/hooks/use-mcp-host-context.ts
@@ -73,25 +73,38 @@ function subscribeToTheme(callback: () => void): () => void {
 }
 
 // MCP apps embed parsers that can't read CSS Color 4 (`oklch()` / `lab()`), and
-// our Tailwind v4 theme tokens are authored in `oklch()`. `getComputedStyle`
-// doesn't downconvert (Chrome re-serializes to `lab()`), so round-trip each color
-// through a canvas 2D context, which parses CSS Color 4 and serializes back to a
-// legacy `rgb()`/`#hex` every parser understands.
+// our Tailwind v4 theme tokens are authored in `oklch()` (which `getComputedStyle`
+// re-serializes to `lab()` in Chrome). Round-trip each color through a canvas 2D
+// context to downconvert to 8-bit sRGB. NB: we read the painted *pixel*, not the
+// `fillStyle` getter — current Chrome preserves `lab()`/`oklch()` in the getter's
+// serialization (whatwg/html#8917), so the getter alone leaves them unchanged.
 let _colorCanvasCtx: CanvasRenderingContext2D | null | undefined;
 
 function normalizeColor(value: string): string {
 	if (typeof document === "undefined") return value;
 	if (_colorCanvasCtx === undefined) {
-		_colorCanvasCtx = document.createElement("canvas").getContext("2d");
+		// willReadFrequently: this context exists only for getImageData readback
+		// (never displayed), so a CPU-backed canvas avoids per-call GPU syncs.
+		_colorCanvasCtx = document
+			.createElement("canvas")
+			.getContext("2d", { willReadFrequently: true });
 	}
-	if (!_colorCanvasCtx) return value;
+	const ctx = _colorCanvasCtx;
+	if (!ctx) return value;
 	// Assigning an unparseable value leaves fillStyle unchanged; seed a sentinel
 	// so we can detect that and fall back to the original string.
 	const sentinel = "#000001";
-	_colorCanvasCtx.fillStyle = sentinel;
-	_colorCanvasCtx.fillStyle = value;
-	const normalized = _colorCanvasCtx.fillStyle;
-	return normalized === sentinel && value !== sentinel ? value : normalized;
+	ctx.fillStyle = sentinel;
+	ctx.fillStyle = value;
+	if (ctx.fillStyle === sentinel && value !== sentinel) return value;
+	// Paint one pixel and read it back: getImageData always yields 8-bit sRGB,
+	// i.e. a legacy `rgb()`/`rgba()` every MCP-app color parser understands.
+	ctx.clearRect(0, 0, 1, 1);
+	ctx.fillRect(0, 0, 1, 1);
+	const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+	return a === 255
+		? `rgb(${r}, ${g}, ${b})`
+		: `rgba(${r}, ${g}, ${b}, ${(a / 255).toFixed(3)})`;
 }
 
 function resolveStyleVariables(): Partial<McpUiStyles> {


### PR DESCRIPTION
## What

Makes Metabase's interactive `visualize_query` "MCP App" actually render inside auxilia. Rendering one chart exercised three independent subsystems — MCP capability negotiation, MCP session lifetime, and iframe origin — each of which collided with auxilia's "proxy server-side + sandboxed iframe" model. Full write-up in `metabase-mcp-app.md`.

## Changes

**Backend (MCP client)**
- Patch `ClientSession.initialize` to advertise the `io.modelcontextprotocol/ui` capability (under `extensions` + `experimental`) so servers expose UI-bearing tools; make output-schema validation lenient (log, don't raise) for Metabase's mismatched `outputSchema`. (`app/mcp/client/initialize.py`, applied in `app/main.py`)
- `tools/list` pagination + a `terminate_on_close` param so the app paths don't `DELETE` the MCP session the browser still needs (the embedded `sessionToken` is bound to it). (`app/mcp/servers/service.py`, `app/mcp/apps/router.py`)
- Persistent MCP session per turn so a `construct_query` → `visualize_query(query_handle)` chain survives (the handle was minted in one per-call session and gone by the next). (`app/agents/toolset.py`, `app/agents/runtime.py`)

**Frontend (`@mcp-ui/client`)**
- Render the app via a `blob:` URL on a real origin (valid `location.origin`) instead of `srcdoc` (`"null"`), which broke the embed's request-URL construction. (`web/public/sandbox.html`)
- Advertise `hostCapabilities`/`hostInfo` so the app routes data through our authenticated proxy instead of an unauthenticated direct fetch. (`mcp-app-widget.tsx`)
- **Color normalization fix (this PR's follow-up commit):** `normalizeColor` relied on the canvas `fillStyle` *getter* to downconvert our Tailwind v4 `oklch()` theme vars, but current Chrome preserves `lab()`/`oklch()` in that serialization (whatwg/html#8917) — a no-op for exactly those colors, so the app crashed with `Unable to parse color from string: lab(100 0 0)`. Now reads the painted pixel via `getImageData` (always 8-bit sRGB) with `willReadFrequently`. (`web/src/hooks/use-mcp-host-context.ts`)

## Verified

- Full `construct_query → visualize_query → read_resource` chain confirmed against the live server via `backend/scripts/probe_metabase_mcp.py` (capability negotiation, output validation, resource fetch).
- The chart **renders end-to-end** in a production build.

## Known limitation (dev only)

Under React StrictMode (Next dev default), the dev double-mount makes `@mcp-ui/client` 7.1.1's `AppRenderer` tear down its host↔app transport mid-connect → `protocol.ts "Not connected"` and the app stuck on Metabase's "press Run" placeholder. **Renders fine in production builds.** 7.1.1 is the latest release; tracked for the next bump. A note is left by `<AppRenderer>`.

## Release

Conventional `fix(mcp):` commits touching `backend/` and `web/` → release-please will propose patch bumps: **web 0.5.1 → 0.5.2**, **backend 0.4.1 → 0.4.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Metabase’s interactive `visualize_query` MCP App to render end-to-end in auxilia by fixing MCP capability negotiation, session lifetime, and iframe origin. The chart now displays in production builds.

- **Bug Fixes**
  - Backend: Advertise MCP Apps UI capability during `ClientSession.initialize` with a defensive fallback; log (not raise) output-schema mismatches; hold one persistent MCP session per server per turn via `Toolset.prepare()`/`Toolset.open()`; paginate `tools/list` with repeated/cyclic cursor detection and a page cap; keep app sessions alive with `terminate_on_close=false`; apply patches at startup.
  - Frontend: Load the app via a `blob:` URL (real `location.origin`) with `srcdoc` fallback; send `hostInfo`/`hostCapabilities` so requests go through our proxy; normalize theme colors to `rgb()` via canvas; memoize tool input to avoid resetting the app state. Note: under React StrictMode (dev only), `@mcp-ui/client` 7.1.1 can show “Not connected”; production renders are fine.

- **Dependencies**
  - Bump `@mcp-ui/client` to `7.1.1`.

<sup>Written for commit 69e1ea0cf55302314ccecc0c8069d229335bf925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

