### PR TITLE
fix(slack): durable-delivery follow-ups (tool output, errors, HITL header)

### DIFF
--- a/backend/app/agents/stream.py
+++ b/backend/app/agents/stream.py
@@ -311,6 +311,12 @@ class SlackStreamAdapter:
         chunk = data[0]
         if not isinstance(chunk, dict):
             return []
+        # `stream_mode="messages"` yields every node's messages, including the
+        # `ToolMessage` from the tools node whose `content` is the raw tool-result
+        # payload. Only AI output is user-facing text / tool calls — surfacing a
+        # ToolMessage's content would dump the raw tool result into the chat.
+        if chunk.get("type") not in ("AIMessageChunk", "ai", "AIMessage"):
+            return []
 
         events: list[dict[str, Any]] = []
         for tc in chunk.get("tool_call_chunks") or chunk.get("tool_calls") or []:

--- a/backend/app/integrations/slack/blocks.py
+++ b/backend/app/integrations/slack/blocks.py
@@ -64,26 +64,31 @@ def format_tool_streamer_label(tool_name: str) -> str:
     return f"\n\n:{prefix.lower()}:  **{prefix}**  ›  `{suffix}`\n\n"
 
 
-def _tool_context_block(tool_name: str) -> dict:
-    """Build the context block header for a tool name."""
+def _tool_header_block(tool_name: str) -> dict:
+    """Build the section header for a tool name.
+
+    A `section` (not a `context`) block so the approval card's tool header
+    renders at the same body size as the streamed `format_tool_streamer_label`
+    — a `context` block renders smaller/greyer and looked inconsistent.
+    """
     prefix, suffix = _split_tool_name(tool_name)
     return {
-        "type": "context",
-        "elements": [
-            {
-                "type": "mrkdwn",
-                "text": f":{prefix}:  *{prefix}*  ›  `{suffix}`",
-            }
-        ],
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f":{prefix}:  *{prefix}*  ›  `{suffix}`",
+        },
     }
 
 
 def build_tool_approval_blocks(
-    tool_call_id: str, tool_name: str, tool_input: dict,
+    tool_call_id: str,
+    tool_name: str,
+    tool_input: dict,
 ) -> list[dict]:
     """Build Block Kit blocks for a tool approval request with Approve/Reject buttons."""
     return [
-        _tool_context_block(tool_name),
+        _tool_header_block(tool_name),
         {
             "type": "section",
             "text": {"type": "mrkdwn", "text": _format_tool_input(tool_input)},

--- a/backend/app/integrations/slack/consumer.py
+++ b/backend/app/integrations/slack/consumer.py
@@ -67,7 +67,42 @@ class SlackRunConsumer(DeliveryConsumer):
     async def run(self) -> None:
         channel_id = self.delivery["channel_id"]
         thread_ts = self.delivery["thread_ts"]
+        logger.info(
+            "Slack delivery starting for run %s (channel=%s, thread_ts=%s)",
+            self.record.id,
+            channel_id,
+            thread_ts,
+        )
+        try:
+            status, text_chars = await self._stream_to_slack(channel_id, thread_ts)
+        except Exception:  # noqa: BLE001 — never leave the thread silent
+            logger.exception("Slack delivery crashed for run %s", self.record.id)
+            await self._post_failure_notice(channel_id, thread_ts)
+            return
 
+        logger.info(
+            "Slack delivery for run %s ended: status=%s text_chars=%s",
+            self.record.id,
+            status,
+            text_chars,
+        )
+        if status == RunStatus.interrupted.value:
+            await self._post_approvals(channel_id, thread_ts)
+        elif status == RunStatus.success.value:
+            await self._post_auxilia_link(channel_id, thread_ts)
+        elif status in (RunStatus.error.value, RunStatus.timeout.value):
+            await self._post_failure_notice(channel_id, thread_ts)
+
+    async def _stream_to_slack(
+        self, channel_id: str, thread_ts: str
+    ) -> tuple[str | None, int]:
+        """Relay the event log into a Slack streaming message.
+
+        Returns the run's terminal status and how many characters of text were
+        streamed (0 is the tell-tale of an empty/never-answered turn). Always
+        closes the streaming message — a mid-stream error must not leave an
+        in-progress Slack message open.
+        """
         streamer = await self.client.chat_stream(
             channel=channel_id,
             thread_ts=thread_ts,
@@ -76,15 +111,14 @@ class SlackRunConsumer(DeliveryConsumer):
         )
         adapter = SlackStreamAdapter()
         status: str | None = None
-        # Always close the streaming message: a transient Redis/SSE or Slack
-        # append error must not leave an in-progress Slack message open, even
-        # though the worker treats delivery as best-effort.
+        text_chars = 0
         try:
             async for event in adapter.stream(
                 RunService(self.redis).stream(self.record.id)
             ):
                 kind = event["type"]
                 if kind == "text":
+                    text_chars += len(event["content"])
                     await streamer.append(markdown_text=event["content"])
                 elif kind == "tool_start":
                     await streamer.append(
@@ -98,11 +132,18 @@ class SlackRunConsumer(DeliveryConsumer):
                     status = event["status"]
         finally:
             await streamer.stop()
+        return status, text_chars
 
-        if status == RunStatus.interrupted.value:
-            await self._post_approvals(channel_id, thread_ts)
-        elif status == RunStatus.success.value:
-            await self._post_auxilia_link(channel_id, thread_ts)
+    async def _post_failure_notice(self, channel_id: str, thread_ts: str) -> None:
+        """Tell the user the turn failed, so the thread is never left blank."""
+        await self.client.chat_postMessage(
+            channel=channel_id,
+            thread_ts=thread_ts,
+            text=(
+                "Sorry — something went wrong while generating a response. "
+                "Please try again."
+            ),
+        )
 
     async def _post_approvals(self, channel_id: str, thread_ts: str) -> None:
         """Post a Block Kit approve/reject message per pending tool call."""

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -84,16 +84,20 @@ def _is_pending(msg: dict) -> bool:
 
 
 def _extract_decision(msg: dict) -> str | None:
-    """Extract the decision from a decided approval message."""
+    """Extract the decision from a decided approval message.
+
+    The decision is appended to the tool-header `section` block (the first
+    section of the approval card); only that block carries the status emoji.
+    """
     for block in msg.get("blocks", []):
-        if block.get("type") != "context":
+        if block.get("type") != "section":
             continue
-        for el in block.get("elements", []):
-            text = el.get("text", "")
-            if ":white_check_mark:" in text:
-                return "approve"
-            if ":no_entry_sign:" in text:
-                return "reject"
+        text = (block.get("text") or {}).get("text", "")
+        if ":white_check_mark:" in text:
+            return "approve"
+        if ":no_entry_sign:" in text:
+            return "reject"
+        return None  # only the first (header) section carries the decision
     return None
 
 
@@ -147,25 +151,28 @@ async def _update_approval_message(
     status_label = "Approved" if approved else "Rejected"
 
     updated_blocks: list[dict] = []
+    header_done = False
     for block in blocks:
         if block.get("type") == "actions":
             continue
 
-        if block.get("type") == "context" and not any(
-            status in el.get("text", "")
-            for el in block.get("elements", [])
-            for status in (":white_check_mark:", ":no_entry_sign:")
+        # The tool-header section is the first mrkdwn section; append the
+        # decision there (and never to the input section that follows it).
+        text_obj = block.get("text") or {}
+        if (
+            not header_done
+            and block.get("type") == "section"
+            and text_obj.get("type") == "mrkdwn"
         ):
-            elements = block.get("elements", [])
-            if elements and elements[0].get("type") == "mrkdwn":
+            header_done = True
+            text = text_obj.get("text", "")
+            if ":white_check_mark:" not in text and ":no_entry_sign:" not in text:
                 block = {
                     **block,
-                    "elements": [
-                        {
-                            **elements[0],
-                            "text": f"{elements[0]['text']}  ›  {status_emoji} {status_label}",
-                        }
-                    ],
+                    "text": {
+                        **text_obj,
+                        "text": f"{text}  ›  {status_emoji} {status_label}",
+                    },
                 }
         updated_blocks.append(block)
 

--- a/backend/tests/agents/test_stream.py
+++ b/backend/tests/agents/test_stream.py
@@ -140,6 +140,24 @@ async def test_slack_tool_start_emitted_once():
     # The consumer derives approvals from the checkpoint, not the stream.
     assert all(e["type"] != "tool_approval_request" for e in events)
 
+    # The model's final answer streams as text...
+    streamed = "".join(e["content"] for e in events if e["type"] == "text")
+    assert "The weather in Paris is 22°C." in streamed
+    # ...but the raw tool-result ToolMessage must NOT be dumped as text.
+    assert "temperature" not in streamed
+
+
+async def test_slack_tool_message_content_is_not_streamed():
+    """A ToolMessage in the messages stream is not surfaced as assistant text."""
+    tool_sse = (
+        "event: messages\n"
+        'data: [{"type": "tool", "content": "{\\"secret\\": 42}", '
+        '"id": "tm-1", "tool_call_id": "call_1"}, {}]\n\n'
+    )
+    events = await _collect(SlackStreamAdapter().stream(_async_gen([tool_sse])))
+
+    assert events == []
+
 
 async def test_slack_end_event_carries_status():
     """The terminal sentinel is surfaced as an `end` event with its status."""

--- a/backend/tests/integrations/slack/test_consumer.py
+++ b/backend/tests/integrations/slack/test_consumer.py
@@ -144,5 +144,37 @@ async def test_consumer_posts_approval_blocks_on_interrupt(monkeypatch):
     assert "tool_reject" in action_ids
 
 
+async def test_consumer_posts_failure_notice_on_error(monkeypatch):
+    monkeypatch.setattr(
+        consumer_mod.RunService,
+        "stream",
+        _sse_stream('event: end\ndata: {"status": "error"}\n\n'),
+    )
+
+    consumer = SlackRunConsumer(_record(_slack_delivery()))
+    fake = _FakeClient()
+    consumer.client = fake
+    await consumer.run()
+
+    assert fake.streamer.stopped
+    assert len(fake.posts) == 1
+    assert "something went wrong" in fake.posts[0]["text"].lower()
+
+
+async def test_consumer_posts_failure_notice_when_stream_crashes(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("redis gone")
+
+    monkeypatch.setattr(consumer_mod.RunService, "stream", _boom)
+
+    consumer = SlackRunConsumer(_record(_slack_delivery()))
+    fake = _FakeClient()
+    consumer.client = fake
+    # A crash mid-delivery is handled: the thread gets a notice, not silence.
+    await consumer.run()
+
+    assert any("something went wrong" in p["text"].lower() for p in fake.posts)
+
+
 async def _async(value):
     return value

--- a/backend/tests/integrations/slack/test_handlers.py
+++ b/backend/tests/integrations/slack/test_handlers.py
@@ -4,6 +4,44 @@ from types import SimpleNamespace
 
 import app.integrations.slack.handlers as handlers_mod
 from app.exceptions import DomainValidationError
+from app.integrations.slack.blocks import build_tool_approval_blocks
+from app.integrations.slack.handlers import _extract_decision
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.updated: dict = {}
+
+    async def chat_update(self, **kwargs):
+        self.updated = kwargs
+
+
+def _header_text(blocks: list[dict]) -> str:
+    return next(b["text"]["text"] for b in blocks if b.get("type") == "section")
+
+
+async def test_approval_header_is_a_section_block():
+    # The tool header must be a body-size section, not a small context block,
+    # so it matches the streamed tool label.
+    blocks = build_tool_approval_blocks("call_1", "BigQuery_execute_sql", {"a": 1})
+    assert blocks[0]["type"] == "section"
+    assert all(b.get("type") != "context" for b in blocks)
+
+
+async def test_approval_decision_round_trips_through_section_header():
+    blocks = build_tool_approval_blocks("call_1", "BigQuery_execute_sql", {"a": 1})
+    msg = {"blocks": blocks}
+    # Pending: no decision yet, buttons present.
+    assert _extract_decision(msg) is None
+
+    client = _RecordingClient()
+    await handlers_mod._update_approval_message(client, "C1", "111.1", blocks, True)
+    updated = client.updated["blocks"]
+
+    # Decision lands on the header section; the input section is untouched.
+    assert ":white_check_mark:" in _header_text(updated)
+    assert not any(b.get("type") == "actions" for b in updated)
+    assert _extract_decision({"blocks": updated}) == "approve"
 
 
 def _patch_run_service(monkeypatch, *, raises: Exception | None = None):


### PR DESCRIPTION
## Summary

Follow-up fixes to the durable Slack runtime (#161), gathered after that PR merged. Each addresses inconsistent Slack replies observed in real use.

- **Stop streaming non-AI messages.** In `stream_mode="messages"`, LangGraph yields messages from every node — including the `ToolMessage` from the tools node, whose `content` is the raw tool-result JSON. The adapter was relaying that as assistant text (dumping raw JSON into the thread), and the oversized `chat.appendStream` could error and kill the stream before the model's real answer. Now only AI-message chunks yield text/tool_start.
- **Surface run errors/timeouts.** A run that finalizes `error`/`timeout` from an exception publishes no `error` SSE — only the `end` sentinel — so the consumer used to go completely silent. It now posts a failure notice (and logs the delivery lifecycle: terminal status + streamed text length, the tell-tale of an empty turn).
- **Make push delivery fully best-effort.** A delivery-factory exception was raised before the worker's try/finalize, which could leak the heartbeat/mutex and leave a run stuck `running`; it's now caught. The Slack stream is always closed in a `finally`.
- **HITL approval header sizing.** The approval card's tool header was a Block Kit `context` block (small/grey); it's now a `section` block so it matches the streamed tool label. The decision marker round-trips through that section.

## Testing

Adds/updates tests: adapter skips ToolMessage text + streams the final answer; consumer posts a failure notice on error and on a mid-delivery crash; worker stays `success` when the delivery factory raises; approval header is a section and the approve/reject decision round-trips. Full suite green (285), `ruff` clean.

## Note

Pure follow-up to #161 (already released via #162); no release-artifact changes here. A `fix(slack):` commit, so release-please will cut a patch on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack durable delivery to only stream model output, show a clear failure notice on errors/timeouts, and align the HITL approval header with streamed labels. This prevents raw tool JSON in threads, avoids stuck streams, and makes approvals clearer.

- **Bug Fixes**
  - Stream only model messages (`AIMessage*`); skip `ToolMessage` content to avoid dumping tool-result JSON and oversized appends.
  - Post a failure notice when a run ends `error`/`timeout` or the stream crashes; log terminal status and streamed text length; never leave the thread blank.
  - Always close the Slack stream in `finally` and catch delivery-factory exceptions to keep runs from sticking in `running`.
  - Update approval UI: tool header is a `section` block (not `context`) to match streamed labels; approval decision is appended to that header and parsed from it.

<sup>Written for commit 88cf81bdb6a53690d540c71b40f56db5c42d416b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

