### PR TITLE
feat(slack): run Slack agent turns through the durable runtime

### DIFF
--- a/backend/app/agents/runs/SPEC.md
+++ b/backend/app/agents/runs/SPEC.md
@@ -149,7 +149,7 @@ event log and relays each chunk to the channel.
 
 - A run carries an opaque `delivery` descriptor (`RunRecord.delivery`); `None`
   means pull. The schema is owned by the channel (Slack writes
-  `{"channel": "slack", "channel_id", "thread_ts", "slack_user_id", "team_id"}`),
+  `{"channel": "slack", "channel_id": "C…", "thread_ts": "…", "slack_user_id": "U…", "team_id": "T…"}`),
   not by this module — `app/agents/runs` never imports `app/integrations`.
 - The composition root (`main.py`) injects a `DeliveryFactory` into
   `RunDispatcher` → `RunWorker`. After the run goes `running`, the worker builds a

--- a/backend/app/agents/runs/SPEC.md
+++ b/backend/app/agents/runs/SPEC.md
@@ -71,6 +71,7 @@ Redis primitives playing the "repository" role:
 | `control.py`  | `RunControl` — cancel signal (Redis list, polled via non-blocking `LPOP`)              |
 | `queue.py`    | `RunQueue` — FIFO dispatch: `enqueue(run_id)` / `dequeue()` (`BRPOP`)                   |
 | `worker.py`   | `RunWorker` (executes one run) + `RunDispatcher` (BRPOP loop, semaphore, task-per-run) |
+| `delivery.py` | `DeliveryConsumer` protocol + `DeliveryFactory` type — the push-delivery seam      |
 | `reaper.py`   | `RunReaper` — periodic orphan recovery                                                 |
 | `service.py`  | `RunService` — orchestrates the primitives; the public API                             |
 | `schemas.py`  | `RunResponse`, `RunCreate` — DTOs                                                       |
@@ -138,6 +139,28 @@ finished run replays the whole log including the sentinel.
 Distribution: the shared `runs:queue` means any instance's dispatcher can run any
 run; the per-thread mutex keeps a thread to one active run at a time. Cluster
 capacity = `instances × RUN_WORKER_CONCURRENCY`.
+
+## Push delivery (sources with no client connection)
+
+Most consumers **pull**: an HTTP request rides the event log (`/runs/stream`) and
+can drop without affecting the run. Slack has no client connection to ride, so it
+is **pushed**: the worker spawns a `DeliveryConsumer` that subscribes to the run's
+event log and relays each chunk to the channel.
+
+- A run carries an opaque `delivery` descriptor (`RunRecord.delivery`); `None`
+  means pull. The schema is owned by the channel (Slack writes
+  `{"channel": "slack", "channel_id", "thread_ts", "slack_user_id", "team_id"}`),
+  not by this module — `app/agents/runs` never imports `app/integrations`.
+- The composition root (`main.py`) injects a `DeliveryFactory` into
+  `RunDispatcher` → `RunWorker`. After the run goes `running`, the worker builds a
+  consumer from the record (if the factory returns one) and runs it concurrently
+  with the stream, awaiting it after `finalize` publishes the `end` sentinel.
+- Delivery is best-effort: a consumer crash is logged and never changes the run's
+  terminal status.
+- The Slack consumer (`app/integrations/slack/consumer.py`) parses the canonical
+  LangGraph SSE log via `SlackStreamAdapter`, streams text/tool labels through
+  `chat.startStream`/`appendStream`/`stopStream`, and on the terminal event posts
+  approval blocks (interrupted) or the auxilia link (success).
 
 ## Multitask strategy (per thread)
 

--- a/backend/app/agents/runs/delivery.py
+++ b/backend/app/agents/runs/delivery.py
@@ -1,0 +1,27 @@
+"""Push delivery — the seam between a run and a non-HTTP recipient.
+
+Most runs are *pulled*: an HTTP subscriber rides the event log (`/runs/stream`).
+A push channel (e.g. Slack) has no client connection to ride, so its updates are
+delivered by a worker-side consumer that subscribes to the run's event log and
+relays each chunk to the channel.
+
+This module stays channel-agnostic: it defines the consumer shape and the factory
+type only. The composition root (`main.py`) injects a concrete factory (the Slack
+one), so `app/agents/runs` never imports `app/integrations`.
+"""
+
+from collections.abc import Callable
+from typing import Protocol
+
+from app.agents.runs.state import RunRecord
+
+
+class DeliveryConsumer(Protocol):
+    """Relays a run's event log to a push channel, end to end."""
+
+    async def run(self) -> None: ...
+
+
+# Built once per run from its record; returns `None` when the record has no push
+# delivery (the common case — a pull subscriber handles it instead).
+DeliveryFactory = Callable[[RunRecord], DeliveryConsumer | None]

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -41,12 +41,17 @@ class RunService:
         trigger: str | None = None,
         config_overrides: dict | None = None,
         output_schema: dict | None = None,
+        delivery: dict | None = None,
         multitask_strategy: str = "reject",
     ) -> RunRecord:
         """Create + enqueue a run. Caller has already authorized the thread.
 
         With the default `reject` strategy, creating a run while the thread has an
         active one raises `DomainValidationError`.
+
+        `delivery` is an opaque push-target descriptor (e.g. Slack channel/thread)
+        the worker hands to a delivery consumer; `None` means a pull subscriber
+        rides the event log instead.
         """
         if input is not None and command is not None:
             raise DomainValidationError("Provide either input or command, not both.")
@@ -63,6 +68,7 @@ class RunService:
             trigger=trigger,
             config_overrides=config_overrides,
             output_schema=output_schema,
+            delivery=delivery,
             multitask_strategy=multitask_strategy,
         )
         await self.registry.create(record, ttl=run_settings.ttl_seconds)

--- a/backend/app/agents/runs/state.py
+++ b/backend/app/agents/runs/state.py
@@ -104,6 +104,11 @@ class RunRecord(BaseModel):
     # JSON Schema for a structured final answer (the invoke consumer reads it back).
     output_schema: dict | None = None
 
+    # Opaque push-delivery descriptor. `None` = pull (an HTTP subscriber rides
+    # the event log). A push channel (e.g. Slack) sets it so the worker spawns a
+    # delivery consumer; the schema is owned by that channel, not by this module.
+    delivery: dict | None = None
+
     # Terminal error text, when status is `error`/`timeout`.
     error: str | None = None
 

--- a/backend/app/agents/runs/worker.py
+++ b/backend/app/agents/runs/worker.py
@@ -76,10 +76,19 @@ class RunWorker:
             await delivery  # the sentinel is published; let the consumer finish
 
     def _start_delivery(self, record: RunRecord) -> asyncio.Task | None:
-        """Spawn the push-delivery consumer for this run, if one applies."""
+        """Spawn the push-delivery consumer for this run, if one applies.
+
+        Building the consumer is best-effort: a factory that raises must not abort
+        the run before it executes/finalizes (which would leave the mutex held and
+        the heartbeat orphaned), so failures are logged and treated as no delivery.
+        """
         if self._delivery_factory is None:
             return None
-        consumer = self._delivery_factory(record)
+        try:
+            consumer = self._delivery_factory(record)
+        except Exception:  # noqa: BLE001 — delivery is best-effort
+            logger.exception("Delivery factory failed for run %s", record.id)
+            return None
         if consumer is None:
             return None
         return asyncio.create_task(self._deliver(record.id, consumer))

--- a/backend/app/agents/runs/worker.py
+++ b/backend/app/agents/runs/worker.py
@@ -12,6 +12,7 @@ import logging
 from contextlib import suppress
 
 from app.agents.runs.control import RunControl
+from app.agents.runs.delivery import DeliveryFactory
 from app.agents.runs.events import RunEventStream
 from app.agents.runs.service import RunService
 from app.agents.runs.settings import run_settings
@@ -32,10 +33,11 @@ _ERROR_EVENT_PREFIX = "event: error"
 class RunWorker:
     """Executes a single run end to end."""
 
-    def __init__(self, redis=None):
+    def __init__(self, redis=None, delivery_factory: DeliveryFactory | None = None):
         self.service = RunService(redis)
         self.registry = self.service.registry
         self.redis = self.service.redis
+        self._delivery_factory = delivery_factory
 
     async def run(self, run_id: str) -> None:
         record = await self.registry.get(run_id)
@@ -56,6 +58,10 @@ class RunWorker:
                 poll_seconds=run_settings.cancel_poll_seconds
             )
         )
+        # A push consumer (e.g. Slack) relays the event log concurrently; it reads
+        # from id 0, so there's no race with the chunks we publish below, and it
+        # ends when `finalize` writes the sentinel.
+        delivery = self._start_delivery(record)
         status, error = RunStatus.success, None
         try:
             status, error = await self._execute(record, events, cancel_watch)
@@ -66,6 +72,25 @@ class RunWorker:
             await self._stop(heartbeat)
             await self._stop(cancel_watch)
         await self.service.finalize(run_id, status, error=error)
