### PR TITLE
feat(mcp): hardcode Gmail OAuth scopes instead of PRM discovery

### DIFF
--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -155,15 +155,26 @@ class WebOAuthClientProvider(OAuthClientProvider):
                 if not ok:
                     break
 
-            # Step 3: scope selection — PRM scopes_supported if advertised,
-            # otherwise no scope param (the server omits it, e.g. Notion).
-            discovered_scopes = get_client_metadata_scopes(
-                None,
-                self.context.protected_resource_metadata,
-                self.context.oauth_metadata,
-            )
-            if discovered_scopes:
-                self.context.client_metadata.scope = discovered_scopes
+            # Step 3: scope selection — hardcoded per-server (e.g. Gmail),
+            # otherwise PRM scopes_supported if advertised, otherwise no scope
+            # param (the server omits it, e.g. Notion).
+            # TODO: Handle scopes automatically
+            if "gmailmcp.googleapis.com" in str(self.context.server_url):
+                self.context.client_metadata.scope = (
+                    "openid "
+                    "https://www.googleapis.com/auth/userinfo.email "
+                    "https://www.googleapis.com/auth/gmail.readonly "
+                    "https://www.googleapis.com/auth/gmail.compose "
+                    "https://www.googleapis.com/auth/gmail.modify"
+                )
+            else:
+                discovered_scopes = get_client_metadata_scopes(
+                    None,
+                    self.context.protected_resource_metadata,
+                    self.context.oauth_metadata,
+                )
+                if discovered_scopes:
+                    self.context.client_metadata.scope = discovered_scopes
 
             # Step 4: ensure a registered client. Static credentials (e.g.
             # Google) are loaded into client_info by _initialize; otherwise

--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -159,7 +159,7 @@ class WebOAuthClientProvider(OAuthClientProvider):
             # otherwise PRM scopes_supported if advertised, otherwise no scope
             # param (the server omits it, e.g. Notion).
             # TODO: Handle scopes automatically
-            if "gmailmcp.googleapis.com" in str(self.context.server_url):
+            if str(self.context.server_url) == "https://gmailmcp.googleapis.com/mcp/v1":
                 self.context.client_metadata.scope = (
                     "openid "
                     "https://www.googleapis.com/auth/userinfo.email "


### PR DESCRIPTION
## What & why

PR #135 replaced the per-server hardcoded OAuth scope mapping with PRM (`scopes_supported`) discovery. For Gmail that means requesting Google's **full advertised scope set**, which is broader than what auxilia needs.

This re-introduces a hardcoded scope override for the **Gmail** MCP server — just to try pinning exactly what we request — while leaving PRM discovery in place for every other server.

The override lives inline in the scope-selection step of `initiate_authorization`, in the same style as the original pre-#135 code (kept the `# TODO: Handle scopes automatically` marker). Because that method only has `self.context.server_url` (not the server name the old code matched on), it keys on the `gmailmcp.googleapis.com` URL.

Gmail scopes requested:
- `openid`
- `userinfo.email`
- `gmail.readonly`
- `gmail.compose`
- `gmail.modify`

## Notes

- Only affects the authorize URL built on a fresh OAuth initiation; existing connections keep their granted scopes until full re-auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcoded Gmail OAuth scopes in the MCP client to request a minimal set instead of the full PRM-discovered scopes. Other servers still use PRM `scopes_supported`.

- **New Features**
  - Gmail now requests only: openid, https://www.googleapis.com/auth/userinfo.email, https://www.googleapis.com/auth/gmail.readonly, https://www.googleapis.com/auth/gmail.compose, https://www.googleapis.com/auth/gmail.modify
  - Override triggers when `server_url` equals `https://gmailmcp.googleapis.com/mcp/v1` and applies on new OAuth initiations only

<sup>Written for commit 18365d11f8dbc1430f2f5590a7397a4ea1aa7e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

