### PR TITLE
feat(agents): add Archived tab with restore and permanent delete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,16 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: eslint-web
+        name: eslint (web)
+        # Lints only the changed web files (like ruff). Runs from web/ so the
+        # type-aware parser resolves tsconfig/node_modules; strips the leading
+        # "web/" from the repo-relative paths pre-commit passes in. Uses the
+        # stricter eslint.precommit.mjs (type-aware rules) so async-handler /
+        # void-expression mistakes are caught at commit time on touched files.
+        entry: bash -c 'cd web && args=(); for f in "$@"; do args+=("${f#web/}"); done; exec npx eslint --config eslint.precommit.mjs "${args[@]}"' --
+        language: system
+        files: ^web/.*\.(ts|tsx)$
+        pass_filenames: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,18 @@ See **Backend conventions** above for the full layered architecture, naming rule
 - **Zustand stores** for client state (agents, threads, MCP servers, user)
 - **Axios interceptors** handle camelCase ↔ snake_case conversion automatically; the `tools` JSONB field is preserved as-is
 - **shadcn/ui** components in `components/ui/`; feature-specific components live next to their page
+- **Never pass an async/Promise-returning function directly to a void event handler** (`onClick`, `onChange`, `onSubmit`, etc.) — ESLint's `@typescript-eslint/no-misused-promises` flags it. Wrap the call so the handler returns void:
+
+  ```tsx
+  // BAD
+  <button onClick={handleRestore}>      // handleRestore is async
+  <button onClick={() => handleSave()}> // also flagged: arrow returns the Promise
+
+  // GOOD
+  <button onClick={() => { void handleRestore(); }}>
+  ```
+
+  The same rule flags any arrow with an implicit non-void return in a void slot, so prefer a block body (`onClick={() => { setView(tab.key); }}`) over an expression body when the call's return value isn't `void`.
 
 ### Agent Permissions
 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,16 @@ Have an idea? [Open an issue](https://github.com/keurcien/auxilia/issues/new) or
 Contributions are very welcome! Whether it's a bug report, an agent idea, a new MCP server recipe, or a UI improvement:
 
 1. Fork the repo and create a branch (`git checkout -b feature/my-change`)
-2. Run `make dev` and make sure tests pass (`cd backend && uv run pytest`)
-3. Open a pull request
+2. Enable the git hooks once per clone: `pre-commit install` (install [pre-commit](https://pre-commit.com/#install) first if needed)
+3. Run `make dev` and make sure tests pass (`cd backend && uv run pytest`)
+4. Open a pull request
+
+### Pre-commit hooks
+
+`pre-commit install` wires up the hooks defined in `.pre-commit-config.yaml`, which run automatically on `git commit` against your changed files:
+
+- **ruff** (`ruff-check --fix`, `ruff-format`) — lints and formats changed Python.
+- **eslint (web)** — lints changed `web/` TypeScript using `web/eslint.precommit.mjs`, a stricter, type-aware config that catches mistakes the default `npm run lint` doesn't — e.g. `@typescript-eslint/no-misused-promises` (passing an `async` function to an `onClick`) and `@typescript-eslint/no-confusing-void-expression` (a void-returning arrow shorthand). `npm run lint` and `next build` are unaffected, so you only fix these in files you touch.
 
 Please read `CLAUDE.md` in the root of the repo — it documents the backend's layered architecture (router → service → repository → model) and naming conventions.
 

--- a/backend/app/agents/core/repository.py
+++ b/backend/app/agents/core/repository.py
@@ -24,12 +24,16 @@ class AgentRepository(BaseRepository[AgentDB]):
         user_role: WorkspaceRole | None,
         agent_id: UUID | None = None,
         include_archived: bool = False,
+        archived_only: bool = False,
     ) -> list:
         """Join agent ↔ MCP links ↔ user permission in one shot.
 
         When ``user_id`` is set and the user is not a workspace admin, the
         query includes a third tuple element: the user's permission row (or
         ``None``). Otherwise rows are ``(AgentDB, AgentMCPServerDB | None)``.
+
+        ``archived_only`` restricts the result to archived agents (for the
+        Archived view); it takes precedence over ``include_archived``.
         """
         is_workspace_admin = user_role == WorkspaceRole.admin
         include_permissions = bool(user_id) and not is_workspace_admin
@@ -49,7 +53,9 @@ class AgentRepository(BaseRepository[AgentDB]):
             )
         if agent_id is not None:
             stmt = stmt.where(AgentDB.id == agent_id)
-        if not include_archived:
+        if archived_only:
+            stmt = stmt.where(AgentDB.is_archived == True)  # noqa: E712
+        elif not include_archived:
             stmt = stmt.where(AgentDB.is_archived == False)  # noqa: E712
         stmt = stmt.order_by(AgentDB.created_at.asc())
 
@@ -60,6 +66,18 @@ class AgentRepository(BaseRepository[AgentDB]):
         agent.is_archived = True
         self.db.add(agent)
         await self.db.flush()
+
+    async def restore(self, agent: AgentDB) -> None:
+        agent.is_archived = False
+        self.db.add(agent)
+        await self.db.flush()
+
+    async def delete_all_permissions(self, agent_id: UUID) -> None:
+        existing = await self.get_permissions(agent_id)
+        for perm in existing:
+            await self.db.delete(perm)
+        if existing:
+            await self.db.flush()
 
     async def get_permissions(self, agent_id: UUID) -> list[AgentUserPermissionDB]:
         stmt = select(AgentUserPermissionDB).where(

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.agents.core.repository import AgentRepository
+from app.agents.mcp_servers.repository import AgentMCPServerRepository
 from app.agents.models import (
     AgentDB,
     AgentUserPermissionDB,
@@ -26,6 +27,7 @@ from app.exceptions import NotFoundError, PermissionDeniedError
 from app.mcp.servers.models import MCPServerDB
 from app.mcp.utils import probe_mcp_server
 from app.service import BaseService
+from app.threads.service import ThreadService
 from app.users.models import WorkspaceRole
 
 
@@ -38,6 +40,8 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     def __init__(self, db: AsyncSession):
         super().__init__(db, AgentRepository(db))
         self.subagent_service = SubagentService(db)
+        self.thread_service = ThreadService(db)
+        self.mcp_server_repository = AgentMCPServerRepository(db)
 
     @staticmethod
     def _resolve_permission(
@@ -135,9 +139,10 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         self,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
+        archived: bool = False,
     ) -> list[AgentResponse]:
         rows = await self.repository.list_with_permissions(
-            user_id=user_id, user_role=user_role
+            user_id=user_id, user_role=user_role, archived_only=archived
         )
         agents_map, mcp_map, permissions_map = self._group_rows(rows, user_id)
         return await self._assemble(
@@ -173,6 +178,52 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             raise PermissionDeniedError("Not authorized to delete this agent")
         await self.subagent_service.delete_all_for_agent(agent_id)
         await self.repository.archive(agent)
+
+    async def restore(
+        self,
+        agent_id: UUID,
+        user_id: UUID | None = None,
+        user_role: WorkspaceRole | None = None,
+    ) -> AgentResponse:
+        existing = await self.get(
+            agent_id,
+            user_id=user_id,
+            user_role=user_role,
+            include_archived=True,
+        )
+        if existing.current_user_permission not in ("owner", "admin"):
+            raise PermissionDeniedError("Not authorized to restore this agent")
+        agent = await self.get_or_404(agent_id)
+        await self.repository.restore(agent)
+        return await self.get(
+            agent_id,
+            user_id=user_id,
+            user_role=user_role,
+            include_archived=True,
+        )
+
+    async def delete_permanently(
+        self,
+        agent_id: UUID,
+        user_id: UUID | None = None,
+        user_role: WorkspaceRole | None = None,
+    ) -> None:
+        existing = await self.get(
+            agent_id,
+            user_id=user_id,
+            user_role=user_role,
+            include_archived=True,
+        )
+        if existing.current_user_permission not in ("owner", "admin"):
+            raise PermissionDeniedError(
+                "Not authorized to permanently delete this agent"
+            )
+        agent = await self.get_or_404(agent_id)
+        await self.subagent_service.delete_all_for_agent(agent_id)
+        await self.mcp_server_repository.delete_all_for_agent(agent_id)
+        await self.thread_service.delete_all_for_agent(agent_id)
+        await self.repository.delete_all_permissions(agent_id)
+        await self.repository.delete(agent)
 
     async def get_permissions(self, agent_id: UUID) -> list[AgentUserPermissionDB]:
         return await self.repository.get_permissions(agent_id)

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -219,11 +219,16 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                 "Not authorized to permanently delete this agent"
             )
         agent = await self.get_or_404(agent_id)
+        # Delete every DB row that references the agent first (threads must go
+        # before the agent row due to the FK), then purge checkpoints last.
+        thread_ids = await self.thread_service.delete_rows_for_agent(agent_id)
         await self.subagent_service.delete_all_for_agent(agent_id)
         await self.mcp_server_repository.delete_all_for_agent(agent_id)
-        await self.thread_service.delete_all_for_agent(agent_id)
         await self.repository.delete_all_permissions(agent_id)
         await self.repository.delete(agent)
+        # Checkpoints live on a separate auto-committed connection and can't be
+        # rolled back, so purge them only after all DB deletes have succeeded.
+        await self.thread_service.purge_checkpoints(thread_ids)
 
     async def get_permissions(self, agent_id: UUID) -> list[AgentUserPermissionDB]:
         return await self.repository.get_permissions(agent_id)

--- a/backend/app/agents/mcp_servers/repository.py
+++ b/backend/app/agents/mcp_servers/repository.py
@@ -20,3 +20,14 @@ class AgentMCPServerRepository(BaseRepository[AgentMCPServerDB]):
         )
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def delete_all_for_agent(self, agent_id: UUID) -> None:
+        stmt = select(AgentMCPServerDB).where(
+            AgentMCPServerDB.agent_id == agent_id
+        )
+        result = await self.db.execute(stmt)
+        links = result.scalars().all()
+        for link in links:
+            await self.db.delete(link)
+        if links:
+            await self.db.flush()

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -47,11 +47,12 @@ async def create_agent(
 
 @router.get("/", response_model=list[AgentResponse])
 async def get_agents(
+    archived: bool = False,
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> list[AgentResponse]:
     return await service.list(
-        user_id=current_user.id, user_role=current_user.role
+        user_id=current_user.id, user_role=current_user.role, archived=archived
     )
 
 
@@ -87,6 +88,28 @@ async def delete_agent(
     service: AgentService = Depends(get_agent_service),
 ) -> None:
     await service.delete(
+        agent_id, user_id=current_user.id, user_role=current_user.role
+    )
+
+
+@router.post("/{agent_id}/restore", response_model=AgentResponse)
+async def restore_agent(
+    agent_id: UUID,
+    current_user: UserDB = Depends(get_current_user),
+    service: AgentService = Depends(get_agent_service),
+) -> AgentResponse:
+    return await service.restore(
+        agent_id, user_id=current_user.id, user_role=current_user.role
+    )
+
+
+@router.delete("/{agent_id}/permanent", status_code=204)
+async def delete_agent_permanently(
+    agent_id: UUID,
+    current_user: UserDB = Depends(get_current_user),
+    service: AgentService = Depends(get_agent_service),
+) -> None:
+    await service.delete_permanently(
         agent_id, user_id=current_user.id, user_role=current_user.role
     )
 

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -108,6 +108,7 @@ class AgentResponse(SQLModel):
     color: str | None
     description: str | None
     has_code_interpreter: bool
+    is_archived: bool = False
     created_at: datetime
     updated_at: datetime
     mcp_servers: list[AgentMCPServerResponse] | None = None

--- a/backend/app/threads/repository.py
+++ b/backend/app/threads/repository.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -22,6 +23,10 @@ class ThreadRepository(BaseRepository[ThreadDB]):
         stmt = select(ThreadDB.id).where(ThreadDB.agent_id == agent_id)
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
+
+    async def delete_for_agent(self, agent_id: UUID) -> None:
+        stmt = delete(ThreadDB).where(ThreadDB.agent_id == agent_id)
+        await self.db.execute(stmt)
 
     async def get_with_agent(self, thread_id: str):
         stmt = (

--- a/backend/app/threads/repository.py
+++ b/backend/app/threads/repository.py
@@ -18,6 +18,11 @@ class ThreadRepository(BaseRepository[ThreadDB]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def list_ids_for_agent(self, agent_id: UUID) -> list[str]:
+        stmt = select(ThreadDB.id).where(ThreadDB.agent_id == agent_id)
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
     async def get_with_agent(self, thread_id: str):
         stmt = (
             select(

--- a/backend/app/threads/service.py
+++ b/backend/app/threads/service.py
@@ -72,9 +72,7 @@ class ThreadService(BaseService[ThreadDB, ThreadRepository]):
         rows = await self.repository.list_for_user(user_id)
         return [_thread_with_agent(*row) for row in rows]
 
-    async def list_for_agent(
-        self, agent_id: UUID
-    ) -> list[AgentThreadResponse]:
+    async def list_for_agent(self, agent_id: UUID) -> list[AgentThreadResponse]:
         rows = await self.repository.list_for_agent(agent_id)
         return [_agent_thread(*row) for row in rows]
 
@@ -99,20 +97,31 @@ class ThreadService(BaseService[ThreadDB, ThreadRepository]):
         await self.db.delete(thread)
         return thread
 
-    async def delete_all_for_agent(self, agent_id: UUID) -> None:
-        """Delete every thread belonging to an agent along with its LangGraph
-        checkpoints. Used when an agent is permanently deleted."""
+    async def delete_rows_for_agent(self, agent_id: UUID) -> list[str]:
+        """Bulk-delete an agent's thread rows (one statement) and return their
+        ids so the caller can purge LangGraph checkpoints afterwards.
+
+        Checkpoint deletion is intentionally NOT done here: it is an external,
+        non-transactional side effect and must run only after all DB deletes
+        have succeeded — see ``purge_checkpoints``."""
         thread_ids = await self.repository.list_ids_for_agent(agent_id)
+        if thread_ids:
+            await self.repository.delete_for_agent(agent_id)
+            await self.db.flush()
+        return thread_ids
+
+    async def purge_checkpoints(self, thread_ids: list[str]) -> None:
+        """Delete the LangGraph checkpoints for the given threads.
+
+        This writes to a separate, auto-committed connection (the checkpointer),
+        so it cannot be rolled back with the request transaction. Callers must
+        run it last — once every DB delete has succeeded — to avoid leaving
+        threads in Postgres without their checkpoints."""
         if not thread_ids:
             return
         async with get_checkpointer() as checkpointer:
             for thread_id in thread_ids:
                 await checkpointer.adelete_thread(thread_id=thread_id)
-        for thread_id in thread_ids:
-            thread = await self.repository.get(thread_id)
-            if thread is not None:
-                await self.db.delete(thread)
-        await self.db.flush()
 
     async def get_or_create(
         self,

--- a/backend/app/threads/service.py
+++ b/backend/app/threads/service.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import get_db
+from app.database import get_checkpointer, get_db
 from app.exceptions import NotFoundError
 from app.service import BaseService
 from app.threads.models import ThreadDB, ThreadSource
@@ -98,6 +98,21 @@ class ThreadService(BaseService[ThreadDB, ThreadRepository]):
         thread = await self.get_or_404(thread_id)
         await self.db.delete(thread)
         return thread
+
+    async def delete_all_for_agent(self, agent_id: UUID) -> None:
+        """Delete every thread belonging to an agent along with its LangGraph
+        checkpoints. Used when an agent is permanently deleted."""
+        thread_ids = await self.repository.list_ids_for_agent(agent_id)
+        if not thread_ids:
+            return
+        async with get_checkpointer() as checkpointer:
+            for thread_id in thread_ids:
+                await checkpointer.adelete_thread(thread_id=thread_id)
+        for thread_id in thread_ids:
+            thread = await self.repository.get(thread_id)
+            if thread is not None:
+                await self.db.delete(thread)
+        await self.db.flush()
 
     async def get_or_create(
         self,

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -308,6 +308,82 @@ def test_delete_agent_requires_auth(client: TestClient):
     assert response.status_code == 401
 
 
+def test_get_agents_archived_passthrough(client: TestClient, mock_db, current_user):
+    """GET /agents?archived=true returns the archived list."""
+    agent = AgentDB(
+        id=uuid4(),
+        name="Archived Agent",
+        instructions="...",
+        owner_id=current_user.id,
+        is_archived=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    mock_result = MagicMock()
+    mock_result.all.return_value = [(agent, None, None)]
+    mock_db.execute.return_value = mock_result
+
+    response = client.get("/agents/?archived=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["is_archived"] is True
+
+
+def test_restore_agent_as_owner(client: TestClient, mock_db, current_user):
+    """Owner can restore an archived agent."""
+    agent = AgentDB(
+        id=uuid4(),
+        name="Archived Agent",
+        instructions="...",
+        owner_id=current_user.id,
+        is_archived=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    mock_result = MagicMock()
+    mock_result.all.return_value = [(agent, None)]
+    mock_result.scalar_one_or_none.return_value = agent
+    mock_db.execute.return_value = mock_result
+
+    response = client.post(f"/agents/{agent.id}/restore")
+    assert response.status_code == 200
+    assert agent.is_archived is False
+
+
+def test_restore_agent_requires_auth(client: TestClient):
+    response = client.post(f"/agents/{uuid4()}/restore")
+    assert response.status_code == 401
+
+
+def test_delete_agent_permanently_requires_auth(client: TestClient):
+    response = client.delete(f"/agents/{uuid4()}/permanent")
+    assert response.status_code == 401
+
+
+def test_delete_agent_permanently_forbidden_for_non_manager(
+    client: TestClient, mock_db, current_user
+):
+    """A user without owner/admin permission cannot permanently delete."""
+    other_owner = uuid4()
+    assert other_owner != current_user.id
+    agent = AgentDB(
+        id=uuid4(),
+        name="Someone Else's Agent",
+        instructions="...",
+        owner_id=other_owner,
+        is_archived=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    mock_result = MagicMock()
+    mock_result.all.return_value = [(agent, None)]
+    mock_db.execute.return_value = mock_result
+
+    response = client.delete(f"/agents/{agent.id}/permanent")
+    assert response.status_code == 403
+
+
 def _make_thread(*, agent_id, user_id, source=ThreadSource.web) -> ThreadDB:
     return ThreadDB(
         id=str(uuid4()),

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -52,7 +52,8 @@ def mock_repo():
 @pytest.fixture
 def mock_thread_service():
     svc = MagicMock()
-    svc.delete_all_for_agent = AsyncMock()
+    svc.delete_rows_for_agent = AsyncMock(return_value=["t1", "t2"])
+    svc.purge_checkpoints = AsyncMock()
     return svc
 
 
@@ -96,16 +97,16 @@ def service(
 
 
 def make_agent(**kwargs):
-    defaults = dict(
-        id=uuid4(),
-        name="Test Agent",
-        instructions="Be helpful",
-        owner_id=uuid4(),
-        emoji=None,
-        description=None,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-    )
+    defaults = {
+        "id": uuid4(),
+        "name": "Test Agent",
+        "instructions": "Be helpful",
+        "owner_id": uuid4(),
+        "emoji": None,
+        "description": None,
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
+    }
     return AgentDB(**{**defaults, **kwargs})
 
 
@@ -293,9 +294,7 @@ async def test_list_agents_granted_permission_from_row(service, mock_repo):
         (agent, None, PermissionLevel.editor)
     ]
 
-    result = await service.list(
-        user_id=non_owner_id, user_role=WorkspaceRole.member
-    )
+    result = await service.list(user_id=non_owner_id, user_role=WorkspaceRole.member)
 
     assert result[0].current_user_permission == "editor"
 
@@ -305,9 +304,7 @@ async def test_list_agents_no_permission_when_not_granted(service, mock_repo):
     non_owner_id = uuid4()
     mock_repo.list_with_permissions.return_value = [(agent, None, None)]
 
-    result = await service.list(
-        user_id=non_owner_id, user_role=WorkspaceRole.member
-    )
+    result = await service.list(user_id=non_owner_id, user_role=WorkspaceRole.member)
 
     assert result[0].current_user_permission is None
 
@@ -352,9 +349,7 @@ async def test_update_agent_passes_only_set_fields(service, mock_repo):
     mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    await service.update(
-        agent.id, AgentPatch(name="New Name"), user_id=agent.owner_id
-    )
+    await service.update(agent.id, AgentPatch(name="New Name"), user_id=agent.owner_id)
 
     update_schema = mock_repo.update.call_args[0][1]
     assert isinstance(update_schema, AgentPatch)
@@ -470,9 +465,7 @@ async def test_restore_agent_allows_workspace_admin(service, mock_repo):
     mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    await service.restore(
-        agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin
-    )
+    await service.restore(agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin)
 
     mock_repo.restore.assert_awaited_once_with(agent)
 
@@ -509,9 +502,29 @@ async def test_delete_permanently_cascades_for_owner(
 
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
     mock_agent_mcp_repo.delete_all_for_agent.assert_awaited_once_with(agent.id)
-    mock_thread_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
+    mock_thread_service.delete_rows_for_agent.assert_awaited_once_with(agent.id)
     mock_repo.delete_all_permissions.assert_awaited_once_with(agent.id)
     mock_repo.delete.assert_awaited_once_with(agent)
+    # Checkpoints are purged last, after every DB delete has run.
+    mock_thread_service.purge_checkpoints.assert_awaited_once_with(["t1", "t2"])
+
+
+async def test_delete_permanently_purges_checkpoints_after_db_deletes(
+    service, mock_repo, mock_thread_service
+):
+    """Checkpoint purge (non-rollbackable) must run after the agent row delete."""
+    agent = make_agent(is_archived=True)
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+
+    manager = MagicMock()
+    manager.attach_mock(mock_repo.delete, "delete_agent")
+    manager.attach_mock(mock_thread_service.purge_checkpoints, "purge_checkpoints")
+
+    await service.delete_permanently(agent.id, user_id=agent.owner_id)
+
+    ordered = [name for name, _, _ in manager.mock_calls]
+    assert ordered.index("delete_agent") < ordered.index("purge_checkpoints")
 
 
 async def test_delete_permanently_denied_for_editor(

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -40,9 +40,26 @@ def mock_repo():
     repo.create = AsyncMock()
     repo.update = AsyncMock()
     repo.archive = AsyncMock()
+    repo.restore = AsyncMock()
+    repo.delete = AsyncMock()
+    repo.delete_all_permissions = AsyncMock()
     repo.get_permissions = AsyncMock()
     repo.set_permissions = AsyncMock()
     repo.list_with_permissions = AsyncMock(return_value=[])
+    return repo
+
+
+@pytest.fixture
+def mock_thread_service():
+    svc = MagicMock()
+    svc.delete_all_for_agent = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def mock_agent_mcp_repo():
+    repo = MagicMock()
+    repo.delete_all_for_agent = AsyncMock()
     return repo
 
 
@@ -58,10 +75,18 @@ def mock_subagent_service():
 
 
 @pytest.fixture
-def service(mock_db, mock_repo, mock_subagent_service):
+def service(
+    mock_db,
+    mock_repo,
+    mock_subagent_service,
+    mock_thread_service,
+    mock_agent_mcp_repo,
+):
     svc = AgentService(mock_db)
     svc.repository = mock_repo
     svc.subagent_service = mock_subagent_service
+    svc.thread_service = mock_thread_service
+    svc.mcp_server_repository = mock_agent_mcp_repo
     return svc
 
 
@@ -423,6 +448,85 @@ async def test_delete_agent_allows_workspace_admin(
 
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
     mock_repo.archive.assert_awaited_once_with(agent)
+
+
+# ---------------------------------------------------------------------------
+# restore
+# ---------------------------------------------------------------------------
+
+
+async def test_restore_agent_sets_unarchived_for_owner(service, mock_repo):
+    agent = make_agent(is_archived=True)
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+
+    await service.restore(agent.id, user_id=agent.owner_id)
+
+    mock_repo.restore.assert_awaited_once_with(agent)
+
+
+async def test_restore_agent_allows_workspace_admin(service, mock_repo):
+    agent = make_agent(is_archived=True)
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+
+    await service.restore(
+        agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin
+    )
+
+    mock_repo.restore.assert_awaited_once_with(agent)
+
+
+async def test_restore_agent_denied_for_editor(service, mock_repo):
+    agent = make_agent(is_archived=True)
+    mock_repo.list_with_permissions.return_value = [
+        (agent, None, PermissionLevel.editor)
+    ]
+
+    with pytest.raises(PermissionDeniedError):
+        await service.restore(agent.id, user_id=uuid4())
+
+    mock_repo.restore.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# delete_permanently
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_permanently_cascades_for_owner(
+    service,
+    mock_repo,
+    mock_subagent_service,
+    mock_thread_service,
+    mock_agent_mcp_repo,
+):
+    agent = make_agent(is_archived=True)
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+
+    await service.delete_permanently(agent.id, user_id=agent.owner_id)
+
+    mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
+    mock_agent_mcp_repo.delete_all_for_agent.assert_awaited_once_with(agent.id)
+    mock_thread_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
+    mock_repo.delete_all_permissions.assert_awaited_once_with(agent.id)
+    mock_repo.delete.assert_awaited_once_with(agent)
+
+
+async def test_delete_permanently_denied_for_editor(
+    service, mock_repo, mock_agent_mcp_repo
+):
+    agent = make_agent(is_archived=True)
+    mock_repo.list_with_permissions.return_value = [
+        (agent, None, PermissionLevel.editor)
+    ]
+
+    with pytest.raises(PermissionDeniedError):
+        await service.delete_permanently(agent.id, user_id=uuid4())
+
+    mock_agent_mcp_repo.delete_all_for_agent.assert_not_called()
+    mock_repo.delete.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/agents/mcp_servers/test_repository.py
+++ b/backend/tests/agents/mcp_servers/test_repository.py
@@ -123,3 +123,32 @@ async def test_delete_calls_delete_and_flushes(repo, mock_db):
 
     mock_db.delete.assert_awaited_once_with(link)
     mock_db.flush.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# delete_all_for_agent
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_all_for_agent_deletes_every_link(repo, mock_db):
+    agent_id = uuid4()
+    links = [make_link(agent_id=agent_id), make_link(agent_id=agent_id)]
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = links
+    mock_db.execute.return_value = mock_result
+
+    await repo.delete_all_for_agent(agent_id)
+
+    assert mock_db.delete.await_count == 2
+    mock_db.flush.assert_awaited_once()
+
+
+async def test_delete_all_for_agent_noop_when_no_links(repo, mock_db):
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_db.execute.return_value = mock_result
+
+    await repo.delete_all_for_agent(uuid4())
+
+    mock_db.delete.assert_not_called()
+    mock_db.flush.assert_not_called()

--- a/backend/tests/threads/test_service.py
+++ b/backend/tests/threads/test_service.py
@@ -1,7 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
-from app.threads.models import ThreadDB
 from app.threads.service import ThreadService
 
 
@@ -15,35 +14,59 @@ def _make_service():
     return svc, db
 
 
-async def test_delete_all_for_agent_deletes_threads_and_checkpoints():
+# ---------------------------------------------------------------------------
+# delete_rows_for_agent
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_rows_for_agent_bulk_deletes_and_returns_ids():
     svc, db = _make_service()
     agent_id = uuid4()
     thread_ids = ["t1", "t2"]
     svc.repository.list_ids_for_agent = AsyncMock(return_value=thread_ids)
-    svc.repository.get = AsyncMock(
-        side_effect=lambda tid: ThreadDB(id=tid, user_id=uuid4(), agent_id=agent_id)
-    )
+    svc.repository.delete_for_agent = AsyncMock()
 
+    result = await svc.delete_rows_for_agent(agent_id)
+
+    assert result == thread_ids
+    # One bulk delete, not a per-thread loop (no N+1).
+    svc.repository.delete_for_agent.assert_awaited_once_with(agent_id)
+    db.flush.assert_awaited_once()
+
+
+async def test_delete_rows_for_agent_noop_when_no_threads():
+    svc, db = _make_service()
+    svc.repository.list_ids_for_agent = AsyncMock(return_value=[])
+    svc.repository.delete_for_agent = AsyncMock()
+
+    result = await svc.delete_rows_for_agent(uuid4())
+
+    assert result == []
+    svc.repository.delete_for_agent.assert_not_called()
+    db.flush.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# purge_checkpoints
+# ---------------------------------------------------------------------------
+
+
+async def test_purge_checkpoints_deletes_each_thread():
+    svc, _ = _make_service()
     checkpointer = AsyncMock()
     with patch("app.threads.service.get_checkpointer") as mock_cp:
         mock_cp.return_value.__aenter__ = AsyncMock(return_value=checkpointer)
         mock_cp.return_value.__aexit__ = AsyncMock(return_value=None)
-        await svc.delete_all_for_agent(agent_id)
+        await svc.purge_checkpoints(["t1", "t2"])
 
     assert checkpointer.adelete_thread.await_count == 2
     checkpointer.adelete_thread.assert_any_await(thread_id="t1")
     checkpointer.adelete_thread.assert_any_await(thread_id="t2")
-    assert db.delete.await_count == 2
-    db.flush.assert_awaited_once()
 
 
-async def test_delete_all_for_agent_noop_when_no_threads():
-    svc, db = _make_service()
-    svc.repository.list_ids_for_agent = AsyncMock(return_value=[])
-
+async def test_purge_checkpoints_noop_when_empty():
+    svc, _ = _make_service()
     with patch("app.threads.service.get_checkpointer") as mock_cp:
-        await svc.delete_all_for_agent(uuid4())
+        await svc.purge_checkpoints([])
 
     mock_cp.assert_not_called()
-    db.delete.assert_not_called()
-    db.flush.assert_not_called()

--- a/backend/tests/threads/test_service.py
+++ b/backend/tests/threads/test_service.py
@@ -1,0 +1,49 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from app.threads.models import ThreadDB
+from app.threads.service import ThreadService
+
+
+def _make_service():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.delete = AsyncMock()
+    db.flush = AsyncMock()
+    svc = ThreadService(db)
+    svc.repository = MagicMock()
+    return svc, db
+
+
+async def test_delete_all_for_agent_deletes_threads_and_checkpoints():
+    svc, db = _make_service()
+    agent_id = uuid4()
+    thread_ids = ["t1", "t2"]
+    svc.repository.list_ids_for_agent = AsyncMock(return_value=thread_ids)
+    svc.repository.get = AsyncMock(
+        side_effect=lambda tid: ThreadDB(id=tid, user_id=uuid4(), agent_id=agent_id)
+    )
+
+    checkpointer = AsyncMock()
+    with patch("app.threads.service.get_checkpointer") as mock_cp:
+        mock_cp.return_value.__aenter__ = AsyncMock(return_value=checkpointer)
+        mock_cp.return_value.__aexit__ = AsyncMock(return_value=None)
+        await svc.delete_all_for_agent(agent_id)
+
+    assert checkpointer.adelete_thread.await_count == 2
+    checkpointer.adelete_thread.assert_any_await(thread_id="t1")
+    checkpointer.adelete_thread.assert_any_await(thread_id="t2")
+    assert db.delete.await_count == 2
+    db.flush.assert_awaited_once()
+
+
+async def test_delete_all_for_agent_noop_when_no_threads():
+    svc, db = _make_service()
+    svc.repository.list_ids_for_agent = AsyncMock(return_value=[])
+
+    with patch("app.threads.service.get_checkpointer") as mock_cp:
+        await svc.delete_all_for_agent(uuid4())
+
+    mock_cp.assert_not_called()
+    db.delete.assert_not_called()
+    db.flush.assert_not_called()

--- a/web/eslint.precommit.mjs
+++ b/web/eslint.precommit.mjs
@@ -1,0 +1,27 @@
+// Stricter ESLint config used ONLY by the pre-commit hook (see
+// .pre-commit-config.yaml), which lints just the files you change. It layers
+// type-aware rules on top of the base config so violations are caught before
+// commit — without changing `npm run lint` / `next build`, which keep using
+// eslint.config.mjs and stay unaffected by the repo's existing violations.
+import base from "./eslint.config.mjs";
+
+export default [
+	...base,
+	{
+		files: ["src/**/*.{ts,tsx}"],
+		languageOptions: {
+			parserOptions: {
+				projectService: true,
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+		rules: {
+			// "Promise-returning function provided to attribute where a void
+			// return was expected" — wrap async handlers: onClick={() => { void fn(); }}
+			"@typescript-eslint/no-misused-promises": "error",
+			// "Returning a void expression from an arrow function shorthand is
+			// forbidden" — use a block body: (x) => { doVoidThing(x); }
+			"@typescript-eslint/no-confusing-void-expression": "error",
+		},
+	},
+];

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -115,7 +115,9 @@ export default function AgentCard({
 				className={`group flex h-full flex-col rounded-xl border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card p-4 pb-0 transition-[border-color,box-shadow] duration-[130ms] ease-out hover:border-[#cfe0d8] dark:hover:border-white/20 hover:shadow-[0_3px_10px_rgba(30,45,40,0.06)] ${
 					hasAccess ? "cursor-pointer" : "cursor-default"
 				}`}
-				onClick={() => hasAccess && setOpen(true)}
+				onClick={() => {
+					if (hasAccess) setOpen(true);
+				}}
 			>
 				{/* Head: tile · name/handle · role */}
 				<div className="mb-2.5 flex min-w-0 items-center gap-[11px]">
@@ -183,7 +185,7 @@ export default function AgentCard({
 			{open && archived && (
 				<ArchivedAgentDialog
 					agent={agent}
-					onClose={() => setOpen(false)}
+					onClose={() => { setOpen(false); }}
 					onRemoved={(id) => onRemoved?.(id)}
 				/>
 			)}
@@ -191,11 +193,11 @@ export default function AgentCard({
 			{open && !archived && createPortal(
 				<div
 					className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(30,45,40,0.2)] backdrop-blur-[4px] animate-in fade-in duration-200"
-					onClick={() => setOpen(false)}
+					onClick={() => { setOpen(false); }}
 				>
 					<div
 						className="bg-white dark:bg-card rounded-[28px] p-8 w-[440px] max-w-[90vw] shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] animate-in slide-in-from-bottom-4 zoom-in-[0.97] duration-300"
-						onClick={(e) => e.stopPropagation()}
+						onClick={(e) => { e.stopPropagation(); }}
 					>
 						{/* Avatar + Name + Close */}
 						<div className="flex items-center gap-4 mb-6">
@@ -217,7 +219,7 @@ export default function AgentCard({
 								</div>
 							</div>
 							<button
-								onClick={() => setOpen(false)}
+								onClick={() => { setOpen(false); }}
 								className="shrink-0 self-start w-9 h-9 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
 							>
 								<X className="h-4 w-4 text-[#6B7F76]" />

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
-import { ArrowRight, Pencil, X } from "lucide-react";
+import { ArrowRight, Pencil } from "lucide-react";
 import { Agent, AgentPermission } from "@/types/agents";
-import { agentColorBackground, agentPastel } from "@/lib/colors";
+import { agentPastel } from "@/lib/colors";
 import { useMcpServersStore } from "@/stores/mcp-servers-store";
 import ArchivedAgentDialog from "@/app/(protected)/agents/components/archived-agent-dialog";
+import AgentDialogShell from "@/app/(protected)/agents/components/agent-dialog-shell";
 import Image from "next/image";
 
 interface AgentCardProps {
@@ -84,7 +84,11 @@ export default function AgentCard({
 		if (!agent.mcpServers) return [];
 		return agent.mcpServers.map((s) => {
 			const full = mcpServers.find((m) => m.id === s.mcpServerId);
-			return { id: s.mcpServerId, name: full?.name ?? s.mcpServerId, iconUrl: full?.iconUrl };
+			return {
+				id: s.mcpServerId,
+				name: full?.name ?? s.mcpServerId,
+				iconUrl: full?.iconUrl,
+			};
 		});
 	}, [agent.mcpServers, mcpServers]);
 
@@ -185,122 +189,96 @@ export default function AgentCard({
 			{open && archived && (
 				<ArchivedAgentDialog
 					agent={agent}
-					onClose={() => { setOpen(false); }}
+					onClose={() => {
+						setOpen(false);
+					}}
 					onRemoved={(id) => onRemoved?.(id)}
 				/>
 			)}
 
-			{open && !archived && createPortal(
-				<div
-					className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(30,45,40,0.2)] backdrop-blur-[4px] animate-in fade-in duration-200"
-					onClick={() => { setOpen(false); }}
+			{open && !archived && (
+				<AgentDialogShell
+					agent={agent}
+					subtitle={`@${agent.name.toLowerCase().replace(/\s+/g, "_")}`}
+					onClose={() => {
+						setOpen(false);
+					}}
 				>
-					<div
-						className="bg-white dark:bg-card rounded-[28px] p-8 w-[440px] max-w-[90vw] shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] animate-in slide-in-from-bottom-4 zoom-in-[0.97] duration-300"
-						onClick={(e) => { e.stopPropagation(); }}
-					>
-						{/* Avatar + Name + Close */}
-						<div className="flex items-center gap-4 mb-6">
-							<div
-								style={{
-									background: agentColorBackground(color),
-									border: `1.5px solid ${color}18`,
-								}}
-								className="shrink-0 w-[60px] h-[60px] rounded-full flex items-center justify-center text-[30px]"
-							>
-								{agent.emoji || "🤖"}
-							</div>
-							<div className="flex-1 min-w-0">
-								<div className="font-[family-name:var(--font-jakarta-sans)] text-[20px] font-extrabold text-[#1E2D28] dark:text-foreground tracking-[-0.02em] truncate">
-									{agent.name}
-								</div>
-								<div className="font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#A3B5AD] dark:text-muted-foreground font-medium mt-0.5">
-									@{agent.name.toLowerCase().replace(/\s+/g, "_")}
-								</div>
-							</div>
-							<button
-								onClick={() => { setOpen(false); }}
-								className="shrink-0 self-start w-9 h-9 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
-							>
-								<X className="h-4 w-4 text-[#6B7F76]" />
-							</button>
+					{/* Description */}
+					<div className="mb-5">
+						<div className="font-[family-name:var(--font-dm-sans)] text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-1.5">
+							Description
 						</div>
-
-						{/* Description */}
-						<div className="mb-5">
-							<div className="font-[family-name:var(--font-dm-sans)] text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-1.5">
-								Description
-							</div>
-							<p className="font-[family-name:var(--font-dm-sans)] text-[14px] text-[#6B7F76] dark:text-muted-foreground leading-relaxed">
-								{agent.description || "No description provided."}
-							</p>
-						</div>
-
-						{/* Tools */}
-						{resolvedServers.length > 0 && (
-							<div className="mb-5">
-								<div className="font-[family-name:var(--font-dm-sans)] text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-2.5">
-									Tools
-								</div>
-								<div className="flex flex-wrap gap-2">
-									{resolvedServers.map((server) => (
-										<Image
-											unoptimized
-											key={server.id}
-											src={
-												server.iconUrl ??
-												"https://storage.googleapis.com/choose-assets/mcp.png"
-											}
-											alt={server.name}
-											width={24}
-											height={24}
-											className="shrink-0 rounded-md"
-										/>
-									))}
-								</div>
-							</div>
-						)}
-
-						{/* Subagents */}
-						{agent.subagents?.length > 0 && (
-							<div className="mb-7">
-								<div className="font-[family-name:var(--font-dm-sans)] text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-2.5">
-									Subagents
-								</div>
-								<div className="flex flex-wrap gap-2">
-									{agent.subagents.map((sub) => (
-										<div
-											key={sub.id}
-											className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#F5F8F6] dark:bg-white/5 font-[family-name:var(--font-dm-sans)] text-[13px] font-medium"
-										>
-											<span className="text-sm">{sub.emoji || "🤖"}</span>
-											<span className="text-[#6B7F76] dark:text-muted-foreground">{sub.name}</span>
-										</div>
-									))}
-								</div>
-							</div>
-						)}
-
-						{/* Buttons */}
-						<div className="flex gap-2.5">
-							<button
-								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
-								onClick={handleEdit}
-							>
-								<Pencil className="size-[15px] text-[#6B7F76]" />
-								Edit
-							</button>
-							<button
-								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#111111] dark:bg-white font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white dark:text-[#111111] cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90"
-								onClick={handleChat}
-							>
-								Chat
-								<ArrowRight className="size-[15px]" />
-							</button>
-						</div>
+						<p className="font-[family-name:var(--font-dm-sans)] text-[14px] text-[#6B7F76] dark:text-muted-foreground leading-relaxed">
+							{agent.description || "No description provided."}
+						</p>
 					</div>
-				</div>,
-				document.body,
+
+					{/* Tools */}
+					{resolvedServers.length > 0 && (
+						<div className="mb-5">
+							<div className="font-[family-name:var(--font-dm-sans)] text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-2.5">
+								Tools
+							</div>
+							<div className="flex flex-wrap gap-2">
+								{resolvedServers.map((server) => (
+									<Image
+										unoptimized
+										key={server.id}
+										src={
+											server.iconUrl ??
+											"https://storage.googleapis.com/choose-assets/mcp.png"
+										}
+										alt={server.name}
+										width={24}
+										height={24}
+										className="shrink-0 rounded-md"
+									/>
+								))}
+							</div>
+						</div>
+					)}
+
+					{/* Subagents */}
+					{agent.subagents?.length > 0 && (
+						<div className="mb-7">
+							<div className="font-[family-name:var(--font-dm-sans)] text-[12px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em] mb-2.5">
+								Subagents
+							</div>
+							<div className="flex flex-wrap gap-2">
+								{agent.subagents.map((sub) => (
+									<div
+										key={sub.id}
+										className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#F5F8F6] dark:bg-white/5 font-[family-name:var(--font-dm-sans)] text-[13px] font-medium"
+									>
+										<span className="text-sm">{sub.emoji || "🤖"}</span>
+										<span className="text-[#6B7F76] dark:text-muted-foreground">
+											{sub.name}
+										</span>
+									</div>
+								))}
+							</div>
+						</div>
+					)}
+
+					{/* Buttons */}
+					<div className="flex gap-2.5">
+						<button
+							className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground cursor-pointer transition-all hover:border-[#A3B5AD]"
+							onClick={handleEdit}
+						>
+							<Pencil className="size-[15px] text-[#6B7F76]" />
+							Edit
+						</button>
+						<button
+							className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#111111] dark:bg-white font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white dark:text-[#111111] cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90"
+							onClick={handleChat}
+						>
+							Chat
+							<ArrowRight className="size-[15px]" />
+						</button>
+					</div>
+				</AgentDialogShell>
 			)}
 		</>
 	);

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -7,10 +7,15 @@ import { ArrowRight, Pencil, X } from "lucide-react";
 import { Agent, AgentPermission } from "@/types/agents";
 import { agentColorBackground, agentPastel } from "@/lib/colors";
 import { useMcpServersStore } from "@/stores/mcp-servers-store";
+import ArchivedAgentDialog from "@/app/(protected)/agents/components/archived-agent-dialog";
 import Image from "next/image";
 
 interface AgentCardProps {
 	agent: Agent;
+	// In the Archived view the card opens a restore/delete dialog instead of
+	// the edit/chat modal, and only manage-capable users can open it.
+	archived?: boolean;
+	onRemoved?: (agentId: string) => void;
 }
 
 const PERMISSION_HIERARCHY: Record<AgentPermission, number> = {
@@ -60,11 +65,20 @@ const NO_ACCESS_BADGE = {
 	text: "text-[#A35462] dark:text-rose-300",
 };
 
-export default function AgentCard({ agent }: AgentCardProps) {
+export default function AgentCard({
+	agent,
+	archived = false,
+	onRemoved,
+}: AgentCardProps) {
 	const router = useRouter();
 	const [open, setOpen] = useState(false);
 	const mcpServers = useMcpServersStore((state) => state.mcpServers);
-	const hasAccess = !!agent.currentUserPermission;
+	// Only the agent owner/admin (or workspace admin, which resolves to "admin")
+	// may manage an archived agent.
+	const canManage =
+		agent.currentUserPermission === "owner" ||
+		agent.currentUserPermission === "admin";
+	const hasAccess = archived ? canManage : !!agent.currentUserPermission;
 
 	const resolvedServers = useMemo(() => {
 		if (!agent.mcpServers) return [];
@@ -166,7 +180,15 @@ export default function AgentCard({ agent }: AgentCardProps) {
 				)}
 			</div>
 
-			{open && createPortal(
+			{open && archived && (
+				<ArchivedAgentDialog
+					agent={agent}
+					onClose={() => setOpen(false)}
+					onRemoved={(id) => onRemoved?.(id)}
+				/>
+			)}
+
+			{open && !archived && createPortal(
 				<div
 					className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(30,45,40,0.2)] backdrop-blur-[4px] animate-in fade-in duration-200"
 					onClick={() => setOpen(false)}

--- a/web/src/app/(protected)/agents/components/agent-dialog-shell.tsx
+++ b/web/src/app/(protected)/agents/components/agent-dialog-shell.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Agent } from "@/types/agents";
+import { agentColorBackground } from "@/lib/colors";
+
+interface AgentDialogShellProps {
+	agent: Agent;
+	// Secondary line under the agent name (e.g. the @handle, or "Archived").
+	subtitle: React.ReactNode;
+	onClose: () => void;
+	// When true, overlay/close-button clicks are ignored (e.g. while a request
+	// is in flight).
+	closeDisabled?: boolean;
+	children: React.ReactNode;
+}
+
+// Shared modal chrome for agent dialogs: a centered portal with a blurred
+// overlay, the rounded card container, and the avatar/name/subtitle/close
+// header. Both the active-agent modal (AgentCard) and the archived-agent
+// dialog render their body as children so the chrome stays consistent.
+export default function AgentDialogShell({
+	agent,
+	subtitle,
+	onClose,
+	closeDisabled = false,
+	children,
+}: AgentDialogShellProps) {
+	const color = agent.color || "#9E9E9E";
+	const close = () => {
+		if (!closeDisabled) onClose();
+	};
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(30,45,40,0.2)] backdrop-blur-[4px] animate-in fade-in duration-200"
+			onClick={close}
+		>
+			<div
+				className="bg-white dark:bg-card rounded-[28px] p-8 w-[440px] max-w-[90vw] shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] animate-in slide-in-from-bottom-4 zoom-in-[0.97] duration-300"
+				onClick={(e) => {
+					e.stopPropagation();
+				}}
+			>
+				{/* Avatar + Name + Close */}
+				<div className="flex items-center gap-4 mb-6">
+					<div
+						style={{
+							background: agentColorBackground(color),
+							border: `1.5px solid ${color}18`,
+						}}
+						className="shrink-0 w-[60px] h-[60px] rounded-full flex items-center justify-center text-[30px]"
+					>
+						{agent.emoji || "🤖"}
+					</div>
+					<div className="flex-1 min-w-0">
+						<div className="font-[family-name:var(--font-jakarta-sans)] text-[20px] font-extrabold text-[#1E2D28] dark:text-foreground tracking-[-0.02em] truncate">
+							{agent.name}
+						</div>
+						<div className="font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#A3B5AD] dark:text-muted-foreground font-medium mt-0.5">
+							{subtitle}
+						</div>
+					</div>
+					<button
+						onClick={close}
+						className="shrink-0 self-start w-9 h-9 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
+					>
+						<X className="h-4 w-4 text-[#6B7F76]" />
+					</button>
+				</div>
+
+				{children}
+			</div>
+		</div>,
+		document.body,
+	);
+}

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { ArrowRight, Info, Plus, Search, Zap } from "lucide-react";
+import { Archive, ArrowRight, Info, Plus, Search, Zap } from "lucide-react";
 import { Agent } from "@/types/agents";
 import AgentCard from "@/app/(protected)/agents/components/agent-card";
 import { api } from "@/lib/api/client";
@@ -78,10 +78,14 @@ function AgentSection({
 	label,
 	agents,
 	note,
+	archived,
+	onRemoved,
 }: {
 	label: string;
 	agents: Agent[];
 	note?: React.ReactNode;
+	archived?: boolean;
+	onRemoved?: (agentId: string) => void;
 }) {
 	const [expanded, setExpanded] = useState(false);
 	const hasMore = agents.length > SECTION_CAP;
@@ -119,7 +123,7 @@ function AgentSection({
 						className="h-full animate-in fade-in slide-in-from-bottom-3 duration-400"
 						style={{ animationDelay: `${i * 40}ms`, animationFillMode: "both" }}
 					>
-						<AgentCard agent={agent} />
+						<AgentCard agent={agent} archived={archived} onRemoved={onRemoved} />
 					</div>
 				))}
 			</div>
@@ -131,23 +135,28 @@ interface AgentListProps {
 	search: string;
 	onClearSearch?: () => void;
 	onCreateAgent?: () => void;
+	archived?: boolean;
 }
 
 export default function AgentList({
 	search,
 	onClearSearch,
 	onCreateAgent,
+	archived = false,
 }: AgentListProps) {
 	const [agents, setAgents] = useState<Agent[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
 		api
-			.get<Agent[]>("/agents")
+			.get<Agent[]>(archived ? "/agents?archived=true" : "/agents")
 			.then((response) => setAgents(response.data))
 			.catch(console.error)
 			.finally(() => setIsLoading(false));
-	}, []);
+	}, [archived]);
+
+	const handleRemoved = (agentId: string) =>
+		setAgents((prev) => prev.filter((a) => a.id !== agentId));
 
 	const matches = useMemo(() => {
 		if (!search) return agents;
@@ -165,6 +174,17 @@ export default function AgentList({
 	);
 
 	if (isLoading) return null;
+
+	// Empty archived view.
+	if (archived && agents.length === 0) {
+		return (
+			<EmptyState
+				icon={<Archive className="size-[22px] text-[#4CA882]" />}
+				title="No archived agents"
+				subtitle="Agents you archive show up here, where they can be restored or deleted permanently."
+			/>
+		);
+	}
 
 	// Empty workspace — no agents at all.
 	if (agents.length === 0) {
@@ -221,6 +241,8 @@ export default function AgentList({
 					key={group.key}
 					label={group.label}
 					agents={group.items}
+					archived={archived}
+					onRemoved={handleRemoved}
 					note={
 						group.key === "discover" ? (
 							<div className="flex items-center gap-2.5 px-4 py-3 mb-5 rounded-xl bg-primary/10 text-primary text-[13.5px]">

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -150,13 +150,14 @@ export default function AgentList({
 	useEffect(() => {
 		api
 			.get<Agent[]>(archived ? "/agents?archived=true" : "/agents")
-			.then((response) => setAgents(response.data))
+			.then((response) => { setAgents(response.data); })
 			.catch(console.error)
-			.finally(() => setIsLoading(false));
+			.finally(() => { setIsLoading(false); });
 	}, [archived]);
 
-	const handleRemoved = (agentId: string) =>
+	const handleRemoved = (agentId: string) => {
 		setAgents((prev) => prev.filter((a) => a.id !== agentId));
+	};
 
 	const matches = useMemo(() => {
 		if (!search) return agents;

--- a/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
+++ b/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
@@ -105,7 +105,9 @@ export default function ArchivedAgentDialog({
 							<button
 								disabled={busy}
 								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#C0455A] font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white cursor-pointer shadow-[0_4px_12px_-2px_rgba(192,69,90,0.3)] transition-all hover:opacity-90 disabled:opacity-50"
-								onClick={handleDelete}
+								onClick={() => {
+									void handleDelete();
+								}}
 							>
 								<Trash2 className="size-[15px]" />
 								{busy ? "Deleting..." : "Delete permanently"}
@@ -130,7 +132,9 @@ export default function ArchivedAgentDialog({
 							<button
 								disabled={busy}
 								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#111111] dark:bg-white font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white dark:text-[#111111] cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90 disabled:opacity-50"
-								onClick={handleRestore}
+								onClick={() => {
+									void handleRestore();
+								}}
 							>
 								<ArchiveRestore className="size-[15px]" />
 								{busy ? "Restoring..." : "Restore"}

--- a/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
+++ b/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
@@ -52,11 +52,13 @@ export default function ArchivedAgentDialog({
 	return createPortal(
 		<div
 			className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(30,45,40,0.2)] backdrop-blur-[4px] animate-in fade-in duration-200"
-			onClick={() => !busy && onClose()}
+			onClick={() => {
+				if (!busy) onClose();
+			}}
 		>
 			<div
 				className="bg-white dark:bg-card rounded-[28px] p-8 w-[440px] max-w-[90vw] shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] animate-in slide-in-from-bottom-4 zoom-in-[0.97] duration-300"
-				onClick={(e) => e.stopPropagation()}
+				onClick={(e) => { e.stopPropagation(); }}
 			>
 				{/* Avatar + Name + Close */}
 				<div className="flex items-center gap-4 mb-6">
@@ -78,7 +80,9 @@ export default function ArchivedAgentDialog({
 						</div>
 					</div>
 					<button
-						onClick={() => !busy && onClose()}
+						onClick={() => {
+							if (!busy) onClose();
+						}}
 						className="shrink-0 self-start w-9 h-9 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
 					>
 						<X className="h-4 w-4 text-[#6B7F76]" />
@@ -98,7 +102,7 @@ export default function ArchivedAgentDialog({
 							<button
 								disabled={busy}
 								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground cursor-pointer transition-all hover:border-[#A3B5AD] disabled:opacity-50"
-								onClick={() => setConfirmingDelete(false)}
+								onClick={() => { setConfirmingDelete(false); }}
 							>
 								Cancel
 							</button>
@@ -124,7 +128,7 @@ export default function ArchivedAgentDialog({
 							<button
 								disabled={busy}
 								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#C0455A] cursor-pointer transition-all hover:border-[#C0455A]/40 disabled:opacity-50"
-								onClick={() => setConfirmingDelete(true)}
+								onClick={() => { setConfirmingDelete(true); }}
 							>
 								<Trash2 className="size-[15px]" />
 								Delete permanently

--- a/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
+++ b/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { createPortal } from "react-dom";
-import { ArchiveRestore, Trash2, TriangleAlert, X } from "lucide-react";
+import { ArchiveRestore, Trash2, TriangleAlert } from "lucide-react";
 import { Agent } from "@/types/agents";
-import { agentColorBackground } from "@/lib/colors";
 import { api } from "@/lib/api/client";
+import AgentDialogShell from "@/app/(protected)/agents/components/agent-dialog-shell";
 
 interface ArchivedAgentDialogProps {
 	agent: Agent;
@@ -21,7 +20,6 @@ export default function ArchivedAgentDialog({
 }: ArchivedAgentDialogProps) {
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 	const [busy, setBusy] = useState(false);
-	const color = agent.color || "#9E9E9E";
 
 	const handleRestore = async () => {
 		setBusy(true);
@@ -49,105 +47,74 @@ export default function ArchivedAgentDialog({
 		}
 	};
 
-	return createPortal(
-		<div
-			className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(30,45,40,0.2)] backdrop-blur-[4px] animate-in fade-in duration-200"
-			onClick={() => {
-				if (!busy) onClose();
-			}}
+	return (
+		<AgentDialogShell
+			agent={agent}
+			subtitle="Archived"
+			onClose={onClose}
+			closeDisabled={busy}
 		>
-			<div
-				className="bg-white dark:bg-card rounded-[28px] p-8 w-[440px] max-w-[90vw] shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] animate-in slide-in-from-bottom-4 zoom-in-[0.97] duration-300"
-				onClick={(e) => { e.stopPropagation(); }}
-			>
-				{/* Avatar + Name + Close */}
-				<div className="flex items-center gap-4 mb-6">
-					<div
-						style={{
-							background: agentColorBackground(color),
-							border: `1.5px solid ${color}18`,
-						}}
-						className="shrink-0 w-[60px] h-[60px] rounded-full flex items-center justify-center text-[30px]"
-					>
-						{agent.emoji || "🤖"}
+			{confirmingDelete ? (
+				<>
+					<div className="flex items-start gap-2.5 px-4 py-3 mb-6 rounded-xl bg-[#F3E4E6] dark:bg-rose-950/40 text-[#A35462] dark:text-rose-300 text-[13.5px] leading-relaxed">
+						<TriangleAlert className="size-4 shrink-0 mt-0.5" />
+						<span>
+							This permanently deletes the agent, its tool connections, and
+							every chat thread that used it. This cannot be undone.
+						</span>
 					</div>
-					<div className="flex-1 min-w-0">
-						<div className="font-[family-name:var(--font-jakarta-sans)] text-[20px] font-extrabold text-[#1E2D28] dark:text-foreground tracking-[-0.02em] truncate">
-							{agent.name}
-						</div>
-						<div className="font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#A3B5AD] dark:text-muted-foreground font-medium mt-0.5">
-							Archived
-						</div>
+					<div className="flex gap-2.5">
+						<button
+							disabled={busy}
+							className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground cursor-pointer transition-all hover:border-[#A3B5AD] disabled:opacity-50"
+							onClick={() => {
+								setConfirmingDelete(false);
+							}}
+						>
+							Cancel
+						</button>
+						<button
+							disabled={busy}
+							className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#C0455A] font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white cursor-pointer shadow-[0_4px_12px_-2px_rgba(192,69,90,0.3)] transition-all hover:opacity-90 disabled:opacity-50"
+							onClick={() => {
+								void handleDelete();
+							}}
+						>
+							<Trash2 className="size-[15px]" />
+							{busy ? "Deleting..." : "Delete permanently"}
+						</button>
 					</div>
-					<button
-						onClick={() => {
-							if (!busy) onClose();
-						}}
-						className="shrink-0 self-start w-9 h-9 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
-					>
-						<X className="h-4 w-4 text-[#6B7F76]" />
-					</button>
-				</div>
-
-				{confirmingDelete ? (
-					<>
-						<div className="flex items-start gap-2.5 px-4 py-3 mb-6 rounded-xl bg-[#F3E4E6] dark:bg-rose-950/40 text-[#A35462] dark:text-rose-300 text-[13.5px] leading-relaxed">
-							<TriangleAlert className="size-4 shrink-0 mt-0.5" />
-							<span>
-								This permanently deletes the agent, its tool connections, and
-								every chat thread that used it. This cannot be undone.
-							</span>
-						</div>
-						<div className="flex gap-2.5">
-							<button
-								disabled={busy}
-								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground cursor-pointer transition-all hover:border-[#A3B5AD] disabled:opacity-50"
-								onClick={() => { setConfirmingDelete(false); }}
-							>
-								Cancel
-							</button>
-							<button
-								disabled={busy}
-								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#C0455A] font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white cursor-pointer shadow-[0_4px_12px_-2px_rgba(192,69,90,0.3)] transition-all hover:opacity-90 disabled:opacity-50"
-								onClick={() => {
-									void handleDelete();
-								}}
-							>
-								<Trash2 className="size-[15px]" />
-								{busy ? "Deleting..." : "Delete permanently"}
-							</button>
-						</div>
-					</>
-				) : (
-					<>
-						<p className="mb-6 font-[family-name:var(--font-dm-sans)] text-[14px] text-[#6B7F76] dark:text-muted-foreground leading-relaxed">
-							Restore this agent to make it available again, or delete it
-							permanently to remove it and all of its chat history.
-						</p>
-						<div className="flex gap-2.5">
-							<button
-								disabled={busy}
-								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#C0455A] cursor-pointer transition-all hover:border-[#C0455A]/40 disabled:opacity-50"
-								onClick={() => { setConfirmingDelete(true); }}
-							>
-								<Trash2 className="size-[15px]" />
-								Delete permanently
-							</button>
-							<button
-								disabled={busy}
-								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#111111] dark:bg-white font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white dark:text-[#111111] cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90 disabled:opacity-50"
-								onClick={() => {
-									void handleRestore();
-								}}
-							>
-								<ArchiveRestore className="size-[15px]" />
-								{busy ? "Restoring..." : "Restore"}
-							</button>
-						</div>
-					</>
-				)}
-			</div>
-		</div>,
-		document.body,
+				</>
+			) : (
+				<>
+					<p className="mb-6 font-[family-name:var(--font-dm-sans)] text-[14px] text-[#6B7F76] dark:text-muted-foreground leading-relaxed">
+						Restore this agent to make it available again, or delete it
+						permanently to remove it and all of its chat history.
+					</p>
+					<div className="flex gap-2.5">
+						<button
+							disabled={busy}
+							className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#C0455A] cursor-pointer transition-all hover:border-[#C0455A]/40 disabled:opacity-50"
+							onClick={() => {
+								setConfirmingDelete(true);
+							}}
+						>
+							<Trash2 className="size-[15px]" />
+							Delete permanently
+						</button>
+						<button
+							disabled={busy}
+							className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#111111] dark:bg-white font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white dark:text-[#111111] cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90 disabled:opacity-50"
+							onClick={() => {
+								void handleRestore();
+							}}
+						>
+							<ArchiveRestore className="size-[15px]" />
+							{busy ? "Restoring..." : "Restore"}
+						</button>
+					</div>
+				</>
+			)}
+		</AgentDialogShell>
 	);
 }

--- a/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
+++ b/web/src/app/(protected)/agents/components/archived-agent-dialog.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { ArchiveRestore, Trash2, TriangleAlert, X } from "lucide-react";
+import { Agent } from "@/types/agents";
+import { agentColorBackground } from "@/lib/colors";
+import { api } from "@/lib/api/client";
+
+interface ArchivedAgentDialogProps {
+	agent: Agent;
+	onClose: () => void;
+	// Called after the agent leaves the archived list (restored or deleted).
+	onRemoved: (agentId: string) => void;
+}
+
+export default function ArchivedAgentDialog({
+	agent,
+	onClose,
+	onRemoved,
+}: ArchivedAgentDialogProps) {
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
+	const [busy, setBusy] = useState(false);
+	const color = agent.color || "#9E9E9E";
+
+	const handleRestore = async () => {
+		setBusy(true);
+		try {
+			await api.post(`/agents/${agent.id}/restore`);
+			onRemoved(agent.id);
+			onClose();
+		} catch (error) {
+			console.error("Error restoring agent:", error);
+			alert("Failed to restore agent. Please try again.");
+			setBusy(false);
+		}
+	};
+
+	const handleDelete = async () => {
+		setBusy(true);
+		try {
+			await api.delete(`/agents/${agent.id}/permanent`);
+			onRemoved(agent.id);
+			onClose();
+		} catch (error) {
+			console.error("Error deleting agent:", error);
+			alert("Failed to delete agent. Please try again.");
+			setBusy(false);
+		}
+	};
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(30,45,40,0.2)] backdrop-blur-[4px] animate-in fade-in duration-200"
+			onClick={() => !busy && onClose()}
+		>
+			<div
+				className="bg-white dark:bg-card rounded-[28px] p-8 w-[440px] max-w-[90vw] shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] animate-in slide-in-from-bottom-4 zoom-in-[0.97] duration-300"
+				onClick={(e) => e.stopPropagation()}
+			>
+				{/* Avatar + Name + Close */}
+				<div className="flex items-center gap-4 mb-6">
+					<div
+						style={{
+							background: agentColorBackground(color),
+							border: `1.5px solid ${color}18`,
+						}}
+						className="shrink-0 w-[60px] h-[60px] rounded-full flex items-center justify-center text-[30px]"
+					>
+						{agent.emoji || "🤖"}
+					</div>
+					<div className="flex-1 min-w-0">
+						<div className="font-[family-name:var(--font-jakarta-sans)] text-[20px] font-extrabold text-[#1E2D28] dark:text-foreground tracking-[-0.02em] truncate">
+							{agent.name}
+						</div>
+						<div className="font-[family-name:var(--font-dm-sans)] text-[13.5px] text-[#A3B5AD] dark:text-muted-foreground font-medium mt-0.5">
+							Archived
+						</div>
+					</div>
+					<button
+						onClick={() => !busy && onClose()}
+						className="shrink-0 self-start w-9 h-9 rounded-full bg-[#F5F8F6] dark:bg-white/10 flex items-center justify-center cursor-pointer transition-colors hover:bg-[#EDF4F0] dark:hover:bg-white/15"
+					>
+						<X className="h-4 w-4 text-[#6B7F76]" />
+					</button>
+				</div>
+
+				{confirmingDelete ? (
+					<>
+						<div className="flex items-start gap-2.5 px-4 py-3 mb-6 rounded-xl bg-[#F3E4E6] dark:bg-rose-950/40 text-[#A35462] dark:text-rose-300 text-[13.5px] leading-relaxed">
+							<TriangleAlert className="size-4 shrink-0 mt-0.5" />
+							<span>
+								This permanently deletes the agent, its tool connections, and
+								every chat thread that used it. This cannot be undone.
+							</span>
+						</div>
+						<div className="flex gap-2.5">
+							<button
+								disabled={busy}
+								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-foreground cursor-pointer transition-all hover:border-[#A3B5AD] disabled:opacity-50"
+								onClick={() => setConfirmingDelete(false)}
+							>
+								Cancel
+							</button>
+							<button
+								disabled={busy}
+								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#C0455A] font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white cursor-pointer shadow-[0_4px_12px_-2px_rgba(192,69,90,0.3)] transition-all hover:opacity-90 disabled:opacity-50"
+								onClick={handleDelete}
+							>
+								<Trash2 className="size-[15px]" />
+								{busy ? "Deleting..." : "Delete permanently"}
+							</button>
+						</div>
+					</>
+				) : (
+					<>
+						<p className="mb-6 font-[family-name:var(--font-dm-sans)] text-[14px] text-[#6B7F76] dark:text-muted-foreground leading-relaxed">
+							Restore this agent to make it available again, or delete it
+							permanently to remove it and all of its chat history.
+						</p>
+						<div className="flex gap-2.5">
+							<button
+								disabled={busy}
+								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#C0455A] cursor-pointer transition-all hover:border-[#C0455A]/40 disabled:opacity-50"
+								onClick={() => setConfirmingDelete(true)}
+							>
+								<Trash2 className="size-[15px]" />
+								Delete permanently
+							</button>
+							<button
+								disabled={busy}
+								className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-full bg-[#111111] dark:bg-white font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-white dark:text-[#111111] cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] transition-all hover:opacity-90 disabled:opacity-50"
+								onClick={handleRestore}
+							>
+								<ArchiveRestore className="size-[15px]" />
+								{busy ? "Restoring..." : "Restore"}
+							</button>
+						</div>
+					</>
+				)}
+			</div>
+		</div>,
+		document.body,
+	);
+}

--- a/web/src/app/(protected)/agents/page.tsx
+++ b/web/src/app/(protected)/agents/page.tsx
@@ -21,6 +21,7 @@ export default function AgentsPage() {
 	const [isCreating, setIsCreating] = useState(false);
 	const [errorDialogOpen, setErrorDialogOpen] = useState(false);
 	const [search, setSearch] = useState("");
+	const [view, setView] = useState<"active" | "archived">("active");
 
 	const handleCreateAgent = async () => {
 		if (!user) return;
@@ -88,12 +89,34 @@ export default function AgentsPage() {
 					</Button>
 				</div>
 			</div>
+			<div className="mb-2 flex items-center gap-1 border-b border-[#E8EFE9] dark:border-white/10">
+				{(
+					[
+						{ key: "active", label: "Active" },
+						{ key: "archived", label: "Archived" },
+					] as const
+				).map((tab) => (
+					<button
+						key={tab.key}
+						onClick={() => setView(tab.key)}
+						className={`relative -mb-px px-4 py-2.5 font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold cursor-pointer transition-colors ${
+							view === tab.key
+								? "text-[#1E2D28] dark:text-foreground border-b-2 border-[#111111] dark:border-white"
+								: "text-[#8FA89E] dark:text-muted-foreground border-b-2 border-transparent hover:text-[#1E2D28] dark:hover:text-foreground"
+						}`}
+					>
+						{tab.label}
+					</button>
+				))}
+			</div>
 			<AgentList
+				key={view}
 				search={search}
 				onClearSearch={() => {
 					setSearch("");
 				}}
 				onCreateAgent={handleCreateAgent}
+				archived={view === "archived"}
 			/>
 		</PageContainer>
 	);

--- a/web/src/app/(protected)/agents/page.tsx
+++ b/web/src/app/(protected)/agents/page.tsx
@@ -98,7 +98,9 @@ export default function AgentsPage() {
 				).map((tab) => (
 					<button
 						key={tab.key}
-						onClick={() => setView(tab.key)}
+						onClick={() => {
+							setView(tab.key);
+						}}
 						className={`relative -mb-px px-4 py-2.5 font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold cursor-pointer transition-colors ${
 							view === tab.key
 								? "text-[#1E2D28] dark:text-foreground border-b-2 border-[#111111] dark:border-white"

--- a/web/src/app/(protected)/agents/page.tsx
+++ b/web/src/app/(protected)/agents/page.tsx
@@ -81,7 +81,9 @@ export default function AgentsPage() {
 					/>
 					<Button
 						className="flex items-center gap-2 px-6! py-3! h-auto! bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none whitespace-nowrap"
-						onClick={handleCreateAgent}
+						onClick={() => {
+							void handleCreateAgent();
+						}}
 						disabled={isCreating}
 					>
 						<Plus className="w-4 h-4" />
@@ -117,7 +119,9 @@ export default function AgentsPage() {
 				onClearSearch={() => {
 					setSearch("");
 				}}
-				onCreateAgent={handleCreateAgent}
+				onCreateAgent={() => {
+					void handleCreateAgent();
+				}}
 				archived={view === "archived"}
 			/>
 		</PageContainer>

--- a/web/src/types/agents.ts
+++ b/web/src/types/agents.ts
@@ -26,6 +26,7 @@ export interface Agent {
 	color?: string | null;
 	description?: string | null;
 	hasCodeInterpreter: boolean;
+	isArchived: boolean;
 	mcpServers: AgentMCPServer[];
 	subagents: SubagentInfo[];
 	isSubagent: boolean;


### PR DESCRIPTION
## Summary

Adds an **Active / Archived** tab to the Agents page so archived agents are visible and manageable in the UI, and wires up **Restore** and **Delete permanently**. Also fixes a latent bug: an MCP server linked to an *archived* agent could not be deleted, because the archived agent still held the binding.

## Backend
- `GET /agents?archived=true` — lists archived agents, threaded through `AgentService.list` → repo `archived_only` filter. Same visibility policy as the active list (grouped by resolved permission).
- `POST /agents/{id}/restore` — sets `is_archived=False`. Gated to owner / agent-admin / workspace-admin.
- `DELETE /agents/{id}/permanent` — hard-deletes the agent and **cascades cleanup** of MCP bindings, subagent links, user permissions, and threads + their LangGraph checkpoints, in an order that respects the RESTRICT FKs. Gated to owner / agent-admin / workspace-admin.
- `is_archived` exposed on `AgentResponse`.
- The existing `DELETE /agents/{id}` (archive) is unchanged.

## Frontend
- **Active / Archived** tab bar on the Agents page.
- Archived cards reuse the existing grid + grouping. Clicking opens an `ArchivedAgentDialog` with **Restore** and **Delete permanently** (two-step confirm). The dialog only opens for owners / agent-admins / workspace-admins; members/editors/no-access cannot interact.

## Threads handling
On permanent delete, the agent's threads **and their checkpoints** are deleted (via the existing `checkpointer.adelete_thread`). The cost/generation audit trail lives in Langfuse, so observability is preserved.

## Tests
- 165 backend tests pass (added coverage for restore/permanent-delete service + router gates, MCP-binding bulk cleanup, and thread + checkpoint cascade).
- Frontend eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Active/Archived tab to the Agents page so archived agents are visible and manageable, with restore and permanent delete that fully clean up related data and safely purge checkpoints after DB deletes. Also adds a pre-commit ESLint hook for `web/` and docs on setup and async handler patterns.

- **New Features**
  - Backend: `GET /agents?archived=true`, `POST /agents/{id}/restore`, `DELETE /agents/{id}/permanent`; `is_archived` on responses.
  - Permissions: restore/permanent delete limited to owner, agent-admin, or workspace-admin.
  - Frontend: Active/Archived tabs; archived cards open a dialog with Restore and Delete permanently; extracted `AgentDialogShell` to share modal chrome.
  - Permanent delete cascades: removes MCP bindings, subagent links, user permissions, and threads; bulk-deletes thread rows first, then purges LangGraph checkpoints last (non-transactional).
  - Tooling: pre-commit ESLint hook for `web/` using `web/eslint.precommit.mjs` to run type-aware rules (`@typescript-eslint/no-misused-promises`, `@typescript-eslint/no-confusing-void-expression`) on changed files only. README and `CLAUDE.md` document hooks and the async handler pattern.

- **Bug Fixes**
  - MCP servers linked to archived agents can now be deleted; permanent delete clears the bindings.
  - Wrapped async UI handlers (restore/delete, tab switch) to satisfy `@typescript-eslint/no-misused-promises` and avoid unhandled promises.

<sup>Written for commit 6166e0db6d3a6e07180c2e43ba2e2e6c788ecd91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