+        if delivery is not None:
+            await delivery  # the sentinel is published; let the consumer finish
+
+    def _start_delivery(self, record: RunRecord) -> asyncio.Task | None:
+        """Spawn the push-delivery consumer for this run, if one applies."""
+        if self._delivery_factory is None:
+            return None
+        consumer = self._delivery_factory(record)
+        if consumer is None:
+            return None
+        return asyncio.create_task(self._deliver(record.id, consumer))
+
+    @staticmethod
+    async def _deliver(run_id: str, consumer) -> None:
+        """Run a delivery consumer; a delivery failure never fails the run."""
+        try:
+            await consumer.run()
+        except Exception:  # noqa: BLE001 — delivery is best-effort
+            logger.exception("Delivery failed for run %s", run_id)
 
     async def _execute(
         self, record: RunRecord, events: RunEventStream, cancel_watch: asyncio.Task
@@ -169,8 +194,8 @@ class RunDispatcher:
     """Pulls run_ids off the shared queue and runs them, capped at
     `RUN_WORKER_CONCURRENCY` concurrent runs per process."""
 
-    def __init__(self, redis=None):
-        self.worker = RunWorker(redis)
+    def __init__(self, redis=None, delivery_factory: DeliveryFactory | None = None):
+        self.worker = RunWorker(redis, delivery_factory=delivery_factory)
         self.queue = self.worker.service.queue
         self._semaphore = asyncio.Semaphore(run_settings.worker_concurrency)
         self._stopping = asyncio.Event()

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -28,7 +28,6 @@ from app.agents.schemas import AgentResponse
 from app.agents.settings import agent_settings
 from app.agents.stream import (
     LangGraphStreamAdapter,
-    SlackStreamAdapter,
     encode_synthetic_ai_message_sse,
 )
 from app.agents.structured_output import (
@@ -390,7 +389,6 @@ class Agent:
         trigger: str | None = None,
         config_overrides: dict | None = None,
         output_schema: dict | None = None,
-        stream_adapter: str = "langgraph",
     ):
         """Stream using the native LangGraph SSE protocol.
 
@@ -401,7 +399,6 @@ class Agent:
             config_overrides: Optional config dict with configurable overrides.
             output_schema: Optional JSON Schema; when set, the run produces a
                 `structured_response` in its final state (read via `read_run_result`).
-            stream_adapter: Which stream adapter to use ("langgraph" or "slack").
         """
         async with self._setup(
             agent_input, command, trigger, config_overrides, output_schema
@@ -410,33 +407,22 @@ class Agent:
             stream_input,
             config,
         ):
-            if stream_adapter == "slack":
-                langchain_stream = agent.astream(
-                    stream_input,
-                    config=config,
-                    stream_mode=["messages", "values"],
-                )
-                adapter = SlackStreamAdapter()
-            else:
-                langchain_stream = agent.astream(
-                    stream_input,
-                    config=config,
-                    stream_mode=["messages", "values", "updates"],
-                    subgraphs=True,
-                )
-                adapter = LangGraphStreamAdapter(subgraphs=True)
+            langchain_stream = agent.astream(
+                stream_input,
+                config=config,
+                stream_mode=["messages", "values", "updates"],
+                subgraphs=True,
+            )
+            adapter = LangGraphStreamAdapter(subgraphs=True)
 
             try:
                 async for chunk in adapter.stream(langchain_stream):
                     yield chunk
             except GraphRecursionError:
                 ai_msg = await self._persist_recursion_fallback(agent, config)
-                if stream_adapter == "slack":
-                    yield {"type": "text", "content": ai_msg.content}
-                else:
-                    state = await agent.aget_state(config)
-                    for sse in encode_synthetic_ai_message_sse(ai_msg, state.values):
-                        yield sse
+                state = await agent.aget_state(config)
+                for sse in encode_synthetic_ai_message_sse(ai_msg, state.values):
+                    yield sse
 
 
 def extract_invoke_result(

--- a/backend/app/agents/stream.py
+++ b/backend/app/agents/stream.py
@@ -11,50 +11,12 @@ import logging
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
-from langchain_ai_sdk_adapter import to_ui_message_stream
 from langchain_core.messages import BaseMessage
 from langgraph.errors import GraphRecursionError
 from langgraph.types import Overwrite
 
 
 logger = logging.getLogger(__name__)
-
-
-def _normalize_tool_output(output: Any) -> Any:
-    """Normalize tool output to a clean JSON value or string.
-
-    Handles two cases:
-    1. Library-wrapped structured content: {"_text": raw, "structuredContent": {...}}
-       → normalizes the _text value, preserves the wrapper.
-    2. Raw MCP content parts: [{"type": "text", "text": "{...}"}]
-       → extracts the actual value.
-    """
-    if isinstance(output, dict) and "structuredContent" in output:
-        output["_text"] = _normalize_raw_tool_output(output.get("_text"))
-        return output
-    return _normalize_raw_tool_output(output)
-
-
-def _normalize_raw_tool_output(output: Any) -> Any:
-    """Normalize raw MCP tool content to a clean JSON value or string.
-
-    MCP tools via langchain-mcp-adapters return content as a list of
-    content parts like [{"type": "text", "text": "{...}"}]. This extracts
-    the actual value.
-    """
-    if isinstance(output, list) and len(output) > 0:
-        output = output[0]
-    if isinstance(output, dict) and "text" in output:
-        try:
-            return json.loads(output["text"])
-        except (json.JSONDecodeError, TypeError):
-            return output.get("text", output)
-    if isinstance(output, str):
-        try:
-            return json.loads(output)
-        except (json.JSONDecodeError, TypeError):
-            pass
-    return output
 
 
 # ---------------------------------------------------------------------------
@@ -259,128 +221,107 @@ def encode_synthetic_ai_message_sse(
     ]
 
 
-class SlackStreamAdapter:
-    """Converts a LangGraph stream to typed Slack event dicts.
+def _decode_sse_blocks(sse: str) -> list[tuple[str, Any]]:
+    """Parse one published SSE string into `(event, data)` pairs.
 
-    Yields structured dicts:
+    Each chunk in the run event log is `event: <name>\\ndata: <json>\\n\\n`
+    (one event per publish, but we split defensively). Data lines are joined
+    and JSON-decoded; non-JSON data is returned as a raw string.
+    """
+    pairs: list[tuple[str, Any]] = []
+    for block in sse.split("\n\n"):
+        if not block.strip():
+            continue
+        event = ""
+        data_lines: list[str] = []
+        for line in block.splitlines():
+            if line.startswith("event:"):
+                event = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[len("data:") :].strip())
+        if not event:
+            continue
+        raw = "\n".join(data_lines)
+        try:
+            pairs.append((event, json.loads(raw)))
+        except (json.JSONDecodeError, TypeError):
+            pairs.append((event, raw))
+    return pairs
+
+
+def _chunk_text(content: Any) -> str:
+    """Extract streamable text from an AI message chunk's `content`.
+
+    Providers send either a plain string delta or a list of content blocks;
+    only `text` blocks are surfaced (reasoning/other blocks are skipped)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return ""
+
+
+class SlackStreamAdapter:
+    """Adapts the run's LangGraph SSE event log to typed Slack event dicts.
+
+    Reads the same byte-identical SSE the HTTP `/runs/stream` consumer relays
+    (so the worker publishes one canonical format) and yields:
     - {"type": "text", "content": "..."}
     - {"type": "tool_start", "tool_call_id": "...", "tool_name": "..."}
-    - {"type": "tool_end", "tool_call_id": "...", "tool_name": "...", "input": {...}, "output": ...}
-    - {"type": "tool_approval_request", "tool_call_id": "...", "tool_name": "...", "input": {...}}
+    - {"type": "error", "content": "..."}
+    - {"type": "end", "status": "success" | "interrupted" | ...}
+
+    Only top-level (non-namespaced) `messages` events are surfaced — subagent
+    tokens stream under a `messages|<ns>` event and are intentionally skipped.
+    Approval requests are *not* derived here: when an `end` event reports
+    `interrupted`, the consumer reads them from the checkpoint
+    (`pending_approval_requests`), which carries the real tool-call ids.
     """
 
     def __init__(self):
-        self._tool_info: dict[str, dict[str, Any]] = {}
+        self._tools_started: set[str] = set()
 
     async def stream(
-        self, langchain_stream: AsyncIterator[Any]
+        self, sse_stream: AsyncIterator[str]
     ) -> AsyncGenerator[dict[str, Any], None]:
-        try:
-            async for chunk in to_ui_message_stream(langchain_stream):
-                for event in self._process(chunk):
-                    yield event
-        except GraphRecursionError:
-            # Surfaced by the runtime as a synthetic AI message text event.
-            raise
-        except Exception as e:
-            body = getattr(e, "body", None)
-            msg = (body.get("message") if isinstance(body, dict) else None) or str(e)
-            yield {"type": "error", "content": msg}
+        async for sse in sse_stream:
+            for event, data in _decode_sse_blocks(sse):
+                for out in self._process(event, data):
+                    yield out
 
-    def _process(self, chunk: dict[str, Any]) -> list[dict[str, Any]]:
-        event_type = chunk.get("type")
-
-        if event_type == "text-delta":
-            delta = chunk.get("delta", "")
-            if delta:
-                return [{"type": "text", "content": delta}]
-            return []
-
-        if event_type == "tool-input-start":
-            tc_id = chunk.get("toolCallId")
-            tool_name = chunk.get("toolName")
-            if tc_id and tool_name:
-                self._tool_info[tc_id] = {
-                    "name": tool_name,
-                    "input": {},
-                    "args_buffer": "",
-                }
-            return [
-                {
-                    "type": "tool_start",
-                    "tool_call_id": tc_id,
-                    "tool_name": tool_name,
-                }
-            ]
-
-        if event_type == "tool-input-delta":
-            tc_id = chunk.get("toolCallId")
-            args_delta = chunk.get("inputTextDelta", "")
-            if tc_id in self._tool_info and args_delta:
-                self._tool_info[tc_id]["args_buffer"] += args_delta
-            return []
-
-        if event_type == "tool-input-available":
-            tc_id = chunk.get("toolCallId")
-            tool_input = chunk.get("input", {})
-            if tc_id in self._tool_info:
-                self._tool_info[tc_id]["input"] = tool_input
-            return []
-
-        if event_type == "tool-output-available":
-            tc_id = chunk.get("toolCallId")
-            output = _normalize_tool_output(chunk.get("output"))
-            info = self._tool_info.get(tc_id, {})
-            tool_name = info.get("name", "unknown")
-            tool_input = info.get("input", {})
-
-            if not tool_input and info.get("args_buffer"):
-                try:
-                    tool_input = json.loads(info["args_buffer"])
-                except (json.JSONDecodeError, TypeError):
-                    tool_input = {"raw": info["args_buffer"]}
-
-            return [
-                {
-                    "type": "tool_end",
-                    "tool_call_id": tc_id,
-                    "tool_name": tool_name,
-                    "input": tool_input,
-                    "output": output,
-                }
-            ]
-
-        if event_type == "tool-output-error":
-            tc_id = chunk.get("toolCallId")
-            info = self._tool_info.get(tc_id, {})
-            return [
-                {
-                    "type": "tool_end",
-                    "tool_call_id": tc_id,
-                    "tool_name": info.get("name", "unknown"),
-                    "input": info.get("input", {}),
-                    "output": chunk.get("errorText", "Tool execution failed"),
-                }
-            ]
-
-        if event_type == "tool-approval-request":
-            tc_id = chunk.get("toolCallId")
-            info = self._tool_info.get(tc_id, {})
-            return [
-                {
-                    "type": "tool_approval_request",
-                    "tool_call_id": tc_id,
-                    "tool_name": info.get("name", "unknown"),
-                    "input": info.get("input", {}),
-                }
-            ]
-
-        if event_type == "error":
-            return [
-                {
-                    "type": "error",
-                    "content": chunk.get("errorText", "Unknown error"),
-                }
-            ]
-
+    def _process(self, event: str, data: Any) -> list[dict[str, Any]]:
+        if event == "messages":
+            return self._process_message(data)
+        if event == "error":
+            message = data.get("message") if isinstance(data, dict) else str(data)
+            return [{"type": "error", "content": message or "Unknown error"}]
+        if event == "end":
+            status = data.get("status") if isinstance(data, dict) else None
+            return [{"type": "end", "status": status}]
         return []
+
+    def _process_message(self, data: Any) -> list[dict[str, Any]]:
+        """Turn a top-level `messages` event ([chunk, metadata]) into events."""
+        if not isinstance(data, list) or not data:
+            return []
+        chunk = data[0]
+        if not isinstance(chunk, dict):
+            return []
+
+        events: list[dict[str, Any]] = []
+        for tc in chunk.get("tool_call_chunks") or chunk.get("tool_calls") or []:
+            tc_id, name = tc.get("id"), tc.get("name")
+            if tc_id and name and tc_id not in self._tools_started:
+                self._tools_started.add(tc_id)
+                events.append(
+                    {"type": "tool_start", "tool_call_id": tc_id, "tool_name": name}
+                )
+
+        text = _chunk_text(chunk.get("content", ""))
+        if text:
+            events.append({"type": "text", "content": text})
+        return events

--- a/backend/app/integrations/slack/consumer.py
+++ b/backend/app/integrations/slack/consumer.py
@@ -76,23 +76,28 @@ class SlackRunConsumer(DeliveryConsumer):
         )
         adapter = SlackStreamAdapter()
         status: str | None = None
-        async for event in adapter.stream(
-            RunService(self.redis).stream(self.record.id)
-        ):
-            kind = event["type"]
-            if kind == "text":
-                await streamer.append(markdown_text=event["content"])
-            elif kind == "tool_start":
-                await streamer.append(
-                    markdown_text=format_tool_streamer_label(event["tool_name"])
-                )
-            elif kind == "error":
-                await streamer.append(
-                    markdown_text=f"**`Error: {event['content']}`**\n\n"
-                )
-            elif kind == "end":
-                status = event["status"]
-        await streamer.stop()
+        # Always close the streaming message: a transient Redis/SSE or Slack
+        # append error must not leave an in-progress Slack message open, even
+        # though the worker treats delivery as best-effort.
+        try:
+            async for event in adapter.stream(
+                RunService(self.redis).stream(self.record.id)
+            ):
+                kind = event["type"]
+                if kind == "text":
+                    await streamer.append(markdown_text=event["content"])
+                elif kind == "tool_start":
+                    await streamer.append(
+                        markdown_text=format_tool_streamer_label(event["tool_name"])
+                    )
+                elif kind == "error":
+                    await streamer.append(
+                        markdown_text=f"**`Error: {event['content']}`**\n\n"
+                    )
+                elif kind == "end":
+                    status = event["status"]
+        finally:
+            await streamer.stop()
 
         if status == RunStatus.interrupted.value:
             await self._post_approvals(channel_id, thread_ts)

--- a/backend/app/integrations/slack/consumer.py
+++ b/backend/app/integrations/slack/consumer.py
@@ -1,0 +1,138 @@
+"""Worker-side Slack delivery for durable runs.
+
+A Slack turn has no client connection to ride the event log, so the worker spawns
+a `SlackRunConsumer`: it subscribes to the run's SSE event log, relays text and
+tool labels into a Slack streaming message (`chat.startStream`/`appendStream`/
+`stopStream` via `slack_sdk`'s `chat_stream`), and on the terminal event posts
+either the tool-approval blocks (interrupted) or the "View in auxilia" link
+(success). This is the Slack half of the durable runtime — the web tier only
+enqueues the run (see `router.py`).
+"""
+
+import logging
+
+from redis.asyncio import Redis
+from slack_sdk.web.async_client import AsyncWebClient
+
+from app.agents.runs.delivery import DeliveryConsumer
+from app.agents.runs.service import RunService
+from app.agents.runs.state import RunRecord, RunStatus
+from app.agents.stream import SlackStreamAdapter
+from app.auth.settings import auth_settings
+from app.database import AsyncSessionLocal, get_checkpointer
+from app.integrations.slack.blocks import (
+    build_tool_approval_blocks,
+    format_tool_streamer_label,
+)
+from app.integrations.slack.settings import slack_settings
+from app.threads.models import ThreadDB
+from app.threads.serialization import pending_approval_requests
+
+
+logger = logging.getLogger(__name__)
+
+SLACK_CHANNEL = "slack"
+
+
+def build_slack_run_consumer(record: RunRecord) -> "SlackRunConsumer | None":
+    """The `DeliveryFactory` for Slack: build a consumer iff the run is Slack-bound."""
+    delivery = record.delivery
+    if not delivery or delivery.get("channel") != SLACK_CHANNEL:
+        return None
+    return SlackRunConsumer(record)
+
+
+def build_slack_delivery(
+    *, channel_id: str, thread_ts: str, slack_user_id: str, team_id: str | None
+) -> dict:
+    """The opaque delivery descriptor stored on a Slack-bound run."""
+    return {
+        "channel": SLACK_CHANNEL,
+        "channel_id": channel_id,
+        "thread_ts": thread_ts,
+        "slack_user_id": slack_user_id,
+        "team_id": team_id,
+    }
+
+
+class SlackRunConsumer(DeliveryConsumer):
+    """Relays one run's event log to its Slack thread."""
+
+    def __init__(self, record: RunRecord, redis: Redis | None = None):
+        self.record = record
+        self.delivery = record.delivery or {}
+        self.redis = redis
+        self.client = AsyncWebClient(token=slack_settings.slack_bot_token)
+
+    async def run(self) -> None:
+        channel_id = self.delivery["channel_id"]
+        thread_ts = self.delivery["thread_ts"]
+
+        streamer = await self.client.chat_stream(
+            channel=channel_id,
+            thread_ts=thread_ts,
+            recipient_team_id=self.delivery.get("team_id"),
+            recipient_user_id=self.delivery.get("slack_user_id"),
+        )
+        adapter = SlackStreamAdapter()
+        status: str | None = None
+        async for event in adapter.stream(
+            RunService(self.redis).stream(self.record.id)
+        ):
+            kind = event["type"]
+            if kind == "text":
+                await streamer.append(markdown_text=event["content"])
+            elif kind == "tool_start":
+                await streamer.append(
+                    markdown_text=format_tool_streamer_label(event["tool_name"])
+                )
+            elif kind == "error":
+                await streamer.append(
+                    markdown_text=f"**`Error: {event['content']}`**\n\n"
+                )
+            elif kind == "end":
+                status = event["status"]
+        await streamer.stop()
+
+        if status == RunStatus.interrupted.value:
+            await self._post_approvals(channel_id, thread_ts)
+        elif status == RunStatus.success.value:
+            await self._post_auxilia_link(channel_id, thread_ts)
+
+    async def _post_approvals(self, channel_id: str, thread_ts: str) -> None:
+        """Post a Block Kit approve/reject message per pending tool call."""
+        async with get_checkpointer() as checkpointer:
+            checkpoint = await checkpointer.aget_tuple(
+                config={"configurable": {"thread_id": self.record.thread_id}}
+            )
+        for request in pending_approval_requests(checkpoint):
+            blocks = build_tool_approval_blocks(
+                request["tool_call_id"], request["tool_name"], request["input"]
+            )
+            await self.client.chat_postMessage(
+                channel=channel_id,
+                thread_ts=thread_ts,
+                blocks=blocks,
+                text=f"Approve {request['tool_name']}?",
+            )
+
+    async def _post_auxilia_link(self, channel_id: str, thread_ts: str) -> None:
+        """Post a divider + 'View in auxilia' link once the turn finishes cleanly."""
+        async with AsyncSessionLocal() as db:
+            thread = await db.get(ThreadDB, self.record.thread_id)
+        if thread is None:
+            return
+        url = f"{auth_settings.FRONTEND_URL}/agents/{thread.agent_id}/chat/{thread.id}"
+        await self.client.chat_postMessage(
+            channel=channel_id,
+            thread_ts=thread_ts,
+            blocks=[
+                {"type": "divider"},
+                {
+                    "type": "context",
+                    "elements": [
+                        {"type": "mrkdwn", "text": f"<{url}|*View in auxilia*>"}
+                    ],
+                },
+            ],
+        )

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -1,26 +1,27 @@
 # Handlers contain the business logic for each Slack event type.
 #
 # Threads are created when the user picks an agent via the agent picker
-# (triggered by @auxilia mention).  Subsequent messages in that thread
-# are routed to the configured agent.
+# (triggered by @auxilia mention). Subsequent messages in that thread are
+# routed to the configured agent by *enqueuing a durable run* — the web tier
+# never executes the agent itself (see `app/agents/runs/` and `consumer.py`).
+
+import logging
 
 from slack_sdk.web.async_client import AsyncWebClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.agents.core.service import AgentService
-from app.agents.runtime import Agent
+from app.agents.runs.service import RunService
 from app.auth.settings import auth_settings
 from app.database import AsyncSessionLocal
-from app.integrations.slack.blocks import (
-    build_tool_approval_blocks,
-    format_tool_streamer_label,
-)
+from app.exceptions import DomainValidationError
 from app.integrations.slack.commands.chat import (
     build_agent_picker_blocks,
     list_pickable_agents,
     post_agent_picker,
 )
+from app.integrations.slack.consumer import build_slack_delivery
 from app.integrations.slack.models import SlackEvent, SlackInteractionPayload
 from app.integrations.slack.settings import slack_settings
 from app.integrations.slack.utils import get_user_info, resolve_user
@@ -30,108 +31,46 @@ from app.threads.models import ThreadDB
 from app.users.repository import UserRepository
 
 
-async def post_tool_approval_block(
-    client: AsyncWebClient, channel: str, thread_ts: str, ev: dict,
-) -> None:
-    """Post a tool approval request as a Block Kit message with Approve/Reject buttons."""
-    blocks = build_tool_approval_blocks(
-        ev["tool_call_id"], ev["tool_name"], ev["input"])
-    await client.chat_postMessage(
-        channel=channel, thread_ts=thread_ts,
-        blocks=blocks, text=f"Approve {ev['tool_name']}?",
-    )
+logger = logging.getLogger(__name__)
 
 
-async def _stream_and_collect_approvals(
-    agent: Agent,
-    streamer,
+async def _enqueue_slack_run(
     *,
-    agent_input: dict | None = None,
-    command: dict | None = None,
-) -> list[dict]:
-    """Stream the agent response, forwarding text to the streamer.
-
-    Returns a list of ``tool_approval_request`` events collected during
-    the stream (empty when none were emitted).
-    """
-    approval_requests: list[dict] = []
-
-    async for ev in agent.stream(
-        agent_input=agent_input, command=command, stream_adapter="slack",
-    ):
-        if ev["type"] == "text":
-            await streamer.append(markdown_text=ev["content"])
-        elif ev["type"] == "tool_start":
-            await streamer.append(
-                markdown_text=format_tool_streamer_label(ev["tool_name"])
-            )
-        elif ev["type"] == "tool_approval_request":
-            approval_requests.append(ev)
-        elif ev["type"] == "error":
-            await streamer.append(markdown_text=f"**`Error: {ev['content']}`**\n\n")
-
-    await streamer.stop()
-    return approval_requests
-
-
-async def _run_slack_turn(
-    client: AsyncWebClient,
-    thread: ThreadDB,
-    db: AsyncSession,
+    thread_id: str,
+    user_id: str,
     channel_id: str,
-    thread_ts: str,
-    *,
-    recipient_user_id: str,
-    recipient_team_id: str | None = None,
-    agent_input: dict | None = None,
+    slack_user_id: str,
+    team_id: str | None,
+    input: dict | None = None,
     command: dict | None = None,
 ) -> None:
-    """Build the agent runtime, stream the response, and post follow-ups.
+    """Create a durable run for a Slack turn; the worker executes + delivers it.
 
-    Shared by initial messages and HITL resume: opens the chat streamer,
-    runs the agent, then either posts approval blocks for any pending
-    tool calls or the auxilia link when the turn completes cleanly.
+    A duplicate that slips the webhook dedup races the per-thread mutex and is
+    rejected at create time — swallowed here so Slack still gets a clean ack.
     """
-    streamer = await client.chat_stream(
-        channel=channel_id,
-        thread_ts=thread_ts,
-        recipient_team_id=recipient_team_id,
-        recipient_user_id=recipient_user_id,
+    delivery = build_slack_delivery(
+        channel_id=channel_id,
+        thread_ts=thread_id,
+        slack_user_id=slack_user_id,
+        team_id=team_id,
     )
-
-    agent = await Agent.build(thread=thread, db=db)
-    approval_requests = await _stream_and_collect_approvals(
-        agent, streamer, agent_input=agent_input, command=command,
-    )
-
-    for req in approval_requests:
-        await post_tool_approval_block(client, channel_id, thread_ts, req)
-
-    if not approval_requests:
-        await _post_auxilia_link(client, channel_id, thread_ts, thread)
-
-
-async def _post_auxilia_link(
-    client: AsyncWebClient, channel: str, thread_ts: str, thread: ThreadDB,
-) -> None:
-    """Post a divider + 'Open in auxilia' link as a Block Kit message."""
-    url = f"{auth_settings.FRONTEND_URL}/agents/{thread.agent_id}/chat/{thread.id}"
-    await client.chat_postMessage(
-        channel=channel,
-        thread_ts=thread_ts,
-        blocks=[
-            {"type": "divider"},
-            {
-                "type": "context",
-                "elements": [{"type": "mrkdwn", "text": f"<{url}|*View in auxilia*>"}],
-            },
-        ],
-    )
+    try:
+        await RunService().create(
+            thread_id=thread_id,
+            user_id=user_id,
+            input=input,
+            command=command,
+            delivery=delivery,
+        )
+    except DomainValidationError:
+        logger.info("Slack run for thread %s skipped: active run exists", thread_id)
 
 
 # ---------------------------------------------------------------------------
 # Approval-message introspection  (stateless — reads from the thread itself)
 # ---------------------------------------------------------------------------
+
 
 def _is_pending(msg: dict) -> bool:
     """Check if a message still has approval action buttons."""
@@ -192,14 +131,16 @@ def _collect_batch_decisions(thread_messages: list[dict]) -> list[str] | None:
     if any(_is_pending(msg) for msg in batch):
         return None
 
-    commands = [d for msg in batch if (
-        d := _extract_decision(msg)) is not None]
+    commands = [d for msg in batch if (d := _extract_decision(msg)) is not None]
     return commands or None
 
 
 async def _update_approval_message(
-    client: AsyncWebClient, channel_id: str, message_ts: str,
-    blocks: list[dict], approved: bool,
+    client: AsyncWebClient,
+    channel_id: str,
+    message_ts: str,
+    blocks: list[dict],
+    approved: bool,
 ) -> None:
     """Update the approval message: append decision to header, remove buttons, add divider."""
     status_emoji = ":white_check_mark:" if approved else ":no_entry_sign:"
@@ -219,43 +160,26 @@ async def _update_approval_message(
             if elements and elements[0].get("type") == "mrkdwn":
                 block = {
                     **block,
-                    "elements": [{
-                        **elements[0],
-                        "text": f"{elements[0]['text']}  ›  {status_emoji} {status_label}",
-                    }],
+                    "elements": [
+                        {
+                            **elements[0],
+                            "text": f"{elements[0]['text']}  ›  {status_emoji} {status_label}",
+                        }
+                    ],
                 }
         updated_blocks.append(block)
 
     await client.chat_update(
-        channel=channel_id, ts=message_ts,
-        blocks=updated_blocks, text=status_label,
+        channel=channel_id,
+        ts=message_ts,
+        blocks=updated_blocks,
+        text=status_label,
     )
 
 
 # ---------------------------------------------------------------------------
 # Top-level event handlers
 # ---------------------------------------------------------------------------
-
-async def stream_agent_response(
-    thread: ThreadDB,
-    db: AsyncSession,
-    question: str,
-    event: SlackEvent,
-    client: AsyncWebClient,
-    *,
-    team_id: str | None = None,
-) -> None:
-    """Stream an initial agent response to a user message in a Slack thread."""
-    await _run_slack_turn(
-        client=client,
-        thread=thread,
-        db=db,
-        channel_id=event.channel,
-        thread_ts=event.thread_ts or event.ts,
-        recipient_user_id=event.user,
-        recipient_team_id=team_id,
-        agent_input={"messages": [{"type": "human", "content": question}]},
-    )
 
 
 async def handle_assistant_thread_started(event: SlackEvent) -> None:
@@ -274,12 +198,13 @@ async def handle_assistant_thread_started(event: SlackEvent) -> None:
 
     client = AsyncWebClient(token=slack_settings.slack_bot_token)
     await client.assistant_threads_setStatus(
-        channel_id=channel_id, thread_ts=thread_ts, status="is typing...",
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        status="is typing...",
     )
 
     user_info = await get_user_info(slack_user_id)
-    display_name = (
-        user_info.real_name or user_info.name) if user_info else "there"
+    display_name = (user_info.real_name or user_info.name) if user_info else "there"
 
     # Resolve Slack identity → internal user
     user = None
@@ -322,6 +247,7 @@ async def _is_agent_ready(agent_id: str, user_id: str, db: AsyncSession) -> bool
     """Mirror the /is-ready endpoint: return True only when all bound MCP servers
     are connected for this user."""
     from uuid import UUID
+
     agent = await AgentService(db).get(UUID(agent_id))
 
     if not agent.mcp_servers:
@@ -343,7 +269,7 @@ async def _is_agent_ready(agent_id: str, user_id: str, db: AsyncSession) -> bool
 
 
 async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> None:
-    """Route a Slack message to the configured agent for this thread."""
+    """Route a Slack message to the configured agent by enqueuing a durable run."""
     thread_ts = event.thread_ts or event.ts
 
     question = (event.text or "").strip()
@@ -362,7 +288,9 @@ async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> No
         thread = await db.get(ThreadDB, thread_ts)
 
         if not thread:
-            await post_agent_picker(client, event.channel, thread_ts, db, user.id, user_role=user.role)
+            await post_agent_picker(
+                client, event.channel, thread_ts, db, user.id, user_role=user.role
+            )
             return
 
         if not await _is_agent_ready(str(thread.agent_id), str(user.id), db):
@@ -383,7 +311,10 @@ async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> No
                         "elements": [
                             {
                                 "type": "button",
-                                "text": {"type": "plain_text", "text": "Connect on auxilia"},
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "Connect on auxilia",
+                                },
                                 "url": connect_url,
                                 "style": "primary",
                             }
@@ -394,7 +325,9 @@ async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> No
             return
 
         await client.assistant_threads_setStatus(
-            channel_id=event.channel, thread_ts=thread_ts, status="is typing...",
+            channel_id=event.channel,
+            thread_ts=thread_ts,
+            status="is typing...",
         )
 
         # Set the Slack thread title to the first real user message.
@@ -407,17 +340,22 @@ async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> No
                 title=question[:255],
             )
 
-        await stream_agent_response(
-            thread, db, question, event, client, team_id=team_id,
-        )
+    await _enqueue_slack_run(
+        thread_id=thread_ts,
+        user_id=str(user.id),
+        channel_id=event.channel,
+        slack_user_id=event.user,
+        team_id=team_id,
+        input={"messages": [{"type": "human", "content": question}]},
+    )
 
 
 async def handle_interaction(payload: SlackInteractionPayload) -> None:
     """Handle a Slack block_actions interaction (Approve/Reject buttons).
 
     Uses ``conversations.replies`` to derive approval state from the thread
-    itself — no external state store needed.  The agent is only resumed
-    once every pending tool call has been decided.
+    itself — no external state store needed. The agent is resumed (via a new
+    durable run) only once every pending tool call has been decided.
     """
     if not payload.actions:
         return
@@ -437,7 +375,11 @@ async def handle_interaction(payload: SlackInteractionPayload) -> None:
     if message_ts:
         original_blocks = payload.message.blocks if payload.message else []
         await _update_approval_message(
-            client, channel_id, message_ts, original_blocks, approved,
+            client,
+            channel_id,
+            message_ts,
+            original_blocks,
+            approved,
         )
 
     # Check whether the latest batch of approvals is fully decided
@@ -445,8 +387,8 @@ async def handle_interaction(payload: SlackInteractionPayload) -> None:
     if commands is None:
         return
 
-    # All decided — resume the agent
-    await _resume_agent(client, payload.user.id, channel_id, thread_ts, commands)
+    # All decided — resume the agent via a new run
+    await _resume_agent(client, payload, channel_id, thread_ts, commands)
 
 
 def _extract_interaction_context(
@@ -454,8 +396,10 @@ def _extract_interaction_context(
 ) -> tuple[str | None, str | None, str | None]:
     """Extract channel_id, thread_ts, and message_ts from an interaction payload."""
     channel_id = (
-        payload.channel.id if payload.channel
-        else payload.container.channel_id if payload.container
+        payload.channel.id
+        if payload.channel
+        else payload.container.channel_id
+        if payload.container
         else None
     )
     thread_ts = payload.container.thread_ts if payload.container else None
@@ -464,11 +408,14 @@ def _extract_interaction_context(
 
 
 async def _fetch_and_resolve_decisions(
-    client: AsyncWebClient, channel_id: str, thread_ts: str,
+    client: AsyncWebClient,
+    channel_id: str,
+    thread_ts: str,
 ) -> list[str] | None:
     """Fetch thread replies and return decisions if the latest batch is complete."""
     result = await client.conversations_replies(
-        channel=channel_id, ts=thread_ts,
+        channel=channel_id,
+        ts=thread_ts,
     )
     thread_messages = result.get("messages", [])
     return _collect_batch_decisions(thread_messages)
@@ -476,31 +423,32 @@ async def _fetch_and_resolve_decisions(
 
 async def _resume_agent(
     client: AsyncWebClient,
-    slack_user_id: str,
+    payload: SlackInteractionPayload,
     channel_id: str,
     thread_ts: str,
     commands: list[str],
 ) -> None:
-    """Look up the thread, build the agent runtime, and resume with *commands*."""
-    user = await resolve_user(slack_user_id)
+    """Look up the thread and enqueue a HITL-resume run with *commands*."""
+    user = await resolve_user(payload.user.id)
     if not user:
         return
 
     async with AsyncSessionLocal() as db:
         thread = await db.get(ThreadDB, thread_ts)
-        if not thread:
-            return
+    if not thread:
+        return
 
-        await client.assistant_threads_setStatus(
-            channel_id=channel_id, thread_ts=thread_ts, status="is typing...",
-        )
+    await client.assistant_threads_setStatus(
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        status="is typing...",
+    )
 
-        await _run_slack_turn(
-            client=client,
-            thread=thread,
-            db=db,
-            channel_id=channel_id,
-            thread_ts=thread_ts,
-            recipient_user_id=slack_user_id,
-            command={"resume": {"decisions": [{"type": cmd} for cmd in commands]}},
-        )
+    await _enqueue_slack_run(
+        thread_id=thread_ts,
+        user_id=str(user.id),
+        channel_id=channel_id,
+        slack_user_id=payload.user.id,
+        team_id=(payload.team or {}).get("id"),
+        command={"resume": {"decisions": [{"type": cmd} for cmd in commands]}},
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.exceptions import (
     NotFoundError,
     PermissionDeniedError,
 )
+from app.integrations.slack.consumer import build_slack_run_consumer
 from app.integrations.slack.router import router as slack_router
 from app.invites.router import router as invites_router
 from app.mcp.apps.router import router as mcp_apps_router
@@ -64,7 +65,7 @@ async def lifespan(app: FastAPI):
     dispatcher: RunDispatcher | None = None
     reaper: RunReaper | None = None
     if run_settings.dispatcher_enabled:
-        dispatcher = RunDispatcher()
+        dispatcher = RunDispatcher(delivery_factory=build_slack_run_consumer)
         reaper = RunReaper()
         background = [
             asyncio.create_task(dispatcher.run(), name="run-dispatcher"),

--- a/backend/app/threads/serialization.py
+++ b/backend/app/threads/serialization.py
@@ -117,6 +117,79 @@ def pending_interrupt(checkpoint_tuple: Any) -> Any | None:
     return None
 
 
+def pending_approval_requests(checkpoint_tuple: Any) -> list[dict[str, Any]]:
+    """Return the tool calls awaiting human approval on a paused checkpoint.
+
+    `HumanInTheLoopMiddleware` interrupts with a `HITLRequest` whose
+    `action_requests` carry only `name`/`args` (no id), and resume `decisions`
+    are positional. We re-attach each request to the originating tool call (by
+    name+args, falling back to position) so callers get a stable
+    `tool_call_id` for the approve/reject UI. Returns `[]` when not interrupted.
+    """
+    interrupt_value = pending_interrupt(checkpoint_tuple)
+    requests = (
+        (interrupt_value or {}).get("action_requests")
+        if (isinstance(interrupt_value, dict))
+        else None
+    )
+    if not requests:
+        return []
+
+    channel_values = getattr(checkpoint_tuple, "checkpoint", {}).get(
+        "channel_values", {}
+    )
+    tool_calls = _last_pending_tool_calls(channel_values.get("messages", []))
+
+    approvals: list[dict[str, Any]] = []
+    used: set[int] = set()
+    for index, request in enumerate(requests):
+        match = _match_tool_call(request, tool_calls, used)
+        approvals.append(
+            {
+                "tool_call_id": (match or {}).get("id") or f"approval-{index}",
+                "tool_name": request.get("name", "unknown"),
+                "input": request.get("args", {}),
+            }
+        )
+    return approvals
+
+
+def _last_pending_tool_calls(messages: list) -> list[dict[str, Any]]:
+    """Tool calls on the last AI message that have no result yet."""
+    resulted = {
+        getattr(m, "tool_call_id", None) for m in messages if isinstance(m, ToolMessage)
+    }
+    for msg in reversed(messages):
+        tool_calls = getattr(msg, "tool_calls", None)
+        if tool_calls:
+            return [tc for tc in tool_calls if tc.get("id") not in resulted]
+    return []
+
+
+def _match_tool_call(
+    request: dict, tool_calls: list[dict], used: set[int]
+) -> dict | None:
+    """Find the unused tool call for an action request.
+
+    Prefers an exact name+args match; falls back to the first unused call with
+    the same name (covers two calls to the same tool with identical args).
+    """
+    candidates = [
+        (i, tc)
+        for i, tc in enumerate(tool_calls)
+        if i not in used and tc.get("name") == request.get("name")
+    ]
+    if not candidates:
+        return None
+    for i, tc in candidates:
+        if tc.get("args") == request.get("args"):
+            used.add(i)
+            return tc
+    i, tc = candidates[0]
+    used.add(i)
+    return tc
+
+
 def deserialize_to_ui_messages(langgraph_messages: list) -> list[Message]:
     """Convert LangGraph checkpoint messages to auxilia UI messages.
 

--- a/backend/tests/agents/runs/test_worker.py
+++ b/backend/tests/agents/runs/test_worker.py
@@ -148,6 +148,72 @@ async def test_worker_forwards_output_schema_to_agent(redis, monkeypatch):
     assert captured.get("output_schema") == schema
 
 
+@pytest.mark.usefixtures("patch_agent")
+async def test_worker_invokes_delivery_consumer_for_delivery_records(redis):
+    seen: list[str] = []
+
+    class _Consumer:
+        def __init__(self, record):
+            self.record = record
+
+        async def run(self):
+            # The sentinel is published by finalize before the worker awaits us,
+            # so a real consumer would drain the log here.
+            seen.append(self.record.id)
+
+    def factory(record):
+        return _Consumer(record) if record.delivery else None
+
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="td1",
+        user_id="u1",
+        input={"messages": []},
+        delivery={"channel": "slack", "channel_id": "C"},
+    )
+    await RunWorker(redis, delivery_factory=factory).run(record.id)
+
+    assert seen == [record.id]
+    assert (await service.get(record.id)).status == RunStatus.success
+
+
+@pytest.mark.usefixtures("patch_agent")
+async def test_worker_skips_delivery_for_plain_records(redis):
+    seen: list[str] = []
+
+    def factory(record):
+        seen.append(record.id)  # called, but returns None for pull runs
+        return None
+
+    service = RunService(redis)
+    record = await service.create(thread_id="td2", user_id="u1", input={"messages": []})
+    await RunWorker(redis, delivery_factory=factory).run(record.id)
+
+    assert (await service.get(record.id)).status == RunStatus.success
+
+
+@pytest.mark.usefixtures("patch_agent")
+async def test_worker_succeeds_when_delivery_consumer_crashes(redis):
+    class _BoomConsumer:
+        def __init__(self, record):
+            pass
+
+        async def run(self):
+            raise RuntimeError("delivery boom")
+
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="td3",
+        user_id="u1",
+        input={"messages": []},
+        delivery={"channel": "slack"},
+    )
+    await RunWorker(redis, delivery_factory=_BoomConsumer).run(record.id)
+
+    # Delivery is best-effort: a crash must not change the run's terminal status.
+    assert (await service.get(record.id)).status == RunStatus.success
+
+
 async def test_create_rejects_when_thread_has_active_run(redis):
     service = RunService(redis)
     await service.registry.claim_active("t9", "other-run", ttl=30)

