### PR TITLE
fix(threads): restrict rename endpoint to title only

### DIFF
--- a/backend/app/threads/schemas.py
+++ b/backend/app/threads/schemas.py
@@ -15,7 +15,10 @@ class ThreadCreate(SQLModel):
 
 
 class ThreadPatch(SQLModel):
-    model_id: str | None = None
+    # Rename only: the PATCH endpoint is a cosmetic rename of the thread's
+    # display title. `model_id` is deliberately not patchable here — letting
+    # callers set it to an arbitrary value would break later runs for the
+    # thread ("Unknown model").
     first_message_content: str | None = None
 
 

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -266,6 +266,38 @@ def test_update_thread(client: TestClient, mock_db, current_user):
     assert thread.first_message_content == "New title"
 
 
+def test_update_thread_ignores_model_id(client: TestClient, mock_db, current_user):
+    """Rename is cosmetic: a `model_id` in the body must not mutate the thread."""
+    thread_id = str(uuid4())
+    thread = ThreadDB(
+        id=thread_id,
+        user_id=current_user.id,
+        agent_id=uuid4(),
+        model_id="claude-opus-4-8",
+        first_message_content="Old title",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    mock_result.one_or_none.return_value = (thread, "Test Agent", "🤖", None, False)
+    mock_db.execute.return_value = mock_result
+
+    async def mock_refresh(obj):
+        pass
+
+    mock_db.refresh = mock_refresh
+
+    response = client.patch(
+        f"/threads/{thread_id}",
+        json={"first_message_content": "New title", "model_id": "bogus-model"},
+    )
+    assert response.status_code == 200
+    assert thread.first_message_content == "New title"
+    assert thread.model_id == "claude-opus-4-8"
+
+
 @pytest.mark.usefixtures("current_user")
 def test_update_thread_forbidden_for_non_owner(client: TestClient, mock_db):
     """A non-owner cannot rename a thread."""


### PR DESCRIPTION
## Summary

Follow-up on PR #156 (rename threads from the sidebar).

The cosmetic rename endpoint `PATCH /threads/{thread_id}` typed its body as `ThreadPatch`, which carried both `first_message_content` **and** `model_id`. The frontend only ever sends `first_message_content`, but the endpoint accepted anything — so any caller could set an arbitrary `model_id`. That value is persisted on the thread and read back for subsequent runs, silently breaking later runs with "Unknown model", well beyond the intended rename contract.

## Changes

- Drop `model_id` from `ThreadPatch` so renaming can only change the display title (kept the `ThreadPatch` name per `CONVENTIONS.md`). Pydantic now ignores any `model_id` in the request body.
- Add regression test `test_update_thread_ignores_model_id` asserting a `model_id` in the body does not mutate the thread.

## Testing

- `uv run pytest tests/threads/test_threads_router.py` — 13 passed
- `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the thread rename endpoint to only update the title. Ignores any model_id in the request to prevent broken runs and "Unknown model" errors.

- **Bug Fixes**
  - Removed model_id from `ThreadPatch` used by PATCH `/threads/{thread_id}`; extra model_id fields are now ignored.
  - Added regression test `test_update_thread_ignores_model_id` to ensure renames do not mutate the thread’s model.

<sup>Written for commit c4b0a647fb68844fa64cb85464e724224ee177cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

