### PR TITLE
feat(web): show subagent avatars in agent card footer

### DIFF
--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowRight, Pencil } from "lucide-react";
 import { Agent, AgentPermission } from "@/types/agents";
-import { agentPastel } from "@/lib/colors";
+import { agentPastel, agentColorBackground } from "@/lib/colors";
 import { useMcpServersStore } from "@/stores/mcp-servers-store";
 import ArchivedAgentDialog from "@/app/(protected)/agents/components/archived-agent-dialog";
 import AgentDialogShell from "@/app/(protected)/agents/components/agent-dialog-shell";
@@ -158,9 +158,9 @@ export default function AgentCard({
 					{agent.description || "No description provided."}
 				</p>
 
-				{/* Meta — real MCP server icons */}
-				{resolvedServers.length > 0 && (
-					<div className="flex items-center border-t border-[#edf2ef] dark:border-white/5 py-2.5">
+				{/* Meta — MCP server icons (left) · subagents (right) */}
+				{(resolvedServers.length > 0 || agent.subagents?.length > 0) && (
+					<div className="flex items-center justify-between border-t border-[#edf2ef] dark:border-white/5 py-2.5">
 						<div className="flex items-center">
 							{resolvedServers.map((server) => (
 								<span
@@ -182,6 +182,38 @@ export default function AgentCard({
 								</span>
 							))}
 						</div>
+						{agent.subagents?.length > 0 && (
+							<div className="flex items-center">
+								{agent.subagents.slice(0, 4).map((sub) => (
+									<span
+										key={sub.id}
+										title={sub.name}
+										style={
+											sub.color
+												? {
+														background: agentColorBackground(sub.color),
+														border: `1px solid ${sub.color}18`,
+													}
+												: undefined
+										}
+										className="-ml-1.5 flex size-5 items-center justify-center rounded-full border border-[#e1ebe6] bg-surface text-[13px] leading-none first:ml-0 dark:border-white/10 dark:bg-white/5"
+									>
+										{sub.emoji || "🤖"}
+									</span>
+								))}
+								{agent.subagents.length > 4 && (
+									<span
+										title={agent.subagents
+											.slice(4)
+											.map((s) => s.name)
+											.join(", ")}
+										className="-ml-1.5 flex size-5 items-center justify-center rounded-full border border-[#e1ebe6] bg-surface text-[9px] font-semibold text-[#7d8077] first:ml-0 dark:border-white/10 dark:bg-white/5 dark:text-muted-foreground"
+									>
+										+{agent.subagents.length - 4}
+									</span>
+								)}
+							</div>
+						)}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
## What

Surface an agent's bound subagents directly on its card. The footer now shows MCP server icons on the left and subagent avatars on the right end.

## Details

- Subagents render as overlapping circular avatars (same 20px size as the MCP icons), using each subagent's `emoji` over its `color` gradient background (`agentColorBackground`), matching the existing `AgentAvatar` styling.
- Limited to **4 avatars**; any beyond that collapse into a `+N` overflow pill.
- **Hover tooltips**: each avatar shows the subagent's name; the `+N` pill lists the remaining names.
- The footer now appears when an agent has MCP servers **or** subagents (previously MCP-only).

## Screenshots

_(UI change — footer right side)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show subagent avatars in the agent card footer so users can see linked subagents at a glance. Avatars appear on the right, opposite MCP server icons.

- **New Features**
  - Footer shows when an agent has MCP servers or subagents.
  - Up to 4 overlapping 20px subagent avatars using emoji over `agentColorBackground`.
  - `+N` overflow pill for extras; hover shows names for each avatar and the overflow.

<sup>Written for commit 0d7c441dfe9fc11da5f3ed854bf304e0c46af2d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