--- a/backend/tests/agents/runs/test_worker.py
+++ b/backend/tests/agents/runs/test_worker.py
@@ -193,6 +193,25 @@ async def test_worker_skips_delivery_for_plain_records(redis):
 
 
 @pytest.mark.usefixtures("patch_agent")
+async def test_worker_succeeds_when_delivery_factory_raises(redis):
+    def factory(_record):
+        raise RuntimeError("factory boom")
+
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="td4",
+        user_id="u1",
+        input={"messages": []},
+        delivery={"channel": "slack"},
+    )
+    await RunWorker(redis, delivery_factory=factory).run(record.id)
+
+    # A factory crash must not abort the run before finalize/cleanup.
+    assert (await service.get(record.id)).status == RunStatus.success
+    assert await service.get_active("td4") is None
+
+
+@pytest.mark.usefixtures("patch_agent")
 async def test_worker_succeeds_when_delivery_consumer_crashes(redis):
     class _BoomConsumer:
         def __init__(self, record):

--- a/backend/tests/agents/test_stream.py
+++ b/backend/tests/agents/test_stream.py
@@ -1,16 +1,20 @@
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 
-from app.agents.stream import SlackStreamAdapter
+from app.agents.stream import LangGraphStreamAdapter, SlackStreamAdapter
 
 
 # ── Fixtures: LangGraph astream(stream_mode=["messages", "values"]) tuples ──
