### PR TITLE
feat(mcp): discover OAuth scopes via PRM, drop tool-call 401 probe

### DIFF
--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -5,7 +5,17 @@ from urllib.parse import urlencode, urljoin
 import httpx
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, PKCEParameters
 from mcp.client.auth.exceptions import OAuthTokenError
-from mcp.client.auth.utils import handle_token_response_scopes
+from mcp.client.auth.utils import (
+    build_oauth_authorization_server_metadata_discovery_urls,
+    build_protected_resource_metadata_discovery_urls,
+    create_client_registration_request,
+    create_oauth_metadata_request,
+    get_client_metadata_scopes,
+    handle_auth_metadata_response,
+    handle_protected_resource_response,
+    handle_registration_response,
+    handle_token_response_scopes,
+)
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
 from pydantic import AnyHttpUrl, AnyUrl
 
@@ -16,21 +26,13 @@ from app.settings import app_settings
 logger = logging.getLogger(__name__)
 
 
-def build_oauth_client_metadata(mcp_server: dict) -> OAuthClientMetadata:
-    # TODO: Handle scopes automatically
-    if mcp_server.url == "https://bigquery.googleapis.com/mcp":
-        scope = "https://www.googleapis.com/auth/bigquery"
-    elif mcp_server.name == "Gmail":
-        scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/gmail.metadata"
-    elif mcp_server.name == "Google Sheets":
-        scope = "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive"
-    elif mcp_server.name == "Calendar":
-        scope = "openid https://www.googleapis.com/auth/calendar.calendarlist.readonly https://www.googleapis.com/auth/calendar.events.freebusy https://www.googleapis.com/auth/calendar.events.readonly"
-    elif mcp_server.name == "Drive":
-        scope = "openid https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file"
-    else:
-        scope = "user"
+def build_oauth_client_metadata() -> OAuthClientMetadata:
+    """Static OAuth client-registration metadata for auxilia.
 
+    Scopes are intentionally omitted: they are discovered per-server from the
+    Protected Resource Metadata (RFC 9728 ``scopes_supported``) during
+    authorization, so there is nothing server-specific to configure here.
+    """
     return OAuthClientMetadata(
         client_name="auxilia",
         redirect_uris=[
@@ -39,7 +41,6 @@ def build_oauth_client_metadata(mcp_server: dict) -> OAuthClientMetadata:
         grant_types=["authorization_code", "refresh_token"],
         response_types=["code"],
         token_endpoint_auth_method=None,
-        scope=scope,
     )
 
 
@@ -90,6 +91,89 @@ class WebOAuthClientProvider(OAuthClientProvider):
             self.context.update_token_expiry(self.context.current_tokens)
 
         self._initialized = True
+
+    async def initiate_authorization(self) -> None:
+        """Start the OAuth flow explicitly, without calling a business tool to
+        provoke a 401.
+
+        Discovers OAuth metadata the same way the SDK's ``async_auth_flow``
+        does on a 401 — RFC 9728 Protected Resource Metadata, then RFC 8414 /
+        OIDC Authorization Server Metadata — applies the discovered scopes,
+        then builds the authorization URL (which raises
+        ``OAuthAuthorizationRequired`` via the overridden
+        ``_perform_authorization_code_grant``).
+
+        The discovery GETs run on a plain ``httpx.AsyncClient`` (no MCP
+        session, no anyio task group), so the resulting exception propagates
+        on the normal request stack instead of wrapped in an ``ExceptionGroup``.
+        """
+        if not self._initialized:
+            await self._initialize()
+
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            # Step 1: Protected Resource Metadata (path-based then root well-known).
+            for url in build_protected_resource_metadata_discovery_urls(
+                None, self.context.server_url
+            ):
+                response = await client.send(create_oauth_metadata_request(url))
+                prm = await handle_protected_resource_response(response)
+                if prm:
+                    self.context.protected_resource_metadata = prm
+                    self.context.auth_server_url = str(prm.authorization_servers[0])
+                    break
+
+            # Step 2: Authorization Server Metadata (RFC 8414 / OIDC fallbacks).
+            for url in build_oauth_authorization_server_metadata_discovery_urls(
+                self.context.auth_server_url, self.context.server_url
+            ):
+                response = await client.send(create_oauth_metadata_request(url))
+                ok, asm = await handle_auth_metadata_response(response)
+                if ok and asm:
+                    self.context.oauth_metadata = asm
+                    break
+                if not ok:
+                    break
+
+            # Step 3: scope selection — PRM scopes_supported if advertised,
+            # otherwise no scope param (the server omits it, e.g. Notion).
+            discovered_scopes = get_client_metadata_scopes(
+                None,
+                self.context.protected_resource_metadata,
+                self.context.oauth_metadata,
+            )
+            if discovered_scopes:
+                self.context.client_metadata.scope = discovered_scopes
+
+            # Step 4: ensure a registered client. Static credentials (e.g.
+            # Google) are loaded into client_info by _initialize; otherwise
+            # register dynamically per RFC 7591 (e.g. Notion).
+            if not self.context.client_info:
+                registration_response = await client.send(
+                    create_client_registration_request(
+                        self.context.oauth_metadata,
+                        self.context.client_metadata,
+                        self.context.get_authorization_base_url(
+                            self.context.server_url
+                        ),
+                    )
+                )
+                self.context.client_info = await handle_registration_response(
+                    registration_response
+                )
+
+        if not self.context.client_info:
+            raise OAuthFlowError("No client info available for authorization")
+
+        # Persist client_info so the OAuth callback (a separate HTTP request with
+        # a fresh provider) and the refresh path (probe_mcp_server) can recover
+        # the client_id/secret from storage. connect_to_server persists it on its
+        # own path; the explicit flow skips connect_to_server, so persist it here.
+        await self.context.storage.set_client_info(self.context.client_info)
+
+        # Builds the authorization URL and raises OAuthAuthorizationRequired.
+        # protected_resource_metadata is set, so should_include_resource_param()
+        # is True and the RFC 8707 resource param is included.
+        await self._perform_authorization_code_grant()
 
     async def _handle_token_response(self, response: httpx.Response) -> None:
         """Handle token exchange response."""
@@ -151,8 +235,10 @@ class WebOAuthClientProvider(OAuthClientProvider):
             "code_challenge_method": "S256",
         }
 
