### PR TITLE
fix(slack): de-duplicate HITL tool header; keep quote bar on multi-line args

### DIFF
--- a/backend/app/integrations/slack/blocks.py
+++ b/backend/app/integrations/slack/blocks.py
@@ -3,6 +3,16 @@
 from typing import Any
 
 
+def _quote_lines(lines: list[str]) -> str:
+    """Join entries as a Slack blockquote, prefixing *every physical line*.
+
+    An entry may itself span several lines (a multi-line value like formatted
+    SQL, or an already-quoted nested block), so we split on newlines before
+    prefixing — otherwise the quote bar drops off after the first line.
+    """
+    return "\n".join(f"> {physical}" for line in lines for physical in line.split("\n"))
+
+
 def _format_tool_input(obj: Any, indent: int = 0) -> str:
     """Convert a JSON-compatible object into a clean YAML-like string."""
 
@@ -30,7 +40,7 @@ def _format_tool_input(obj: Any, indent: int = 0) -> str:
             else:
                 lines.append("  " * indent + "- " + str(item))
 
-        return "\n".join(f"> {line}" for line in lines)
+        return _quote_lines(lines)
 
     if isinstance(obj, dict):
         if not obj:
@@ -43,7 +53,7 @@ def _format_tool_input(obj: Any, indent: int = 0) -> str:
             else:
                 val_str = _format_tool_input(value, 0).strip()
                 lines.append("  " * indent + "*" + key + "*: " + val_str)
-        return "\n".join(f"> {line}" for line in lines)
+        return _quote_lines(lines)
 
     return "  " * indent + str(obj)
 
@@ -64,31 +74,17 @@ def format_tool_streamer_label(tool_name: str) -> str:
     return f"\n\n:{prefix.lower()}:  **{prefix}**  ›  `{suffix}`\n\n"
 
 
-def _tool_header_block(tool_name: str) -> dict:
-    """Build the section header for a tool name.
-
-    A `section` (not a `context`) block so the approval card's tool header
-    renders at the same body size as the streamed `format_tool_streamer_label`
-    — a `context` block renders smaller/greyer and looked inconsistent.
-    """
-    prefix, suffix = _split_tool_name(tool_name)
-    return {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": f":{prefix}:  *{prefix}*  ›  `{suffix}`",
-        },
-    }
-
-
 def build_tool_approval_blocks(
     tool_call_id: str,
-    tool_name: str,
     tool_input: dict,
 ) -> list[dict]:
-    """Build Block Kit blocks for a tool approval request with Approve/Reject buttons."""
+    """Build Block Kit blocks for a tool approval request with Approve/Reject buttons.
+
+    The tool name is intentionally *not* repeated here: the streamed tool label
+    (`format_tool_streamer_label`) already shows it immediately above this card,
+    so a header would be redundant.
+    """
     return [
-        _tool_header_block(tool_name),
         {
             "type": "section",
             "text": {"type": "mrkdwn", "text": _format_tool_input(tool_input)},

--- a/backend/app/integrations/slack/consumer.py
+++ b/backend/app/integrations/slack/consumer.py
@@ -153,7 +153,7 @@ class SlackRunConsumer(DeliveryConsumer):
             )
         for request in pending_approval_requests(checkpoint):
             blocks = build_tool_approval_blocks(
-                request["tool_call_id"], request["tool_name"], request["input"]
+                request["tool_call_id"], request["input"]
             )
             await self.client.chat_postMessage(
                 channel=channel_id,

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -86,18 +86,17 @@ def _is_pending(msg: dict) -> bool:
 def _extract_decision(msg: dict) -> str | None:
     """Extract the decision from a decided approval message.
 
-    The decision is appended to the tool-header `section` block (the first
-    section of the approval card); only that block carries the status emoji.
+    The decision lives in the `context` block that `_update_approval_message`
+    swaps in for the buttons; that block is the only one carrying the status emoji.
     """
     for block in msg.get("blocks", []):
-        if block.get("type") != "section":
+        if block.get("type") != "context":
             continue
-        text = (block.get("text") or {}).get("text", "")
+        text = " ".join(el.get("text", "") for el in block.get("elements", []))
         if ":white_check_mark:" in text:
             return "approve"
         if ":no_entry_sign:" in text:
             return "reject"
-        return None  # only the first (header) section carries the decision
     return None
 
 
@@ -146,35 +145,25 @@ async def _update_approval_message(
     blocks: list[dict],
     approved: bool,
 ) -> None:
-    """Update the approval message: append decision to header, remove buttons, add divider."""
+    """Record the decision: drop the buttons and append a status context block.
+
+    The card no longer carries a tool-name header (the streamed label above it
+    already shows it), so the decision marker lives in its own `context` block.
+    That block is load-bearing, not cosmetic: the stateless batch-resume logic
+    (`_extract_decision`) recovers each card's decision by reading this emoji
+    back from the thread.
+    """
     status_emoji = ":white_check_mark:" if approved else ":no_entry_sign:"
     status_label = "Approved" if approved else "Rejected"
 
-    updated_blocks: list[dict] = []
-    header_done = False
-    for block in blocks:
-        if block.get("type") == "actions":
-            continue
-
-        # The tool-header section is the first mrkdwn section; append the
-        # decision there (and never to the input section that follows it).
-        text_obj = block.get("text") or {}
-        if (
-            not header_done
-            and block.get("type") == "section"
-            and text_obj.get("type") == "mrkdwn"
-        ):
-            header_done = True
-            text = text_obj.get("text", "")
-            if ":white_check_mark:" not in text and ":no_entry_sign:" not in text:
-                block = {
-                    **block,
-                    "text": {
-                        **text_obj,
-                        "text": f"{text}  ›  {status_emoji} {status_label}",
-                    },
-                }
-        updated_blocks.append(block)
+    marker = {
+        "type": "context",
+        "elements": [{"type": "mrkdwn", "text": f"{status_emoji} {status_label}"}],
+    }
+    # Replace the Approve/Reject buttons in place with the decision marker, so it
+    # sits where the buttons were (above the trailing divider). A card that's
+    # already decided has no actions block to replace, so it's left untouched.
+    updated_blocks = [marker if b.get("type") == "actions" else b for b in blocks]
 
     await client.chat_update(
         channel=channel_id,

--- a/backend/tests/integrations/slack/test_handlers.py
+++ b/backend/tests/integrations/slack/test_handlers.py
@@ -16,20 +16,25 @@ class _RecordingClient:
         self.updated = kwargs
 
 
-def _header_text(blocks: list[dict]) -> str:
-    return next(b["text"]["text"] for b in blocks if b.get("type") == "section")
+def _context_text(blocks: list[dict]) -> str:
+    return " ".join(
+        el.get("text", "")
+        for b in blocks
+        if b.get("type") == "context"
+        for el in b.get("elements", [])
+    )
 
 
-async def test_approval_header_is_a_section_block():
-    # The tool header must be a body-size section, not a small context block,
-    # so it matches the streamed tool label.
-    blocks = build_tool_approval_blocks("call_1", "BigQuery_execute_sql", {"a": 1})
-    assert blocks[0]["type"] == "section"
+async def test_approval_card_has_no_tool_header():
+    # The streamed tool label already shows the tool name above the card, so the
+    # card must not repeat it — and a pending card carries no decision marker.
+    blocks = build_tool_approval_blocks("call_1", {"a": 1})
     assert all(b.get("type") != "context" for b in blocks)
+    assert any(b.get("type") == "actions" for b in blocks)
 
 
-async def test_approval_decision_round_trips_through_section_header():
-    blocks = build_tool_approval_blocks("call_1", "BigQuery_execute_sql", {"a": 1})
+async def test_approval_decision_round_trips_through_context_block():
+    blocks = build_tool_approval_blocks("call_1", {"a": 1})
     msg = {"blocks": blocks}
     # Pending: no decision yet, buttons present.
     assert _extract_decision(msg) is None
@@ -38,8 +43,8 @@ async def test_approval_decision_round_trips_through_section_header():
     await handlers_mod._update_approval_message(client, "C1", "111.1", blocks, True)
     updated = client.updated["blocks"]
 
-    # Decision lands on the header section; the input section is untouched.
-    assert ":white_check_mark:" in _header_text(updated)
+    # Decision lands in a context block; the buttons are gone.
+    assert ":white_check_mark:" in _context_text(updated)
     assert not any(b.get("type") == "actions" for b in updated)
     assert _extract_decision({"blocks": updated}) == "approve"
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "0.4.7"
+version = "0.4.10"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15306,6 +15306,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,


### PR DESCRIPTION
## Problem

In Slack threads, an HITL tool call rendered **twice**: the streamed tool label
(`format_tool_streamer_label`) showed the server + tool name, and the approval
card posted right below repeated the same header. The web frontend doesn't have
this because it renders a single mutable tool element per `tool_call_id` whose
state transitions through approval — Slack has two separate, non-addressable
surfaces.

A second, smaller issue: when a tool argument was multi-line (e.g. formatted
SQL), the blockquote bar only covered the first line and dropped off the rest.

## Changes

- **Drop the redundant header from the approval card.** The streamed label above
  is now the single tool identity. `build_tool_approval_blocks` emits just the
  input section + Approve/Reject buttons + divider; `_tool_header_block` and the
  unused `tool_name` param are removed.
- **Keep the decision marker, relocated.** The status emoji is load-bearing: the
  stateless batch-resume reconstructs each card's decision by reading it back
  from the thread (`_extract_decision`). It now lives in a `context` block that
  **replaces the buttons in place** (above the divider) once a decision is made.
- **Quote bar extends across multi-line values.** New `_quote_lines` helper
  prefixes `>` to every physical line, fixing multi-line SQL args (and multi-line
  nested objects as a bonus).

| Before | After |
| --- | --- |
| streamed label + card both show `BigQuery › execute_sql_readonly` | label shows it once; card is args + buttons |
| `query: SELECT …` quoted, `FROM …`/`WHERE …` unquoted | whole query quoted |

## Notes

- The visible status placement is intentionally minimal (small grey context
  line) — easy to restyle/relocate later. It can't be dropped entirely without
  breaking resume.
- Only affects newly-posted cards; in-flight cards from before deploy still
  carry their decision in the old header section (short-lived).

## Test plan

- `uv run pytest tests/integrations/slack/` — 18 passed.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the duplicate HITL tool header in Slack approval cards so the streamed label is the single tool identity, and fix multi-line argument quoting so the quote bar spans all lines. The decision marker now lives in a `context` block that replaces the buttons, preserving stateless resume.

- **Bug Fixes**
  - Approval card no longer renders a tool-name header; now shows input + Approve/Reject + divider. Removed `_tool_header_block`, dropped the unused `tool_name` param, and updated the call site.
  - Decision emoji is stored in a `context` block that replaces the buttons; `_extract_decision` reads it from there.
  - Quote bar prefixes every physical line via `_quote_lines`, fixing multi-line SQL and nested values.

- **Dependencies**
  - Updated lock files: `backend/uv.lock` (bumped `backend` to `0.4.10`) and `web/package-lock.json` (marks `fsevents` as dev).

<sup>Written for commit 9734b96a42a537d3b274225d9e5fa4e3650fc16f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