+#
+# The worker publishes LangGraph-native SSE to the run event log; the Slack
+# consumer reads that same SSE back. So these tests drive the fixtures through
+# `LangGraphStreamAdapter` (worker side) and feed the resulting SSE strings into
+# `SlackStreamAdapter` (consumer side) — exercising the real wire boundary.
 
 
 def _make_text_stream_events():
     """Simple text conversation: model streams 'Hello! How can I assist you today?'"""
     msg_id = "lc_run--019cd8c3-7104-7173-9361-b7f162dfa28c"
 
-    # messages mode: streaming AIMessageChunks
     yield (
         "messages",
         (
@@ -27,27 +31,22 @@ def _make_text_stream_events():
             ),
         )
 
-    # values mode: full state snapshot
     yield (
         "values",
         {
             "messages": [
                 HumanMessage(content="hi", id="user-msg-1"),
-                AIMessage(
-                    content="Hello! How can I assist you today?",
-                    id=msg_id,
-                ),
+                AIMessage(content="Hello! How can I assist you today?", id=msg_id),
             ]
         },
     )
 
 
 def _make_tool_call_stream_events():
-    """Tool call: model calls 'get_weather' tool, then responds with text."""
+    """Tool call: model calls 'get_weather', then responds with text."""
     ai_msg_id = "ai-msg-1"
     tool_call_id = "call_abc123"
 