-        if self.context.oauth_metadata.issuer == AnyHttpUrl(
-            "https://accounts.google.com/"
+        if (
+            self.context.oauth_metadata
+            and self.context.oauth_metadata.issuer
+            == AnyHttpUrl("https://accounts.google.com/")
         ):
             auth_params["access_type"] = "offline"
             auth_params["prompt"] = "consent"

--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -92,6 +92,21 @@ class WebOAuthClientProvider(OAuthClientProvider):
 
         self._initialized = True
 
+    async def persist_client_info(self) -> None:
+        """Persist static client registration to storage so the OAuth callback
+        and the refresh path — separate requests with fresh providers — can
+        recover client_id/secret. No-op when there are no static credentials
+        (such servers register dynamically and persist during authorization)."""
+        if not self._client_id:
+            return
+        await self.context.storage.set_client_info(
+            OAuthClientInformationFull(
+                client_id=self._client_id,
+                client_secret=self._client_secret,
+                **self.context.client_metadata.model_dump(),
+            )
+        )
+
     async def initiate_authorization(self) -> None:
         """Start the OAuth flow explicitly, without calling a business tool to
         provoke a 401.

--- a/backend/app/mcp/client/connectivity.py
+++ b/backend/app/mcp/client/connectivity.py
@@ -19,7 +19,7 @@ async def is_oauth_connected(server: MCPServerDB, user_id: str) -> bool:
     connected.
     """
     storage = TokenStorageFactory().get_storage(user_id, str(server.id))
-    client_metadata = build_oauth_client_metadata(server)
+    client_metadata = build_oauth_client_metadata()
     provider = WebOAuthClientProvider(
         server_url=server.url,
         client_metadata=client_metadata,
@@ -38,9 +38,7 @@ async def probe_connectivity(server: MCPServerDB, user_id: str) -> bool:
     return await is_oauth_connected(server, user_id)
 
 
-async def probe_connectivity_with_refresh(
-    server: MCPServerDB, user_id: str
-) -> bool:
+async def probe_connectivity_with_refresh(server: MCPServerDB, user_id: str) -> bool:
     """Probe that also attempts a token refresh when the stored token is
     expired. Delegates to :func:`app.mcp.utils.probe_mcp_server`."""
     return await probe_mcp_server(server, user_id)

--- a/backend/app/mcp/client/factory.py
+++ b/backend/app/mcp/client/factory.py
@@ -14,7 +14,6 @@ class MCPClientConfigFactory:
         self._servers = MCPServerRepository(db)
 
     async def build(self, config: MCPServerDB) -> dict:
-
         base_config = {
             "transport": "http",
             "url": config.url,
@@ -32,7 +31,7 @@ class MCPClientConfigFactory:
                 **base_config,
                 "auth": WebOAuthClientProvider(
                     server_url=config.url,
-                    client_metadata=build_oauth_client_metadata(config),
+                    client_metadata=build_oauth_client_metadata(),
                     storage=self._token_storage_factory.get_storage(
                         self._user_id, config.id
                     ),

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -6,13 +6,12 @@ from uuid import UUID
 from fastapi import Depends
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
-from mcp.shared.auth import OAuthClientInformationFull
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.exceptions import DomainError, DomainValidationError, NotFoundError
 from app.mcp.client.auth import WebOAuthClientProvider, build_oauth_client_metadata
-from app.mcp.client.storage import TokenStorageFactory
+from app.mcp.client.storage import RedisTokenStorage, TokenStorageFactory
 from app.mcp.servers.encryption import decrypt_value as decrypt_api_key
 from app.mcp.servers.models import MCPAuthType, MCPServerDB
 from app.mcp.servers.repository import MCPServerRepository
@@ -23,6 +22,32 @@ from app.mcp.servers.schemas import (
 )
 from app.mcp.utils import probe_mcp_server
 from app.service import BaseService
+
+
+async def _build_oauth_provider(
+    mcp_server: MCPServerDB,
+    storage: RedisTokenStorage,
+    repository: MCPServerRepository,
+) -> WebOAuthClientProvider:
+    """Build a WebOAuthClientProvider for an OAuth2 MCP server, loading and
+    decrypting any stored static client credentials. Servers without stored
+    credentials register dynamically (DCR) during the authorization flow."""
+    client_metadata = build_oauth_client_metadata()
+    oauth_credentials = await repository.get_oauth_credentials(mcp_server.id)
+    client_id = client_secret = None
+    if oauth_credentials:
+        client_id = oauth_credentials.client_id
+        client_secret = decrypt_api_key(oauth_credentials.client_secret_encrypted)
+        client_metadata.token_endpoint_auth_method = (
+            oauth_credentials.token_endpoint_auth_method or "client_secret_post"
+        )
+    return WebOAuthClientProvider(
+        server_url=mcp_server.url,
+        client_metadata=client_metadata,
+        storage=storage,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
 
 
 class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
@@ -96,19 +121,7 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
         if not mcp_server:
             raise NotFoundError("MCP server not found")
 
-        client_metadata = build_oauth_client_metadata()
-
-        oauth_credentials = await self.repository.get_oauth_credentials(mcp_server.id)
-        if oauth_credentials:
-            client_metadata.token_endpoint_auth_method = (
-                oauth_credentials.token_endpoint_auth_method or "client_secret_post"
-            )
-
-        provider = WebOAuthClientProvider(
-            server_url=mcp_server.url,
-            client_metadata=client_metadata,
-            storage=storage,
-        )
+        provider = await _build_oauth_provider(mcp_server, storage, self.repository)
 
         await provider._initialize()
 
@@ -142,24 +155,7 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
         """Build the OAuth provider and start authorization via metadata
         discovery. Raises OAuthAuthorizationRequired with the authorize URL."""
         storage = TokenStorageFactory().get_storage(user_id, str(server.id))
-        client_metadata = build_oauth_client_metadata()
-
-        oauth_credentials = await self.repository.get_oauth_credentials(server.id)
-        client_id = client_secret = None
-        if oauth_credentials:
-            client_id = oauth_credentials.client_id
-            client_secret = decrypt_api_key(oauth_credentials.client_secret_encrypted)
-            client_metadata.token_endpoint_auth_method = (
-                oauth_credentials.token_endpoint_auth_method or "client_secret_post"
-            )
-
-        provider = WebOAuthClientProvider(
-            server_url=server.url,
-            client_metadata=client_metadata,
-            storage=storage,
-            client_id=client_id,
-            client_secret=client_secret,
-        )
+        provider = await _build_oauth_provider(server, storage, self.repository)
         await provider.initiate_authorization()
 
 
@@ -226,37 +222,8 @@ async def connect_to_server(
     storage = TokenStorageFactory().get_storage(user_id, str(mcp_server.id))
 
     if mcp_server.auth_type == MCPAuthType.oauth2:
-        client_metadata = build_oauth_client_metadata()
-
-        oauth_credentials = await repository.get_oauth_credentials(mcp_server.id)
-
-        if oauth_credentials:
-            client_id = oauth_credentials.client_id
-            client_secret = decrypt_api_key(oauth_credentials.client_secret_encrypted)
-
-            client_metadata.token_endpoint_auth_method = (
-                oauth_credentials.token_endpoint_auth_method or "client_secret_post"
-            )
-
-            await storage.set_client_info(
-                OAuthClientInformationFull(
-                    client_id=client_id,
-                    client_secret=client_secret,
-                    **client_metadata.model_dump(),
-                )
-            )
-        else:
-            client_id = None
-            client_secret = None
-
-        provider = WebOAuthClientProvider(
-            server_url=mcp_server.url,
-            client_metadata=client_metadata,
-            storage=storage,
-            client_id=client_id,
-            client_secret=client_secret,
-        )
-
+        provider = await _build_oauth_provider(mcp_server, storage, repository)
+        await provider.persist_client_info()
         client_args = {"url": mcp_server.url, "auth": provider}
     elif mcp_server.auth_type == MCPAuthType.api_key:
         api_key = await repository.get_api_key(mcp_server.id)

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from contextlib import asynccontextmanager
 from uuid import UUID
 
@@ -22,6 +21,7 @@ from app.mcp.servers.schemas import (
     MCPServerPatch,
     OfficialMCPServerResponse,
 )
+from app.mcp.utils import probe_mcp_server
 from app.service import BaseService
 
 
@@ -96,7 +96,7 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
         if not mcp_server:
             raise NotFoundError("MCP server not found")
 
-        client_metadata = build_oauth_client_metadata(mcp_server)
+        client_metadata = build_oauth_client_metadata()
 
         oauth_credentials = await self.repository.get_oauth_credentials(mcp_server.id)
         if oauth_credentials:
@@ -125,10 +125,42 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
         }
 
     async def list_tools(self, server: MCPServerDB, user_id: str) -> list[dict]:
+        if server.auth_type == MCPAuthType.oauth2 and not await probe_mcp_server(
+            server, user_id
+        ):
+            # Not connected: discover OAuth metadata and raise
+            # OAuthAuthorizationRequired (translated globally to
+            # 401 {oauth_required, auth_url}). No business tool is called.
+            await self._initiate_oauth(server, user_id)
+
         async with connect_to_server(server, user_id, self.db) as (_, tools):
             return [
                 {"name": tool.name, "description": tool.description} for tool in tools
             ]
+
+    async def _initiate_oauth(self, server: MCPServerDB, user_id: str) -> None:
+        """Build the OAuth provider and start authorization via metadata
+        discovery. Raises OAuthAuthorizationRequired with the authorize URL."""
+        storage = TokenStorageFactory().get_storage(user_id, str(server.id))
+        client_metadata = build_oauth_client_metadata()
+
+        oauth_credentials = await self.repository.get_oauth_credentials(server.id)
+        client_id = client_secret = None
+        if oauth_credentials:
+            client_id = oauth_credentials.client_id
+            client_secret = decrypt_api_key(oauth_credentials.client_secret_encrypted)
+            client_metadata.token_endpoint_auth_method = (
+                oauth_credentials.token_endpoint_auth_method or "client_secret_post"
+            )
+
+        provider = WebOAuthClientProvider(
+            server_url=server.url,
+            client_metadata=client_metadata,
+            storage=storage,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        await provider.initiate_authorization()
 
 
 # Safety bound for tools/list pagination. A well-behaved server eventually returns
@@ -194,7 +226,7 @@ async def connect_to_server(
     storage = TokenStorageFactory().get_storage(user_id, str(mcp_server.id))
 
     if mcp_server.auth_type == MCPAuthType.oauth2:
-        client_metadata = build_oauth_client_metadata(mcp_server)
+        client_metadata = build_oauth_client_metadata()
 
         oauth_credentials = await repository.get_oauth_credentials(mcp_server.id)
 
@@ -243,19 +275,7 @@ async def connect_to_server(
 
             try:
                 tools = await _list_all_tools(session)
-
-                if mcp_server.url == "https://bigquery.googleapis.com/mcp":
-                    await session.call_tool(
-                        "list_dataset_ids", {"project_id": os.getenv("GCLOUD_PROJECT")}
-                    )
-                elif mcp_server.url == "https://calendarmcp.googleapis.com/mcp/v1":
-                    await session.call_tool("list_calendars", {})
-                elif mcp_server.url == "https://drivemcp.googleapis.com/mcp/v1":
-                    await session.call_tool("list_recent_files", {})
-                elif mcp_server.url == "https://gmailmcp.googleapis.com/mcp/v1":
-                    await session.call_tool("list_labels", {})
                 yield session, tools
-
             except Exception as e:
                 raise DomainError(str(e)) from e
 

--- a/backend/tests/mcp/client/test_auth.py
+++ b/backend/tests/mcp/client/test_auth.py
@@ -1,0 +1,200 @@
+"""Tests for WebOAuthClientProvider.initiate_authorization.
+
+The provider replaces the old "call a dummy tool to provoke a 401" probe: it
+discovers OAuth metadata explicitly (RFC 9728 PRM + RFC 8414/OIDC AS metadata),
+applies the discovered scopes, and raises OAuthAuthorizationRequired with the
+authorize URL — all on the plain request stack (no MCP session / task group).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from mcp.shared.auth import (
+    OAuthClientInformationFull,
+    OAuthMetadata,
+    ProtectedResourceMetadata,
+)
+
+from app.mcp.client import auth as auth_module
+from app.mcp.client.auth import WebOAuthClientProvider, build_oauth_client_metadata
+from app.mcp.client.exceptions import OAuthAuthorizationRequired
+
+
+BIGQUERY_URL = "https://bigquery.googleapis.com/mcp"
+GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+
+
+class _FakeStorage:
+    """Minimal TokenStorage: unauthenticated, records what gets persisted."""
+
+    def __init__(self):
+        self.client_info = None
+
+    async def get_tokens(self):
+        return None
+
+    async def get_client_info(self):
+        return self.client_info
+
+    async def set_client_info(self, client_info):
+        self.client_info = client_info
+
+    async def get_oauth_metadata(self):
+        return None
+
+    async def set_oauth_metadata(self, metadata):
+        self.oauth_metadata = metadata
+
+    async def set_verifier(self, state, verifier):
+        self.verifier = (state, verifier)
+
+
+def _make_provider() -> WebOAuthClientProvider:
+    return WebOAuthClientProvider(
+        server_url=BIGQUERY_URL,
+        client_metadata=build_oauth_client_metadata(),
+        storage=_FakeStorage(),
+        client_id="client-123",
+        client_secret="secret-xyz",
+    )
+
+
+def _asm() -> OAuthMetadata:
+    return OAuthMetadata(
+        issuer="https://accounts.google.com/",
+        authorization_endpoint=GOOGLE_AUTH_ENDPOINT,
+        token_endpoint="https://oauth2.googleapis.com/token",
+    )
+
+
+def _patch_discovery(monkeypatch, prm, asm_result):
+    """Stub the network: send() returns a sentinel, and the SDK parse helpers
+    return the canned PRM / AS-metadata regardless of the response."""
+    monkeypatch.setattr(httpx.AsyncClient, "send", AsyncMock(return_value=object()))
+    monkeypatch.setattr(
+        auth_module, "handle_protected_resource_response", AsyncMock(return_value=prm)
+    )
+    monkeypatch.setattr(
+        auth_module, "handle_auth_metadata_response", AsyncMock(return_value=asm_result)
+    )
+
+
+async def test_uses_scopes_discovered_from_prm(monkeypatch):
+    # The scope advertised by the PRM must end up in the authorize URL.
+    prm = ProtectedResourceMetadata(
+        resource=BIGQUERY_URL,
+        authorization_servers=["https://accounts.google.com"],
+        scopes_supported=["https://www.googleapis.com/auth/bigquery.readonly"],
+    )
+    _patch_discovery(monkeypatch, prm, (True, _asm()))
+
+    provider = _make_provider()
+    with pytest.raises(OAuthAuthorizationRequired) as exc_info:
+        await provider.initiate_authorization()
+
+    # client_info must be persisted so the OAuth callback — a separate request
+    # with a fresh provider — can recover the client_id/secret from storage.
+    assert provider.context.storage.client_info is not None
+    assert provider.context.storage.client_info.client_id == "client-123"
+
+    parsed = urlparse(exc_info.value.url)
+    query = parse_qs(parsed.query)
+
+    # Authorize endpoint comes from discovered AS metadata, not server_url/authorize.
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == GOOGLE_AUTH_ENDPOINT
+    # Discovery overrides the hardcoded scope.
+    assert query["scope"] == ["https://www.googleapis.com/auth/bigquery.readonly"]
+    # RFC 8707 resource param fires because PRM is present (C.3).
+    assert query["resource"] == [BIGQUERY_URL]
+    # PKCE + Google offline-consent params.
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["access_type"] == ["offline"]
+    assert query["prompt"] == ["consent"]
+    assert query["client_id"] == ["client-123"]
+    assert query["response_type"] == ["code"]
+
+
+async def test_omits_scope_param_when_prm_has_no_scopes(monkeypatch):
+    # No hardcoded fallback anymore: if the PRM advertises no scopes (and there
+    # is no WWW-Authenticate scope), the authorize request omits scope entirely.
+    prm = ProtectedResourceMetadata(
+        resource=BIGQUERY_URL,
+        authorization_servers=["https://accounts.google.com"],
+        scopes_supported=None,
+    )
+    _patch_discovery(monkeypatch, prm, (True, _asm()))
+
+    with pytest.raises(OAuthAuthorizationRequired) as exc_info:
+        await _make_provider().initiate_authorization()
+
+    query = parse_qs(urlparse(exc_info.value.url).query)
+    assert "scope" not in query
+
+
+async def test_no_attribute_error_when_as_metadata_discovery_fails(monkeypatch):
+    # AS metadata discovery yields nothing -> context.oauth_metadata stays None.
+    # The hardened issuer guard must not raise AttributeError.
+    prm = ProtectedResourceMetadata(
+        resource=BIGQUERY_URL,
+        authorization_servers=["https://accounts.google.com"],
+        scopes_supported=["https://www.googleapis.com/auth/bigquery"],
+    )
+    _patch_discovery(monkeypatch, prm, (False, None))
+
+    with pytest.raises(OAuthAuthorizationRequired) as exc_info:
+        await _make_provider().initiate_authorization()
+
+    query = parse_qs(urlparse(exc_info.value.url).query)
+    # With no AS metadata, Google-specific params are skipped (guard short-circuits).
+    assert "access_type" not in query
+    # resource param still present (PRM available).
+    assert query["resource"] == [BIGQUERY_URL]
+
+
+async def test_dynamic_client_registration_when_no_static_creds(monkeypatch):
+    # A server with no pre-registered credentials (e.g. Notion) must register
+    # dynamically (RFC 7591) before the authorize URL can be built.
+    notion_url = "https://mcp.notion.com/mcp"
+    prm = ProtectedResourceMetadata(
+        resource=notion_url,
+        authorization_servers=["https://mcp.notion.com"],
+        scopes_supported=None,
+    )
+    asm = OAuthMetadata(
+        issuer="https://mcp.notion.com/",
+        authorization_endpoint="https://mcp.notion.com/authorize",
+        token_endpoint="https://mcp.notion.com/token",
+        registration_endpoint="https://mcp.notion.com/register",
+    )
+    _patch_discovery(monkeypatch, prm, (True, asm))
+    monkeypatch.setattr(
+        auth_module,
+        "handle_registration_response",
+        AsyncMock(
+            return_value=OAuthClientInformationFull(
+                client_id="dcr-client-id",
+                redirect_uris=["https://app.example/cb"],
+            )
+        ),
+    )
+
+    # No client_id/secret -> forces dynamic registration.
+    provider = WebOAuthClientProvider(
+        server_url=notion_url,
+        client_metadata=build_oauth_client_metadata(),
+        storage=_FakeStorage(),
+    )
+
+    with pytest.raises(OAuthAuthorizationRequired) as exc_info:
+        await provider.initiate_authorization()
+
+    # The dynamically-registered client_id is used and persisted for the callback.
+    assert provider.context.storage.client_info.client_id == "dcr-client-id"
+    query = parse_qs(urlparse(exc_info.value.url).query)
+    assert query["client_id"] == ["dcr-client-id"]
+    # Notion advertises no scopes -> none requested.
+    assert "scope" not in query

--- a/backend/tests/mcp/client/test_factory.py
+++ b/backend/tests/mcp/client/test_factory.py
@@ -24,9 +24,7 @@ async def test_no_auth():
 
 @pytest.mark.asyncio
 async def test_api_key_auth():
-    with patch(
-        "app.mcp.client.factory.MCPServerRepository"
-    ) as mock_repo_cls:
+    with patch("app.mcp.client.factory.MCPServerRepository") as mock_repo_cls:
         repo = MagicMock()
         repo.get_api_key = AsyncMock(return_value="secret")
         mock_repo_cls.return_value = repo
@@ -38,7 +36,10 @@ async def test_api_key_auth():
 
 @pytest.mark.asyncio
 @patch("app.mcp.client.factory.WebOAuthClientProvider")
-@patch("app.mcp.client.factory.build_oauth_client_metadata", return_value={"client_id": "abc"})
+@patch(
+    "app.mcp.client.factory.build_oauth_client_metadata",
+    return_value={"client_id": "abc"},
+)
 @patch("app.mcp.client.factory.TokenStorageFactory")
 async def test_oauth_auth(mock_storage_factory_cls, mock_metadata, mock_provider):
     storage = MagicMock()
@@ -48,6 +49,7 @@ async def test_oauth_auth(mock_storage_factory_cls, mock_metadata, mock_provider
     result = await factory.build(_config(MCPAuthType.oauth2))
 
     assert "auth" in result
+    mock_metadata.assert_called_once_with()
     mock_provider.assert_called_once_with(
         server_url="https://mcp.example.com",
         client_metadata={"client_id": "abc"},

--- a/backend/tests/mcp/servers/test_service.py
+++ b/backend/tests/mcp/servers/test_service.py
@@ -1,0 +1,91 @@
+"""Tests for the shared OAuth-provider construction in app/mcp/servers/service.py.
+
+`_build_oauth_provider` is the single place that turns an OAuth2 MCP server into
+a WebOAuthClientProvider (loading + decrypting static credentials); the three
+former copies (handle_oauth_callback / _initiate_oauth / connect_to_server) now
+route through it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from mcp.shared.auth import OAuthClientInformationFull
+
+from app.mcp.servers import service as service_module
+from app.mcp.servers.service import _build_oauth_provider
+
+
+def _repo_with_credentials(**overrides):
+    fields = {
+        "client_id": "cid",
+        "client_secret_encrypted": "enc",
+        "token_endpoint_auth_method": None,
+    }
+    fields.update(overrides)
+    repo = MagicMock()
+    repo.get_oauth_credentials = AsyncMock(return_value=SimpleNamespace(**fields))
+    return repo
+
+
+def _repo_without_credentials():
+    repo = MagicMock()
+    repo.get_oauth_credentials = AsyncMock(return_value=None)
+    return repo
+
+
+async def test_build_oauth_provider_loads_static_credentials(monkeypatch):
+    monkeypatch.setattr(service_module, "decrypt_api_key", lambda _: "decrypted-secret")
+    server = SimpleNamespace(id="s1", url="https://mcp.example.com/mcp")
+
+    provider = await _build_oauth_provider(
+        server,
+        MagicMock(),
+        _repo_with_credentials(token_endpoint_auth_method="client_secret_basic"),
+    )
+
+    assert provider._client_id == "cid"
+    assert provider._client_secret == "decrypted-secret"
+    assert (
+        provider.context.client_metadata.token_endpoint_auth_method
+        == "client_secret_basic"
+    )
+
+
+async def test_build_oauth_provider_without_credentials_defers_to_dcr():
+    server = SimpleNamespace(id="s1", url="https://mcp.notion.com/mcp")
+
+    provider = await _build_oauth_provider(
+        server, MagicMock(), _repo_without_credentials()
+    )
+
+    assert provider._client_id is None
+    assert provider._client_secret is None
+
+
+async def test_persist_client_info_writes_when_credentials_present(monkeypatch):
+    monkeypatch.setattr(service_module, "decrypt_api_key", lambda _: "decrypted-secret")
+    storage = MagicMock()
+    storage.set_client_info = AsyncMock()
+    server = SimpleNamespace(id="s1", url="https://mcp.example.com/mcp")
+
+    provider = await _build_oauth_provider(server, storage, _repo_with_credentials())
+    await provider.persist_client_info()
+
+    storage.set_client_info.assert_awaited_once()
+    persisted = storage.set_client_info.call_args.args[0]
+    assert isinstance(persisted, OAuthClientInformationFull)
+    assert persisted.client_id == "cid"
+    assert persisted.client_secret == "decrypted-secret"
+
+
+async def test_persist_client_info_noop_without_credentials():
+    storage = MagicMock()
+    storage.set_client_info = AsyncMock()
+    server = SimpleNamespace(id="s1", url="https://mcp.notion.com/mcp")
+
+    provider = await _build_oauth_provider(server, storage, _repo_without_credentials())
+    await provider.persist_client_info()
+
+    storage.set_client_info.assert_not_awaited()


### PR DESCRIPTION
## What & why

The OAuth **Connect** flow used to detect "needs authorization" by **calling a hardcoded business tool** (`list_dataset_ids` / `list_calendars` / `list_recent_files` / `list_labels`) per Google URL to provoke a 401. That coupled auth detection to specific servers and a `GCLOUD_PROJECT` env var, and abused tool execution for an auth signal.

This replaces it with an explicit, standards-based authorization initiation:

- **`WebOAuthClientProvider.initiate_authorization()`** — runs RFC 9728 Protected Resource Metadata discovery → RFC 8414 / OIDC Authorization Server Metadata discovery → applies the discovered scopes → performs **Dynamic Client Registration** (RFC 7591) when there are no static credentials → raises `OAuthAuthorizationRequired` with the authorize URL. All on the plain request stack — no MCP session, no `call_tool`.
- **`list_tools`** now gates on the offline `probe_mcp_server` check and only initiates auth when the user isn't connected. A connected user goes straight to listing; **no business tool is ever called.**
- **Scopes are no longer hardcoded** — they come from PRM `scopes_supported` (verified live that every Google MCP server advertises them). `build_oauth_client_metadata()` is now parameterless.

Covers both **static-credential** servers (Google) and **DCR** servers (Notion) — both verified end-to-end locally.

## Behavior changes reviewers should know

- **Scope breadth:** discovered scopes are the server's full advertised set, which for Calendar/Drive/Gmail is **broader** than the old hardcoded read-only sets, and **`openid`/`userinfo.email` are no longer requested**. Existing connections keep their granted scopes until a full re-auth.
- The bogus `else: scope = "user"` default is gone; an OAuth server advertising no PRM scopes now sends **no** `scope` param.
- `GCLOUD_PROJECT` coupling removed.

## Also in this change
- Persist `client_info` during initiation so the OAuth callback (a separate request) and token refresh can recover it — fixes a `Client info not found in storage` 500 on first connect.
- Harden the `oauth_metadata.issuer` guard against `None`.

## Test plan
- New `tests/mcp/client/test_auth.py` (4): scope discovered from PRM, scope omitted when PRM advertises none, no `AttributeError` when AS-metadata discovery fails, and DCR when there are no static creds.
- `tests/mcp/client/test_factory.py`: asserts the new parameterless `build_oauth_client_metadata()` contract.
- `tests/mcp` + `tests/agents/mcp_servers` green (43 passed); `ruff check` + `ruff format` clean.
- Manually verified the Connect → consent → callback → tokens flow for **Google (BigQuery)** and **Notion**.

## Out of scope (follow-ups)
- Consolidate the 5 `WebOAuthClientProvider` construction sites into one factory (this PR added the 5th).
- `mcp>=1.28` bump + `streamablehttp_client` → `streamable_http_client` rename (clears the deprecation warnings).
- Converge the 3 connectivity paths on `probe_mcp_server`; make `is_authenticated()` public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the dummy-tool 401 probe with an explicit OAuth discovery flow that finds scopes via PRM and starts auth without calling any tools. Also deduplicated OAuth provider construction and moved client-info persistence into the provider.

- **New Features**
  - Added `WebOAuthClientProvider.initiate_authorization()` to run PRM + AS metadata discovery, apply discovered scopes, perform DCR when needed, and raise `OAuthAuthorizationRequired` with the authorize URL.
  - `list_tools` now checks offline `probe_mcp_server` and initiates auth only when not connected; no business tools are called.
  - Scopes come from PRM `scopes_supported`; `build_oauth_client_metadata()` is now parameterless.

- **Refactors**
  - Extracted `_build_oauth_provider` to build providers in one place for `handle_oauth_callback`, `_initiate_oauth`, and `connect_to_server`.
  - Moved client-info persistence into `WebOAuthClientProvider.persist_client_info()`; initiation persists so callback/refresh can recover it.
  - Hardened `oauth_metadata.issuer` guard when AS discovery fails and removed `GCLOUD_PROJECT` coupling.

<sup>Written for commit 98e8b8b6a118aecde2c1b2c1cddc22b916617e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

