### PR TITLE
refactor(mcp): tighten WebOAuthClientProvider toward the SDK

### DIFF
--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode, urljoin
 
 import httpx
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, PKCEParameters
-from mcp.client.auth.exceptions import OAuthTokenError
 from mcp.client.auth.utils import (
     build_oauth_authorization_server_metadata_discovery_urls,
     build_protected_resource_metadata_discovery_urls,
@@ -14,7 +13,6 @@ from mcp.client.auth.utils import (
     handle_auth_metadata_response,
     handle_protected_resource_response,
     handle_registration_response,
-    handle_token_response_scopes,
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
 from pydantic import AnyHttpUrl, AnyUrl
@@ -189,23 +187,6 @@ class WebOAuthClientProvider(OAuthClientProvider):
         # protected_resource_metadata is set, so should_include_resource_param()
         # is True and the RFC 8707 resource param is included.
         await self._perform_authorization_code_grant()
-
-    async def _handle_token_response(self, response: httpx.Response) -> None:
-        """Handle token exchange response."""
-        if response.status_code not in {200, 201}:
-            body = await response.aread()  # pragma: no cover
-            body_text = body.decode("utf-8")  # pragma: no cover
-            raise OAuthTokenError(
-                f"Token exchange failed ({response.status_code}): {body_text}"
-            )  # pragma: no cover
-
-        # Parse and validate response with scope validation
-        token_response = await handle_token_response_scopes(response)
-
-        # Store tokens in context
-        self.context.current_tokens = token_response
-        self.context.update_token_expiry(token_response)
-        await self.context.storage.set_tokens(token_response)
 
     async def _perform_authorization_code_grant(self) -> tuple[str, str]:
         """

--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -119,6 +119,12 @@ class WebOAuthClientProvider(OAuthClientProvider):
         The discovery GETs run on a plain ``httpx.AsyncClient`` (no MCP
         session, no anyio task group), so the resulting exception propagates
         on the normal request stack instead of wrapped in an ``ExceptionGroup``.
+
+        Mirrors the 401 branch of ``OAuthClientProvider.async_auth_flow``
+        (PRM -> AS metadata -> scope selection -> DCR -> authorize). The SDK
+        only exposes that sequence as inlined generator code plus the public
+        helpers in ``mcp.client.auth.utils``, so this rebuilds the orchestration
+        on those helpers; keep it in sync with the SDK flow on upgrades.
         """
         if not self._initialized:
             await self._initialize()


### PR DESCRIPTION
## What & why

Two small follow-ups to #135 that reduce `WebOAuthClientProvider`'s divergence from the official MCP SDK. They were approved on #135 but landed **after** it was squash-merged, so they never reached `main`.

- **Drop the redundant `_handle_token_response` override.** It differed from `OAuthClientProvider._handle_token_response` only by also accepting HTTP `201`; a spec-compliant token endpoint returns `200`. Inheriting the SDK method removes one forked method (`manual_exchange` now uses the inherited version).
- **Add a sync-note** to `initiate_authorization` documenting that it mirrors the SDK's `async_auth_flow` 401 branch (built on the SDK's public `mcp.client.auth.utils` helpers) and must be kept in sync on SDK upgrades.

Net: the provider now overrides only what the serverless model requires (`__init__`, `_initialize`, `_perform_authorization_code_grant`) and inherits everything else.

## Test plan
- `tests/mcp` + `tests/agents/mcp_servers` green (47 passed); `ruff check` clean.
- No behavior change except no longer accepting `201` on token exchange (unused in practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten `WebOAuthClientProvider` to align with the MCP SDK by removing a redundant token handler and documenting the auth flow sync points. Token exchange now only accepts HTTP 200 (no longer 201).

- **Refactors**
  - Removed custom `_handle_token_response`; inherit `OAuthClientProvider`’s method. `manual_exchange` now uses the inherited version.
  - Added a sync note to `initiate_authorization` explaining it mirrors the 401 branch of `OAuthClientProvider.async_auth_flow` using `mcp.client.auth.utils`, and must stay in sync on SDK upgrades.

<sup>Written for commit eea8701867a2b3570c7bfed5febc330484d8d48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