-    # Step 1: Model streams tool call chunks
     yield (
         "messages",
         (
@@ -55,7 +54,12 @@ def _make_tool_call_stream_events():
                 content="",
                 id=ai_msg_id,
                 tool_call_chunks=[
-                    {"id": tool_call_id, "name": "get_weather", "args": '{"city":', "index": 0}
+                    {
+                        "id": tool_call_id,
+                        "name": "get_weather",
+                        "args": '{"city":',
+                        "index": 0,
+                    }
                 ],
             ),
             {"langgraph_step": 1, "langgraph_node": "model"},
@@ -74,60 +78,17 @@ def _make_tool_call_stream_events():
             {"langgraph_step": 1, "langgraph_node": "model"},
         ),
     )
-
-    # Values after model step: includes tool call in full message
-    yield (
-        "values",
-        {
-            "messages": [
-                HumanMessage(content="weather in Paris?", id="user-msg-1"),
-                AIMessage(
-                    content="",
-                    id=ai_msg_id,
-                    tool_calls=[
-                        {"id": tool_call_id, "name": "get_weather", "args": {"city": "Paris"}}
-                    ],
-                ),
-            ]
-        },
-    )
-
-    # Step 2: Tool output arrives
     yield (
         "messages",
         (
             ToolMessage(
-                content='{"temperature": 22, "unit": "celsius"}',
+                content='{"temperature": 22}',
                 tool_call_id=tool_call_id,
                 id="tool-msg-1",
             ),
             {"langgraph_step": 2, "langgraph_node": "tools"},
         ),
     )
