### PR TITLE
chore: sync uv.lock version to 0.4.7

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "0.4.6"
+version = "0.4.7"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sync `backend` version in `uv.lock` from 0.4.6 to 0.4.7 to match the current package version and prevent tooling mismatches.

<sup>Written for commit 0f07a79e2f9cdf2f63d1c5197b1c6dc4d2f26414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

