### PR TITLE
Handle Google MCP servers

### DIFF
--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -26,6 +26,8 @@ def build_oauth_client_metadata(mcp_server: dict) -> OAuthClientMetadata:
         scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive"
     elif mcp_server.name == "Calendar":
         scope = "openid https://www.googleapis.com/auth/calendar.calendarlist.readonly https://www.googleapis.com/auth/calendar.events.freebusy https://www.googleapis.com/auth/calendar.events.readonly"
+    elif mcp_server.name == "Drive":
+        scope = "openid https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file"
     else:
         scope = "user"
 
@@ -44,7 +46,13 @@ def build_oauth_client_metadata(mcp_server: dict) -> OAuthClientMetadata:
 class WebOAuthClientProvider(OAuthClientProvider):
     """Web OAuth client provider for MCP servers. Idea is to stick as close as possible to the official MCP SDK."""
 
-    def __init__(self, *args, client_id: str | None = None, client_secret: str | None = None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self._client_id = client_id
         self._client_secret = client_secret
@@ -55,18 +63,27 @@ class WebOAuthClientProvider(OAuthClientProvider):
         self.context.client_info = await self.context.storage.get_client_info()
 
         if not self.context.oauth_metadata:
-            self.context.oauth_metadata = await self.context.storage.get_oauth_metadata()
+            self.context.oauth_metadata = (
+                await self.context.storage.get_oauth_metadata()
+            )
 
-        if self.context.oauth_metadata and self.context.oauth_metadata.issuer == AnyHttpUrl("https://api.supabase.com/"):
-            logger.debug(
-                "Setting token endpoint auth method to client_secret_post")
+        if (
+            self.context.oauth_metadata
+            and self.context.oauth_metadata.issuer
+            == AnyHttpUrl("https://api.supabase.com/")
+        ):
+            logger.debug("Setting token endpoint auth method to client_secret_post")
             self.context.client_info.token_endpoint_auth_method = "client_secret_post"
 
-        if not self.context.client_info and self.context.client_metadata and self._client_id:
+        if (
+            not self.context.client_info
+            and self.context.client_metadata
+            and self._client_id
+        ):
             self.context.client_info = OAuthClientInformationFull(
                 client_id=self._client_id,
                 client_secret=self._client_secret,
-                **self.context.client_metadata.model_dump()
+                **self.context.client_metadata.model_dump(),
             )
 
         if self.context.current_tokens:
@@ -80,7 +97,8 @@ class WebOAuthClientProvider(OAuthClientProvider):
             body = await response.aread()  # pragma: no cover
             body_text = body.decode("utf-8")  # pragma: no cover
             raise OAuthTokenError(
-                f"Token exchange failed ({response.status_code}): {body_text}")  # pragma: no cover
+                f"Token exchange failed ({response.status_code}): {body_text}"
+            )  # pragma: no cover
 
         # Parse and validate response with scope validation
         token_response = await handle_token_response_scopes(response)
@@ -108,8 +126,7 @@ class WebOAuthClientProvider(OAuthClientProvider):
             self.context.oauth_metadata
             and self.context.oauth_metadata.authorization_endpoint
         ):
-            auth_endpoint = str(
-                self.context.oauth_metadata.authorization_endpoint)
+            auth_endpoint = str(self.context.oauth_metadata.authorization_endpoint)
         else:
             auth_base_url = self.context.get_authorization_base_url(
                 self.context.server_url
@@ -134,7 +151,9 @@ class WebOAuthClientProvider(OAuthClientProvider):
             "code_challenge_method": "S256",
         }
 
-        if self.context.oauth_metadata.issuer == AnyHttpUrl("https://accounts.google.com/"):
+        if self.context.oauth_metadata.issuer == AnyHttpUrl(
+            "https://accounts.google.com/"
+        ):
             auth_params["access_type"] = "offline"
             auth_params["prompt"] = "consent"
 
@@ -162,7 +181,9 @@ class WebOAuthClientProvider(OAuthClientProvider):
             raise OAuthFlowError("Client info not found in storage")
 
         if not self.context.oauth_metadata:
-            self.context.oauth_metadata = await self.context.storage.get_oauth_metadata()
+            self.context.oauth_metadata = (
+                await self.context.storage.get_oauth_metadata()
+            )
 
         # Recover Verifier
         verifier = await self.context.storage.get_verifier(state)

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -34,7 +34,8 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
     async def create(self, data: MCPServerCreate) -> MCPServerDB:
         if data.auth_type == MCPAuthType.api_key and not data.api_key:
             raise DomainValidationError(
-                "API key is required when auth_type is 'api_key'")
+                "API key is required when auth_type is 'api_key'"
+            )
 
         db_server = await self.repository.create(data)
 
@@ -72,8 +73,7 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
     async def list_official(self) -> list[OfficialMCPServerResponse]:
         rows = await self.repository.list_official()
         return [
-            OfficialMCPServerResponse(
-                **row[0].model_dump(), is_installed=row[1])
+            OfficialMCPServerResponse(**row[0].model_dump(), is_installed=row[1])
             for row in rows
         ]
 
@@ -113,7 +113,9 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
         await provider._initialize()
 
         if mcp_server.url == "https://mcp.supabase.com/mcp":
-            provider.context.client_metadata.token_endpoint_auth_method = "client_secret_post"
+            provider.context.client_metadata.token_endpoint_auth_method = (
+                "client_secret_post"
+            )
 
         await provider.manual_exchange(code, state)
 
@@ -124,7 +126,9 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
 
     async def list_tools(self, server: MCPServerDB, user_id: str) -> list[dict]:
         async with connect_to_server(server, user_id, self.db) as (_, tools):
-            return [{"name": tool.name, "description": tool.description} for tool in tools]
+            return [
+                {"name": tool.name, "description": tool.description} for tool in tools
+            ]
 
 
 # Safety bound for tools/list pagination. A well-behaved server eventually returns
@@ -196,8 +200,7 @@ async def connect_to_server(
 
         if oauth_credentials:
             client_id = oauth_credentials.client_id
-            client_secret = decrypt_api_key(
-                oauth_credentials.client_secret_encrypted)
+            client_secret = decrypt_api_key(oauth_credentials.client_secret_encrypted)
 
             client_metadata.token_endpoint_auth_method = (
                 oauth_credentials.token_endpoint_auth_method or "client_secret_post"
@@ -225,8 +228,10 @@ async def connect_to_server(
         client_args = {"url": mcp_server.url, "auth": provider}
     elif mcp_server.auth_type == MCPAuthType.api_key:
         api_key = await repository.get_api_key(mcp_server.id)
-        client_args = {"url": mcp_server.url, "headers": {
-            "Authorization": f"Bearer {api_key}"}}
+        client_args = {
+            "url": mcp_server.url,
+            "headers": {"Authorization": f"Bearer {api_key}"},
+        }
     else:
         client_args = {"url": mcp_server.url}
 
@@ -240,9 +245,15 @@ async def connect_to_server(
                 tools = await _list_all_tools(session)
 
                 if mcp_server.url == "https://bigquery.googleapis.com/mcp":
-                    await session.call_tool("list_dataset_ids", {"project_id": os.getenv("GCLOUD_PROJECT")})
+                    await session.call_tool(
+                        "list_dataset_ids", {"project_id": os.getenv("GCLOUD_PROJECT")}
+                    )
                 elif mcp_server.url == "https://calendarmcp.googleapis.com/mcp/v1":
                     await session.call_tool("list_calendars", {})
+                elif mcp_server.url == "https://drivemcp.googleapis.com/mcp/v1":
+                    await session.call_tool("list_recent_files", {})
+                elif mcp_server.url == "https://gmailmcp.googleapis.com/mcp/v1":
+                    await session.call_tool("list_labels", {})
                 yield session, tools
 
             except Exception as e:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "0.4.0"
+version = "0.4.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Google MCP servers (Drive, Gmail) with proper OAuth scopes and automatic warm-up calls so connections work out of the box and tools load quickly.

- **New Features**
  - Added Drive OAuth scopes: openid, drive.readonly, drive.file.
  - On connect, auto-calls initial tools for Google servers: BigQuery datasets (uses GCLOUD_PROJECT), Calendar calendars, Drive recent files, Gmail labels.

<sup>Written for commit cec1c4b09661e6b1639884cbe2814a2cc31819e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