-
-    # Values after tool step
-    yield (
-        "values",
-        {
-            "messages": [
-                HumanMessage(content="weather in Paris?", id="user-msg-1"),
-                AIMessage(
-                    content="",
-                    id=ai_msg_id,
-                    tool_calls=[
-                        {"id": tool_call_id, "name": "get_weather", "args": {"city": "Paris"}}
-                    ],
-                ),
-                ToolMessage(
-                    content='{"temperature": 22, "unit": "celsius"}',
-                    tool_call_id=tool_call_id,
-                    id="tool-msg-1",
-                ),
-            ]
-        },
-    )
-
-    # Step 3: Model responds with text
     yield (
         "messages",
         (
@@ -136,65 +97,72 @@ def _make_tool_call_stream_events():
         ),
     )
 
-    # Final values
-    yield (
-        "values",
-        {
-            "messages": [
-                HumanMessage(content="weather in Paris?", id="user-msg-1"),
-                AIMessage(
-                    content="",
-                    id=ai_msg_id,
-                    tool_calls=[
-                        {"id": tool_call_id, "name": "get_weather", "args": {"city": "Paris"}}
-                    ],
-                ),
-                ToolMessage(
-                    content='{"temperature": 22, "unit": "celsius"}',
-                    tool_call_id=tool_call_id,
-                    id="tool-msg-1",
-                ),
-                AIMessage(content="The weather in Paris is 22°C.", id="ai-msg-2"),
-            ]
-        },
-    )
-
 
 async def _async_gen(events):
     for event in events:
         yield event
 
 
-# ── Slack adapter tests ──────────────────────────────────────────────
+async def _to_sse(events):
+    """Run worker-side LangGraph fixtures through the SSE encoder."""
+    async for sse in LangGraphStreamAdapter(subgraphs=False).stream(_async_gen(events)):
+        yield sse
+
+
+async def _collect(adapter_stream):
+    return [event async for event in adapter_stream]
+
+
+# ── Slack adapter tests (SSE event log → typed Slack events) ─────────────
 
 
 async def test_slack_text_stream():
-    """Slack adapter yields text events."""
-    adapter = SlackStreamAdapter()
-    events = []
-    async for event in adapter.stream(_async_gen(_make_text_stream_events())):
-        events.append(event)
+    """Text deltas in the messages SSE become Slack text events."""
+    events = await _collect(
+        SlackStreamAdapter().stream(_to_sse(_make_text_stream_events()))
+    )
 
     text_events = [e for e in events if e["type"] == "text"]
-    assert len(text_events) > 0
-    full_text = "".join(e["content"] for e in text_events)
-    assert "Hello" in full_text
+    assert text_events
+    assert "Hello" in "".join(e["content"] for e in text_events)
 
 
-async def test_slack_tool_events():
-    """Slack adapter yields tool_start and tool_end events with enriched info."""
-    adapter = SlackStreamAdapter()
-    events = []
-    async for event in adapter.stream(_async_gen(_make_tool_call_stream_events())):
-        events.append(event)
+async def test_slack_tool_start_emitted_once():
+    """A streamed tool call yields a single tool_start with the tool name."""
+    events = await _collect(
+        SlackStreamAdapter().stream(_to_sse(_make_tool_call_stream_events()))
+    )
 
-    types = [e["type"] for e in events]
-    assert "tool_start" in types
-    assert "tool_end" in types
+    tool_starts = [e for e in events if e["type"] == "tool_start"]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["tool_name"] == "get_weather"
+    assert tool_starts[0]["tool_call_id"] == "call_abc123"
+    # The consumer derives approvals from the checkpoint, not the stream.
+    assert all(e["type"] != "tool_approval_request" for e in events)
 
-    tool_start = next(e for e in events if e["type"] == "tool_start")
-    assert tool_start["tool_name"] == "get_weather"
 
-    tool_end = next(e for e in events if e["type"] == "tool_end")
-    assert tool_end["tool_name"] == "get_weather"
-    assert tool_end["output"] is not None
+async def test_slack_end_event_carries_status():
+    """The terminal sentinel is surfaced as an `end` event with its status."""
+    sentinel = 'event: end\ndata: {"status": "interrupted"}\n\n'
+    events = await _collect(SlackStreamAdapter().stream(_async_gen([sentinel])))
+
+    assert events == [{"type": "end", "status": "interrupted"}]
+
+
+async def test_slack_error_event():
+    """An error SSE becomes a Slack error event with the message."""
+    err = 'event: error\ndata: {"message": "boom", "status_code": 500}\n\n'
+    events = await _collect(SlackStreamAdapter().stream(_async_gen([err])))
+
+    assert events == [{"type": "error", "content": "boom"}]
+
+
+async def test_slack_subagent_messages_are_skipped():
+    """Namespaced (subagent) messages events are not streamed to Slack."""
+    ns = (
+        "event: messages|tools:abc\n"
+        'data: [{"type": "AIMessageChunk", "content": "secret", "id": "x"}, {}]\n\n'
+    )
+    events = await _collect(SlackStreamAdapter().stream(_async_gen([ns])))
+
+    assert events == []

--- a/backend/tests/integrations/slack/test_consumer.py
+++ b/backend/tests/integrations/slack/test_consumer.py
@@ -1,0 +1,148 @@
+"""Tests for the worker-side Slack delivery consumer."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import app.integrations.slack.consumer as consumer_mod
+from app.agents.runs.state import RunRecord
+from app.integrations.slack.consumer import (
+    SlackRunConsumer,
+    build_slack_delivery,
+    build_slack_run_consumer,
+)
+
+
+def _record(delivery=None) -> RunRecord:
+    return RunRecord(id="r1", thread_id="t1", user_id="u1", delivery=delivery)
+
+
+def _slack_delivery() -> dict:
+    return build_slack_delivery(
+        channel_id="C1", thread_ts="t1", slack_user_id="U1", team_id="T1"
+    )
+
+
+class _FakeStreamer:
+    def __init__(self):
+        self.appended: list[str] = []
+        self.stopped = False
+        self.kwargs: dict = {}
+
+    async def append(self, markdown_text: str):
+        self.appended.append(markdown_text)
+
+    async def stop(self):
+        self.stopped = True
+
+
+class _FakeClient:
+    def __init__(self):
+        self.streamer = _FakeStreamer()
+        self.posts: list[dict] = []
+
+    async def chat_stream(self, **kwargs):
+        self.streamer.kwargs = kwargs
+        return self.streamer
+
+    async def chat_postMessage(self, **kwargs):
+        self.posts.append(kwargs)
+
+
+def _sse_stream(*chunks):
+    async def _gen(*_args, **_kwargs):
+        for chunk in chunks:
+            yield chunk
+
+    return _gen
+
+
+# ── Factory ──────────────────────────────────────────────────────────
+
+
+def test_factory_skips_non_slack_runs():
+    assert build_slack_run_consumer(_record(None)) is None
+    assert build_slack_run_consumer(_record({"channel": "web"})) is None
+
+
+def test_factory_builds_for_slack_runs():
+    consumer = build_slack_run_consumer(_record(_slack_delivery()))
+    assert isinstance(consumer, SlackRunConsumer)
+
+
+# ── Delivery behavior ──────────────────────────────────────────────────
+
+
+async def test_consumer_streams_text_and_posts_link_on_success(monkeypatch):
+    monkeypatch.setattr(
+        consumer_mod.RunService,
+        "stream",
+        _sse_stream(
+            'event: messages\ndata: [{"type": "AIMessageChunk", "content": "Hi", "id": "a"}, {}]\n\n',
+            'event: end\ndata: {"status": "success"}\n\n',
+        ),
+    )
+
+    @asynccontextmanager
+    async def _session():
+        yield SimpleNamespace(
+            get=lambda model, pk: _async(SimpleNamespace(id="t1", agent_id="agent-1"))
+        )
+
+    monkeypatch.setattr(consumer_mod, "AsyncSessionLocal", _session)
+
+    consumer = SlackRunConsumer(_record(_slack_delivery()))
+    fake = _FakeClient()
+    consumer.client = fake
+    await consumer.run()
+
+    assert "Hi" in "".join(fake.streamer.appended)
+    assert fake.streamer.stopped
+    assert any("View in auxilia" in str(p["blocks"]) for p in fake.posts)
+    # Streaming targets the right Slack thread/recipient.
+    assert fake.streamer.kwargs["channel"] == "C1"
+    assert fake.streamer.kwargs["recipient_user_id"] == "U1"
+
+
+async def test_consumer_posts_approval_blocks_on_interrupt(monkeypatch):
+    monkeypatch.setattr(
+        consumer_mod.RunService,
+        "stream",
+        _sse_stream('event: end\ndata: {"status": "interrupted"}\n\n'),
+    )
+
+    @asynccontextmanager
+    async def _checkpointer():
+        yield SimpleNamespace(aget_tuple=lambda config: _async(None))
+
+    monkeypatch.setattr(consumer_mod, "get_checkpointer", _checkpointer)
+    monkeypatch.setattr(
+        consumer_mod,
+        "pending_approval_requests",
+        lambda _cp: [
+            {
+                "tool_call_id": "call_1",
+                "tool_name": "get_weather",
+                "input": {"city": "Paris"},
+            }
+        ],
+    )
+
+    consumer = SlackRunConsumer(_record(_slack_delivery()))
+    fake = _FakeClient()
+    consumer.client = fake
+    await consumer.run()
+
+    assert fake.streamer.stopped
+    assert len(fake.posts) == 1
+    action_ids = [
+        el.get("action_id")
+        for block in fake.posts[0]["blocks"]
+        if block.get("type") == "actions"
+        for el in block.get("elements", [])
+    ]
+    assert "tool_approve" in action_ids
+    assert "tool_reject" in action_ids
+
+
+async def _async(value):
+    return value

--- a/backend/tests/integrations/slack/test_handlers.py
+++ b/backend/tests/integrations/slack/test_handlers.py
@@ -1,0 +1,80 @@
+"""Tests for the thin Slack web tier — turns enqueue durable runs."""
+
+from types import SimpleNamespace
+
+import app.integrations.slack.handlers as handlers_mod
+from app.exceptions import DomainValidationError
+
+
+def _patch_run_service(monkeypatch, *, raises: Exception | None = None):
+    """Replace RunService with a recorder; returns the captured create kwargs."""
+    captured: dict = {}
+
+    class _FakeRunService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def create(self, **kwargs):
+            if raises is not None:
+                raise raises
+            captured.update(kwargs)
+            return SimpleNamespace(id="run-1")
+
+    monkeypatch.setattr(handlers_mod, "RunService", _FakeRunService)
+    return captured
+
+
+async def test_enqueue_builds_slack_delivery_and_passes_input(monkeypatch):
+    captured = _patch_run_service(monkeypatch)
+
+    await handlers_mod._enqueue_slack_run(
+        thread_id="t1",
+        user_id="u1",
+        channel_id="C1",
+        slack_user_id="U1",
+        team_id="T1",
+        input={"messages": [{"type": "human", "content": "hi"}]},
+    )
+
+    assert captured["thread_id"] == "t1"
+    assert captured["user_id"] == "u1"
+    assert captured["input"] == {"messages": [{"type": "human", "content": "hi"}]}
+    assert captured["command"] is None
+    assert captured["delivery"] == {
+        "channel": "slack",
+        "channel_id": "C1",
+        "thread_ts": "t1",
+        "slack_user_id": "U1",
+        "team_id": "T1",
+    }
+
+
+async def test_enqueue_passes_resume_command(monkeypatch):
+    captured = _patch_run_service(monkeypatch)
+
+    await handlers_mod._enqueue_slack_run(
+        thread_id="t1",
+        user_id="u1",
+        channel_id="C1",
+        slack_user_id="U1",
+        team_id=None,
+        command={"resume": {"decisions": [{"type": "approve"}]}},
+    )
+
+    assert captured["command"] == {"resume": {"decisions": [{"type": "approve"}]}}
+    assert captured["input"] is None
+
+
+async def test_enqueue_swallows_active_run_conflict(monkeypatch):
+    _patch_run_service(monkeypatch, raises=DomainValidationError("active run"))
+
+    # A duplicate that loses the per-thread mutex race must not raise — the
+    # webhook still needs to ack cleanly.
+    await handlers_mod._enqueue_slack_run(
+        thread_id="t1",
+        user_id="u1",
+        channel_id="C1",
+        slack_user_id="U1",
+        team_id=None,
+        input={"messages": []},
+    )

--- a/backend/tests/threads/test_serialization.py
+++ b/backend/tests/threads/test_serialization.py
@@ -1,5 +1,9 @@
+from types import SimpleNamespace
+
 from langchain_ai_sdk_adapter import to_lc_messages
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.threads.serialization import pending_approval_requests
 
 
 async def test_to_lc_messages():
@@ -10,3 +14,54 @@ async def test_to_lc_messages():
     assert len(langchain_messages) == 1
     assert isinstance(langchain_messages[0], HumanMessage)
     assert langchain_messages[0].content == "Lorem ipsum"
+
+
+def _checkpoint(interrupt_value, messages):
+    """A minimal checkpoint tuple: `pending_writes` + `checkpoint.channel_values`."""
+    pending_writes = (
+        [("task-1", "__interrupt__", [SimpleNamespace(value=interrupt_value)])]
+        if interrupt_value is not None
+        else []
+    )
+    return SimpleNamespace(
+        pending_writes=pending_writes,
+        checkpoint={"channel_values": {"messages": messages}},
+    )
+
+
+def test_pending_approval_requests_maps_action_requests_to_tool_call_ids():
+    ai = AIMessage(
+        content="",
+        tool_calls=[{"id": "call_1", "name": "get_weather", "args": {"city": "Paris"}}],
+    )
+    interrupt_value = {
+        "action_requests": [
+            {"name": "get_weather", "args": {"city": "Paris"}, "description": "review"}
+        ],
+        "review_configs": [
+            {"action_name": "get_weather", "allowed_decisions": ["approve"]}
+        ],
+    }
+
+    out = pending_approval_requests(_checkpoint(interrupt_value, [ai]))
+
+    assert out == [
+        {
+            "tool_call_id": "call_1",
+            "tool_name": "get_weather",
+            "input": {"city": "Paris"},
+        }
+    ]
+
+
+def test_pending_approval_requests_empty_when_not_interrupted():
+    assert pending_approval_requests(_checkpoint(None, [])) == []
+
+
+def test_pending_approval_requests_synthesizes_id_without_match():
+    # Interrupt with no matching tool call still yields a usable approval entry.
+    interrupt_value = {"action_requests": [{"name": "send_email", "args": {}}]}
+    out = pending_approval_requests(_checkpoint(interrupt_value, []))
+    assert out == [
+        {"tool_call_id": "approval-0", "tool_name": "send_email", "input": {}}
+    ]


### PR DESCRIPTION
## Summary

Slack was the **last in-process LLM-generation path** — the only source not on the shared run-create flow (chat-stream and invoke already are). This routes Slack turns through `RunService.create` so the webhook acks within Slack's window and does **no** agent execution, and the durable runtime owns queue-leveling, recovery, and HITL resume. Completes the "every source on the shared create flow" goal and unblocks the web/worker split (#148).

Closes #149.

## What changed

**Generic push delivery (runs stays channel-agnostic)**
- `RunRecord.delivery` — an opaque push-target descriptor (`None` = pull, the HTTP-subscriber default) + `RunService.create(delivery=…)`. The schema is owned by the channel; `app/agents/runs` never imports `app/integrations`.
- New `runs/delivery.py` seam: a `DeliveryConsumer` protocol + `DeliveryFactory` type. `main.py` (the composition root) injects the Slack factory into `RunDispatcher` → `RunWorker`, which runs the consumer **concurrently** with the stream and awaits it after `finalize` publishes the `end` sentinel. Delivery is best-effort — a consumer crash is logged and never changes the run's terminal status.

**Slack SSE consumer + re-homed adapter (the issue's "pragmatic" path)**
- `SlackStreamAdapter` now parses the canonical LangGraph SSE event log (text deltas + tool-start labels) instead of the raw `astream`; the dead `stream_adapter="slack"` branch in `runtime.py` is removed.
- New `SlackRunConsumer` (`integrations/slack/consumer.py`) drives `client.chat_stream` (`chat.startStream`/`appendStream`/`stopStream`) and, on the terminal event, posts approval blocks (interrupted) or the "View in auxilia" link (success).
- `pending_approval_requests` (in `threads/serialization.py`) maps the positional `HITLRequest.action_requests` (which carry no tool-call id) back to the originating tool calls, giving the approval UI stable ids.

**Thin web tier**
- `/events` → `RunService.create(input=…, delivery=…)` then ack; approve/reject → `RunService.create(command={"resume": …})`. No `Agent.build`/`Agent.stream` in the web process. A duplicate that loses the per-thread mutex race is swallowed so Slack still gets a clean ack.

## On Bolt
We **don't** need Slack Bolt — we already use `slack_sdk`'s `chat_stream`, which wraps the 2025/26 streaming methods. The assistant + streaming surface is plain REST; Bolt's only real value-add (its `Assistant` middleware and thread-context store) would sit awkwardly next to FastAPI. Staying on raw HTTP + `slack_sdk`.

## Acceptance criteria
- [x] Slack turns create a durable run; the webhook acks within Slack's deadline and does no agent execution.
- [x] A worker-side consumer delivers the run to Slack (streamed updates).
- [x] HITL approve/reject resumes via `RunService.create(command=…)`.
- [x] No `Agent.build`/`Agent.stream` in the web process for Slack.

## Testing
- `SlackStreamAdapter`: SSE event log → typed Slack events (text, tool_start, error, end, subagent-skip).
- `SlackRunConsumer`: streams text + posts the auxilia link on success; posts approve/reject blocks on interrupt.
- `RunWorker`: `delivery_factory` invoked for delivery-bearing records, skipped for pull runs, and a consumer crash leaves the run `success`.
- Slack handlers: enqueue builds the delivery descriptor / resume command and swallows the active-run conflict.
- `pending_approval_requests` mapping.

**279 passed**, `ruff` clean. SPEC.md documents the new push-delivery seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Slack turns through the durable run runtime so webhooks ack fast and do no in-process agent work. Adds a push-delivery seam with a Slack consumer that streams updates and handles HITL; makes delivery fully best-effort.

- **New Features**
  - Push delivery: `RunRecord.delivery` + `RunService.create(delivery=…)`; worker builds a consumer via `DeliveryFactory` and runs it alongside execution.
  - Slack delivery: `SlackRunConsumer` reads LangGraph SSE via `SlackStreamAdapter`, drives `chat_stream`, posts approval blocks on interrupt, and a “View in auxilia” link on success.
  - HITL: approve/reject resumes via `RunService.create(command=…)`.

- **Bug Fixes**
  - Delivery is fully best-effort: worker catches delivery-factory errors and consumer crashes without affecting finalization or the thread mutex (adds regression tests).
  - Slack streaming messages are always closed in a `finally` to avoid dangling streams on Redis/Slack errors; SPEC example corrected.

<sup>Written for commit 1cdba16d70f413f9b53dca47b47367ebe9fbeade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

