### PR TITLE
feat: teams for agent access

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -27,7 +27,8 @@ if database_url:
 # Import all models here for Alembic to detect them
 from app.mcp.servers.models import MCPServerDB  # noqa: F401
 from app.users.models import UserDB  # noqa: F401
-from app.agents.models import AgentDB, AgentMCPServerDB, AgentSubagentDB, AgentUserPermissionDB  # noqa: F401
+from app.agents.models import AgentDB, AgentMCPServerDB, AgentSubagentDB, AgentTeamDB, AgentUserPermissionDB  # noqa: F401
+from app.teams.models import TeamDB  # noqa: F401
 from app.threads.models import ThreadDB  # noqa: F401
 from app.invites.models import InviteDB  # noqa: F401
 from app.auth.tokens.models import PersonalAccessTokenDB  # noqa: F401

--- a/backend/alembic/versions/f3c2b1a09d8e_add_teams.py
+++ b/backend/alembic/versions/f3c2b1a09d8e_add_teams.py
@@ -1,0 +1,70 @@
+"""add teams
+
+Revision ID: f3c2b1a09d8e
+Revises: e4f5a6b7c8d9
+Create Date: 2026-06-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f3c2b1a09d8e'
+down_revision: Union[str, Sequence[str], None] = 'e4f5a6b7c8d9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'teams',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('color', sa.String(length=7), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_teams_name'), 'teams', ['name'], unique=True)
+
+    op.create_table(
+        'agent_teams',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('agent_id', sa.Uuid(), nullable=False),
+        sa.Column('team_id', sa.Uuid(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(['agent_id'], ['agents.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['team_id'], ['teams.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('agent_id', 'team_id', name='uq_agent_team'),
+    )
+
+    op.add_column('users', sa.Column('team_id', sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        'fk_users_team_id_teams', 'users', 'teams', ['team_id'], ['id'],
+        ondelete='SET NULL',
+    )
+
+    op.add_column('invites', sa.Column('team_id', sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        'fk_invites_team_id_teams', 'invites', 'teams', ['team_id'], ['id'],
+        ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('fk_invites_team_id_teams', 'invites', type_='foreignkey')
+    op.drop_column('invites', 'team_id')
+
+    op.drop_constraint('fk_users_team_id_teams', 'users', type_='foreignkey')
+    op.drop_column('users', 'team_id')
+
+    op.drop_table('agent_teams')
+    op.drop_index(op.f('ix_teams_name'), table_name='teams')
+    op.drop_table('teams')

--- a/backend/alembic/versions/f3c2b1a09d8e_add_teams.py
+++ b/backend/alembic/versions/f3c2b1a09d8e_add_teams.py
@@ -43,6 +43,9 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('agent_id', 'team_id', name='uq_agent_team'),
     )
+    # The unique constraint leads with agent_id; team-grant lookups and the
+    # team-delete cascade filter by team_id, so index that column too.
+    op.create_index(op.f('ix_agent_teams_team_id'), 'agent_teams', ['team_id'], unique=False)
 
     op.add_column('users', sa.Column('team_id', sa.Uuid(), nullable=True))
     op.create_foreign_key(

--- a/backend/app/agents/core/repository.py
+++ b/backend/app/agents/core/repository.py
@@ -6,6 +6,7 @@ from sqlmodel import select
 from app.agents.models import (
     AgentDB,
     AgentMCPServerDB,
+    AgentTeamDB,
     AgentUserPermissionDB,
 )
 from app.agents.schemas import AgentPermissionCreate
@@ -22,25 +23,35 @@ class AgentRepository(BaseRepository[AgentDB]):
         *,
         user_id: UUID | None,
         user_role: WorkspaceRole | None,
+        user_team_id: UUID | None = None,
         agent_id: UUID | None = None,
         include_archived: bool = False,
         archived_only: bool = False,
     ) -> list:
-        """Join agent ↔ MCP links ↔ user permission in one shot.
+        """Join agent ↔ MCP links ↔ user permission ↔ team link in one shot.
 
         When ``user_id`` is set and the user is not a workspace admin, the
         query includes a third tuple element: the user's permission row (or
-        ``None``). Otherwise rows are ``(AgentDB, AgentMCPServerDB | None)``.
+        ``None``). When the user also has a ``user_team_id``, a fourth element
+        carries the matching agent↔team link's ``team_id`` (or ``None``) so the
+        service can grant ``member`` through team membership. Otherwise rows are
+        ``(AgentDB, AgentMCPServerDB | None)``.
+
+        The team join is filtered on the user's single ``team_id``, so it
+        matches at most one row per agent — no cartesian fan-out.
 
         ``archived_only`` restricts the result to archived agents (for the
         Archived view); it takes precedence over ``include_archived``.
         """
         is_workspace_admin = user_role == WorkspaceRole.admin
         include_permissions = bool(user_id) and not is_workspace_admin
+        include_team = include_permissions and user_team_id is not None
 
         columns = [AgentDB, AgentMCPServerDB]
         if include_permissions:
             columns.append(AgentUserPermissionDB.permission)
+        if include_team:
+            columns.append(AgentTeamDB.team_id)
 
         stmt = select(*columns).outerjoin(
             AgentMCPServerDB, AgentDB.id == AgentMCPServerDB.agent_id
@@ -50,6 +61,12 @@ class AgentRepository(BaseRepository[AgentDB]):
                 AgentUserPermissionDB,
                 (AgentDB.id == AgentUserPermissionDB.agent_id)
                 & (AgentUserPermissionDB.user_id == user_id),
+            )
+        if include_team:
+            stmt = stmt.outerjoin(
+                AgentTeamDB,
+                (AgentDB.id == AgentTeamDB.agent_id)
+                & (AgentTeamDB.team_id == user_team_id),
             )
         if agent_id is not None:
             stmt = stmt.where(AgentDB.id == agent_id)
@@ -108,3 +125,35 @@ class AgentRepository(BaseRepository[AgentDB]):
         for perm in new_permissions:
             await self.db.refresh(perm)
         return new_permissions
+
+    async def get_team_ids(self, agent_id: UUID) -> list[UUID]:
+        stmt = select(AgentTeamDB.team_id).where(AgentTeamDB.agent_id == agent_id)
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def _get_team_links(self, agent_id: UUID) -> list[AgentTeamDB]:
+        stmt = select(AgentTeamDB).where(AgentTeamDB.agent_id == agent_id)
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def delete_all_teams(self, agent_id: UUID) -> None:
+        existing = await self._get_team_links(agent_id)
+        for link in existing:
+            await self.db.delete(link)
+        if existing:
+            await self.db.flush()
+
+    async def set_teams(self, agent_id: UUID, team_ids: list[UUID]) -> list[UUID]:
+        existing = await self._get_team_links(agent_id)
+        for link in existing:
+            await self.db.delete(link)
+        await self.db.flush()
+
+        new_links = [
+            AgentTeamDB(agent_id=agent_id, team_id=team_id)
+            for team_id in dict.fromkeys(team_ids)
+        ]
+        for link in new_links:
+            self.db.add(link)
+        await self.db.flush()
+        return [link.team_id for link in new_links]

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -49,12 +49,18 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         user_id: UUID | None,
         user_role: WorkspaceRole | None,
         granted: dict[UUID, str],
+        team_agent_ids: set[UUID] | None = None,
     ) -> str | None:
         if user_id and agent.owner_id == user_id:
             return "owner"
         if user_role == WorkspaceRole.admin:
             return "admin"
-        return granted.get(agent.id)
+        explicit = granted.get(agent.id)
+        if explicit:
+            return explicit
+        if team_agent_ids and agent.id in team_agent_ids:
+            return "member"
+        return None
 
     async def _assemble(
         self,
@@ -63,6 +69,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         permissions_map: dict[UUID, str],
         user_id: UUID | None,
         user_role: WorkspaceRole | None,
+        team_agent_ids: set[UUID] | None = None,
     ) -> list[AgentResponse]:
         agent_ids = [a.id for a in agents]
         (
@@ -76,7 +83,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                 subagents=subagents_map.get(agent.id, []),
                 is_subagent=agent.id in is_subagent_ids,
                 current_user_permission=self._resolve_permission(
-                    agent, user_id, user_role, permissions_map
+                    agent, user_id, user_role, permissions_map, team_agent_ids
                 ),
             )
             for agent in agents
@@ -90,10 +97,12 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         dict[UUID, AgentDB],
         dict[UUID, list[AgentMCPServerResponse]],
         dict[UUID, str],
+        set[UUID],
     ]:
         agents_map: dict[UUID, AgentDB] = {}
         mcp_map: dict[UUID, list[AgentMCPServerResponse]] = defaultdict(list)
         permissions_map: dict[UUID, str] = {}
+        team_agent_ids: set[UUID] = set()
         for row in rows:
             agent = row[0]
             link = row[1]
@@ -104,7 +113,9 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                 permission = row[2]
                 if permission and agent.id not in permissions_map:
                     permissions_map[agent.id] = permission.value
-        return agents_map, mcp_map, permissions_map
+            if user_id and len(row) > 3 and row[3] is not None:
+                team_agent_ids.add(agent.id)
+        return agents_map, mcp_map, permissions_map, team_agent_ids
 
     async def create(self, data: AgentCreateDB) -> AgentDB:
         return await self.repository.create(data)
@@ -114,24 +125,29 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         agent_id: UUID,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
+        user_team_id: UUID | None = None,
         include_archived: bool = False,
     ) -> AgentResponse:
         rows = await self.repository.list_with_permissions(
             user_id=user_id,
             user_role=user_role,
+            user_team_id=user_team_id,
             agent_id=agent_id,
             include_archived=include_archived,
         )
         if not rows:
             raise NotFoundError(self.not_found_message)
 
-        agents_map, mcp_map, permissions_map = self._group_rows(rows, user_id)
+        agents_map, mcp_map, permissions_map, team_agent_ids = self._group_rows(
+            rows, user_id
+        )
         responses = await self._assemble(
             list(agents_map.values()),
             mcp_map,
             permissions_map,
             user_id,
             user_role,
+            team_agent_ids,
         )
         return responses[0]
 
@@ -139,18 +155,25 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         self,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
+        user_team_id: UUID | None = None,
         archived: bool = False,
     ) -> list[AgentResponse]:
         rows = await self.repository.list_with_permissions(
-            user_id=user_id, user_role=user_role, archived_only=archived
+            user_id=user_id,
+            user_role=user_role,
+            user_team_id=user_team_id,
+            archived_only=archived,
         )
-        agents_map, mcp_map, permissions_map = self._group_rows(rows, user_id)
+        agents_map, mcp_map, permissions_map, team_agent_ids = self._group_rows(
+            rows, user_id
+        )
         return await self._assemble(
             list(agents_map.values()),
             mcp_map,
             permissions_map,
             user_id,
             user_role,
+            team_agent_ids,
         )
 
     async def update(
@@ -159,13 +182,18 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         data: AgentPatch,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
+        user_team_id: UUID | None = None,
     ) -> AgentResponse:
-        existing = await self.get(agent_id, user_id=user_id, user_role=user_role)
+        existing = await self.get(
+            agent_id, user_id=user_id, user_role=user_role, user_team_id=user_team_id
+        )
         if existing.current_user_permission not in ("owner", "admin", "editor"):
             raise PermissionDeniedError("Not authorized to edit this agent")
         agent = await self.get_or_404(agent_id)
         await self.repository.update(agent, data)
-        return await self.get(agent_id, user_id=user_id, user_role=user_role)
+        return await self.get(
+            agent_id, user_id=user_id, user_role=user_role, user_team_id=user_team_id
+        )
 
     async def delete(
         self,
@@ -184,11 +212,13 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         agent_id: UUID,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
+        user_team_id: UUID | None = None,
     ) -> AgentResponse:
         existing = await self.get(
             agent_id,
             user_id=user_id,
             user_role=user_role,
+            user_team_id=user_team_id,
             include_archived=True,
         )
         if existing.current_user_permission not in ("owner", "admin"):
@@ -199,6 +229,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             agent_id,
             user_id=user_id,
             user_role=user_role,
+            user_team_id=user_team_id,
             include_archived=True,
         )
 
@@ -207,11 +238,13 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         agent_id: UUID,
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
+        user_team_id: UUID | None = None,
     ) -> None:
         existing = await self.get(
             agent_id,
             user_id=user_id,
             user_role=user_role,
+            user_team_id=user_team_id,
             include_archived=True,
         )
         if existing.current_user_permission not in ("owner", "admin"):
@@ -225,6 +258,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         await self.subagent_service.delete_all_for_agent(agent_id)
         await self.mcp_server_repository.delete_all_for_agent(agent_id)
         await self.repository.delete_all_permissions(agent_id)
+        await self.repository.delete_all_teams(agent_id)
         await self.repository.delete(agent)
         # Checkpoints live on a separate auto-committed connection and can't be
         # rolled back, so purge them only after all DB deletes have succeeded.
@@ -237,6 +271,12 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         self, agent_id: UUID, permissions: list[AgentPermissionCreate]
     ) -> list[AgentUserPermissionDB]:
         return await self.repository.set_permissions(agent_id, permissions)
+
+    async def get_team_ids(self, agent_id: UUID) -> list[UUID]:
+        return await self.repository.get_team_ids(agent_id)
+
+    async def set_teams(self, agent_id: UUID, team_ids: list[UUID]) -> list[UUID]:
+        return await self.repository.set_teams(agent_id, team_ids)
 
     async def describe_readiness(self, agent_id: UUID, user_id: str) -> dict:
         agent = await self.get(agent_id, include_archived=True)

--- a/backend/app/agents/models.py
+++ b/backend/app/agents/models.py
@@ -78,6 +78,14 @@ class AgentUserPermissionDB(BaseDBModel, table=True):
     permission: PermissionLevel = Field(nullable=False)
 
 
+class AgentTeamDB(BaseDBModel, table=True):
+    __tablename__ = "agent_teams"
+    __table_args__ = (UniqueConstraint("agent_id", "team_id", name="uq_agent_team"),)
+
+    agent_id: UUID = Field(foreign_key="agents.id", ondelete="CASCADE", nullable=False)
+    team_id: UUID = Field(foreign_key="teams.id", ondelete="CASCADE", nullable=False)
+
+
 class AgentSubagentDB(BaseDBModel, table=True):
     __tablename__ = "agent_subagents"
     __table_args__ = (

--- a/backend/app/agents/models.py
+++ b/backend/app/agents/models.py
@@ -83,7 +83,9 @@ class AgentTeamDB(BaseDBModel, table=True):
     __table_args__ = (UniqueConstraint("agent_id", "team_id", name="uq_agent_team"),)
 
     agent_id: UUID = Field(foreign_key="agents.id", ondelete="CASCADE", nullable=False)
-    team_id: UUID = Field(foreign_key="teams.id", ondelete="CASCADE", nullable=False)
+    team_id: UUID = Field(
+        foreign_key="teams.id", ondelete="CASCADE", index=True, nullable=False
+    )
 
 
 class AgentSubagentDB(BaseDBModel, table=True):

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -147,12 +147,29 @@ async def set_agent_permissions(
     return await service.set_permissions(agent_id, permissions)
 
 
+async def _require_agent_editor(
+    agent_id: UUID, current_user: UserDB, service: AgentService
+) -> None:
+    """Allow only owner / workspace-admin / agent-editor to read or edit the
+    agent's team bindings (team grants confer Member access, so binding them is
+    an edit of the agent)."""
+    agent = await service.get(
+        agent_id,
+        user_id=current_user.id,
+        user_role=current_user.role,
+        user_team_id=current_user.team_id,
+    )
+    if agent.current_user_permission not in ("owner", "admin", "editor"):
+        raise PermissionDeniedError("Not authorized to manage this agent's teams")
+
+
 @router.get("/{agent_id}/teams", response_model=AgentTeamsResponse)
 async def get_agent_teams(
     agent_id: UUID,
-    _: UserDB = Depends(get_current_user),
+    current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> AgentTeamsResponse:
+    await _require_agent_editor(agent_id, current_user, service)
     return AgentTeamsResponse(team_ids=await service.get_team_ids(agent_id))
 
 
@@ -160,9 +177,10 @@ async def get_agent_teams(
 async def set_agent_teams(
     agent_id: UUID,
     data: AgentTeamsSet,
-    _: UserDB = Depends(get_current_user),
+    current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> AgentTeamsResponse:
+    await _require_agent_editor(agent_id, current_user, service)
     return AgentTeamsResponse(team_ids=await service.set_teams(agent_id, data.team_ids))
 
 

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -18,6 +18,8 @@ from app.agents.schemas import (
     AgentPermissionResponse,
     AgentResponse,
     AgentSubagentResponse,
+    AgentTeamsResponse,
+    AgentTeamsSet,
 )
 from app.agents.subagents.service import SubagentService, get_subagent_service
 from app.auth.dependencies import (
@@ -52,7 +54,10 @@ async def get_agents(
     service: AgentService = Depends(get_agent_service),
 ) -> list[AgentResponse]:
     return await service.list(
-        user_id=current_user.id, user_role=current_user.role, archived=archived
+        user_id=current_user.id,
+        user_role=current_user.role,
+        user_team_id=current_user.team_id,
+        archived=archived,
     )
 
 
@@ -66,6 +71,7 @@ async def get_agent(
         agent_id,
         user_id=current_user.id,
         user_role=current_user.role,
+        user_team_id=current_user.team_id,
     )
 
 
@@ -77,7 +83,11 @@ async def update_agent(
     service: AgentService = Depends(get_agent_service),
 ) -> AgentResponse:
     return await service.update(
-        agent_id, agent_update, user_id=current_user.id, user_role=current_user.role
+        agent_id,
+        agent_update,
+        user_id=current_user.id,
+        user_role=current_user.role,
+        user_team_id=current_user.team_id,
     )
 
 
@@ -87,9 +97,7 @@ async def delete_agent(
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
 ) -> None:
-    await service.delete(
-        agent_id, user_id=current_user.id, user_role=current_user.role
-    )
+    await service.delete(agent_id, user_id=current_user.id, user_role=current_user.role)
 
 
 @router.post("/{agent_id}/restore", response_model=AgentResponse)
@@ -99,7 +107,10 @@ async def restore_agent(
     service: AgentService = Depends(get_agent_service),
 ) -> AgentResponse:
     return await service.restore(
-        agent_id, user_id=current_user.id, user_role=current_user.role
+        agent_id,
+        user_id=current_user.id,
+        user_role=current_user.role,
+        user_team_id=current_user.team_id,
     )
 
 
@@ -110,7 +121,10 @@ async def delete_agent_permanently(
     service: AgentService = Depends(get_agent_service),
 ) -> None:
     await service.delete_permanently(
-        agent_id, user_id=current_user.id, user_role=current_user.role
+        agent_id,
+        user_id=current_user.id,
+        user_role=current_user.role,
+        user_team_id=current_user.team_id,
     )
 
 
@@ -131,6 +145,25 @@ async def set_agent_permissions(
     service: AgentService = Depends(get_agent_service),
 ) -> list[AgentPermissionResponse]:
     return await service.set_permissions(agent_id, permissions)
+
+
+@router.get("/{agent_id}/teams", response_model=AgentTeamsResponse)
+async def get_agent_teams(
+    agent_id: UUID,
+    _: UserDB = Depends(get_current_user),
+    service: AgentService = Depends(get_agent_service),
+) -> AgentTeamsResponse:
+    return AgentTeamsResponse(team_ids=await service.get_team_ids(agent_id))
+
+
+@router.put("/{agent_id}/teams", response_model=AgentTeamsResponse)
+async def set_agent_teams(
+    agent_id: UUID,
+    data: AgentTeamsSet,
+    _: UserDB = Depends(get_current_user),
+    service: AgentService = Depends(get_agent_service),
+) -> AgentTeamsResponse:
+    return AgentTeamsResponse(team_ids=await service.set_teams(agent_id, data.team_ids))
 
 
 @router.post(
@@ -229,7 +262,10 @@ async def list_agent_threads(
     """List all threads for an agent across users. Restricted to agent owners
     and admins (workspace or agent-level)."""
     agent = await agent_service.get(
-        agent_id, user_id=current_user.id, user_role=current_user.role
+        agent_id,
+        user_id=current_user.id,
+        user_role=current_user.role,
+        user_team_id=current_user.team_id,
     )
     if agent.current_user_permission not in ("owner", "admin"):
         raise PermissionDeniedError("Not authorized to view this agent's threads")

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -83,6 +83,14 @@ class AgentPermissionCreate(SQLModel):
     permission: PermissionLevel
 
 
+class AgentTeamsSet(SQLModel):
+    team_ids: list[UUID]
+
+
+class AgentTeamsResponse(SQLModel):
+    team_ids: list[UUID]
+
+
 class AgentSubagentResponse(SQLModel):
     id: UUID
     supervisor_id: UUID

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -49,9 +49,7 @@ class AuthService:
 
     async def signin(self, data: SigninRequest) -> tuple[UserDB, str]:
         self._ensure_password_auth()
-        result = await self.db.execute(
-            select(UserDB).where(UserDB.email == data.email)
-        )
+        result = await self.db.execute(select(UserDB).where(UserDB.email == data.email))
         user = result.scalar_one_or_none()
         if user is None or user.password_hash is None:
             raise InvalidCredentialsError("Invalid email or password")
@@ -85,6 +83,7 @@ class AuthService:
             name=data.name,
             password_hash=get_password_hash(data.password),
             role=WorkspaceRole(invite.role),
+            team_id=invite.team_id,
         )
         self.db.add(user)
         invite.status = InviteStatus.accepted
@@ -130,9 +129,13 @@ class AuthService:
         user = result.scalar_one_or_none()
 
         if user:
-            self.db.add(OAuthAccountDB(
-                provider="google", sub_id=google_sub, user_id=user.id,
-            ))
+            self.db.add(
+                OAuthAccountDB(
+                    provider="google",
+                    sub_id=google_sub,
+                    user_id=user.id,
+                )
+            )
             await self.db.flush()
             return self.build_jwt_for_user(user)
 
@@ -148,13 +151,18 @@ class AuthService:
             email=email,
             name=name,
             role=WorkspaceRole(invite.role),
+            team_id=invite.team_id,
         )
         self.db.add(user)
         await self.db.flush()
 
-        self.db.add(OAuthAccountDB(
-            provider="google", sub_id=google_sub, user_id=user.id,
-        ))
+        self.db.add(
+            OAuthAccountDB(
+                provider="google",
+                sub_id=google_sub,
+                user_id=user.id,
+            )
+        )
         invite.status = InviteStatus.accepted
         self.db.add(invite)
         await self.db.flush()

--- a/backend/app/integrations/slack/commands/chat.py
+++ b/backend/app/integrations/slack/commands/chat.py
@@ -29,11 +29,17 @@ SELECT_AGENT_ACTION_ID = "select_agent"
 # Agent fetching
 # ---------------------------------------------------------------------------
 
+
 async def list_pickable_agents(
-    db: AsyncSession, user_id: UUID, user_role: WorkspaceRole | None = None,
+    db: AsyncSession,
+    user_id: UUID,
+    user_role: WorkspaceRole | None = None,
+    user_team_id: UUID | None = None,
 ) -> list[AgentResponse]:
     """Return the agents this user may pick, sorted by name."""
-    all_agents = await AgentService(db).list(user_id=user_id, user_role=user_role)
+    all_agents = await AgentService(db).list(
+        user_id=user_id, user_role=user_role, user_team_id=user_team_id
+    )
     agents = [a for a in all_agents if a.current_user_permission is not None]
     agents.sort(key=lambda a: ((a.name or "").lower(), str(a.id)))
     return agents
@@ -43,9 +49,13 @@ async def list_pickable_agents(
 # Block Kit builders
 # ---------------------------------------------------------------------------
 
+
 def _agent_option(agent: AgentResponse) -> dict:
     return {
-        "text": {"type": "plain_text", "text": f"{agent.emoji or ''} {agent.name}".strip()},
+        "text": {
+            "type": "plain_text",
+            "text": f"{agent.emoji or ''} {agent.name}".strip(),
+        },
         "value": str(agent.id),
     }
 
@@ -67,22 +77,28 @@ def build_agent_picker_blocks(
         {"type": "section", "text": {"type": "mrkdwn", "text": header_text}},
         {
             "type": "actions",
-            "elements": [{
-                "type": "static_select",
-                "action_id": SELECT_AGENT_ACTION_ID,
-                "placeholder": {"type": "plain_text", "text": "Pick an agent…"},
-                "options": options,
-            }],
+            "elements": [
+                {
+                    "type": "static_select",
+                    "action_id": SELECT_AGENT_ACTION_ID,
+                    "placeholder": {"type": "plain_text", "text": "Pick an agent…"},
+                    "options": options,
+                }
+            ],
         },
     ]
     if len(agents) > MAX_OPTIONS:
-        blocks.append({
-            "type": "context",
-            "elements": [{
-                "type": "mrkdwn",
-                "text": f"_Showing the first {MAX_OPTIONS} of {len(agents)} agents._",
-            }],
-        })
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"_Showing the first {MAX_OPTIONS} of {len(agents)} agents._",
+                    }
+                ],
+            }
+        )
     return blocks
 
 
@@ -104,12 +120,18 @@ def _build_agent_selected_blocks(agent: AgentDB) -> list[dict]:
 # Post agent picker
 # ---------------------------------------------------------------------------
 
+
 async def post_agent_picker(
-    client: AsyncWebClient, channel_id: str, thread_ts: str,
-    db: AsyncSession, user_id: UUID, user_role: WorkspaceRole | None = None,
+    client: AsyncWebClient,
+    channel_id: str,
+    thread_ts: str,
+    db: AsyncSession,
+    user_id: UUID,
+    user_role: WorkspaceRole | None = None,
+    user_team_id: UUID | None = None,
 ) -> None:
     """Post an agent picker in the thread."""
-    agents = await list_pickable_agents(db, user_id, user_role)
+    agents = await list_pickable_agents(db, user_id, user_role, user_team_id)
     if not agents:
         return
 
@@ -125,6 +147,7 @@ async def post_agent_picker(
 # ---------------------------------------------------------------------------
 # Interaction handler (dropdown selection)
 # ---------------------------------------------------------------------------
+
 
 async def handle_agent_selection(payload: SlackInteractionPayload) -> None:
     """Process an agent-selection dropdown choice.
@@ -142,8 +165,10 @@ async def handle_agent_selection(payload: SlackInteractionPayload) -> None:
     agent_id = selected.value
 
     channel_id = (
-        payload.channel.id if payload.channel
-        else payload.container.channel_id if payload.container
+        payload.channel.id
+        if payload.channel
+        else payload.container.channel_id
+        if payload.container
         else None
     )
     thread_ts = payload.container.thread_ts if payload.container else None
@@ -183,6 +208,8 @@ async def handle_agent_selection(payload: SlackInteractionPayload) -> None:
     blocks = _build_agent_selected_blocks(agent)
     if message_ts:
         await client.chat_update(
-            channel=channel_id, ts=message_ts,
-            blocks=blocks, text=f"{agent.emoji or ''} *{agent.name}*\n\nAsk me anything to begin.",
+            channel=channel_id,
+            ts=message_ts,
+            blocks=blocks,
+            text=f"{agent.emoji or ''} *{agent.name}*\n\nAsk me anything to begin.",
         )

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -217,7 +217,7 @@ async def handle_assistant_thread_started(event: SlackEvent) -> None:
         return
 
     async with AsyncSessionLocal() as db:
-        agents = await list_pickable_agents(db, user.id, user.role)
+        agents = await list_pickable_agents(db, user.id, user.role, user.team_id)
 
     if not agents:
         await client.chat_postMessage(
@@ -285,7 +285,13 @@ async def handle_message(event: SlackEvent, *, team_id: str | None = None) -> No
 
         if not thread:
             await post_agent_picker(
-                client, event.channel, thread_ts, db, user.id, user_role=user.role
+                client,
+                event.channel,
+                thread_ts,
+                db,
+                user.id,
+                user_role=user.role,
+                user_team_id=user.team_id,
             )
             return
 

--- a/backend/app/invites/models.py
+++ b/backend/app/invites/models.py
@@ -19,6 +19,7 @@ class InviteCreateDB(SQLModel):
     token: str
     invited_by: UUID
     expires_at: datetime
+    team_id: UUID | None = None
 
 
 class InviteDB(BaseDBModel, table=True):
@@ -31,4 +32,10 @@ class InviteDB(BaseDBModel, table=True):
     invited_by: UUID = Field(foreign_key="users.id", nullable=False)
     expires_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False)
+    )
+    team_id: UUID | None = Field(
+        default=None,
+        foreign_key="teams.id",
+        ondelete="SET NULL",
+        nullable=True,
     )

--- a/backend/app/invites/router.py
+++ b/backend/app/invites/router.py
@@ -23,6 +23,7 @@ async def create_invite(
         email=data.email,
         role=data.role.value,
         invited_by=current_user.id,
+        team_id=data.team_id,
     )
     return service._to_response(invite, include_url=True)
 

--- a/backend/app/invites/schemas.py
+++ b/backend/app/invites/schemas.py
@@ -9,6 +9,7 @@ from app.users.models import WorkspaceRole
 class InviteCreate(BaseModel):
     email: EmailStr
     role: WorkspaceRole = WorkspaceRole.member
+    team_id: UUID | None = None
 
 
 class InviteResponse(BaseModel):
@@ -19,5 +20,6 @@ class InviteResponse(BaseModel):
     invite_url: str | None = None
     invited_by: UUID
     invited_by_name: str | None = None
+    team_id: UUID | None = None
     expires_at: datetime
     created_at: datetime

--- a/backend/app/invites/service.py
+++ b/backend/app/invites/service.py
@@ -8,11 +8,12 @@ from sqlmodel import select
 
 from app.auth.settings import auth_settings
 from app.database import get_db
-from app.exceptions import AlreadyExistsError
+from app.exceptions import AlreadyExistsError, NotFoundError
 from app.invites.models import InviteCreateDB, InviteDB, InviteStatus
 from app.invites.repository import InviteRepository
 from app.invites.schemas import InviteResponse
 from app.service import BaseService
+from app.teams.repository import TeamRepository
 from app.users.models import UserDB
 
 
@@ -63,6 +64,8 @@ class InviteService(BaseService[InviteDB, InviteRepository]):
         result = await self.db.execute(select(UserDB).where(UserDB.email == email))
         if result.scalar_one_or_none():
             raise AlreadyExistsError("Email already registered")
+        if team_id is not None and not await TeamRepository(self.db).get(team_id):
+            raise NotFoundError("Team not found")
         await self.repository.revoke_pending_by_email(email)
         data = InviteCreateDB(
             email=email,

--- a/backend/app/invites/service.py
+++ b/backend/app/invites/service.py
@@ -39,6 +39,7 @@ class InviteService(BaseService[InviteDB, InviteRepository]):
             invite_url=self.build_invite_url(invite.token) if include_url else None,
             invited_by=invite.invited_by,
             invited_by_name=invited_by_name,
+            team_id=invite.team_id,
             expires_at=invite.expires_at,
             created_at=invite.created_at,
         )
@@ -51,7 +52,13 @@ class InviteService(BaseService[InviteDB, InviteRepository]):
             and invite.expires_at >= datetime.now(UTC)
         )
 
-    async def create(self, email: str, role: str, invited_by: UUID) -> InviteDB:
+    async def create(
+        self,
+        email: str,
+        role: str,
+        invited_by: UUID,
+        team_id: UUID | None = None,
+    ) -> InviteDB:
         """Create a new invite, revoking any existing pending invite for the same email."""
         result = await self.db.execute(select(UserDB).where(UserDB.email == email))
         if result.scalar_one_or_none():
@@ -63,6 +70,7 @@ class InviteService(BaseService[InviteDB, InviteRepository]):
             token=secrets.token_urlsafe(32),
             invited_by=invited_by,
             expires_at=datetime.now(UTC) + timedelta(days=7),
+            team_id=team_id,
         )
         return await self.repository.create(data)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.model_providers.router import router as model_providers_router
 from app.redis_client import close_redis, get_redis
 from app.sandbox.router import router as sandbox_router
 from app.settings import app_settings
+from app.teams.router import router as teams_router
 from app.threads.router import router as threads_router
 from app.users.router import router as users_router
 
@@ -180,6 +181,7 @@ app.include_router(mcp_servers_router)
 app.include_router(threads_router)
 app.include_router(users_router)
 app.include_router(invites_router)
+app.include_router(teams_router)
 app.include_router(model_providers_router)
 app.include_router(sandbox_router)
 app.include_router(slack_router)

--- a/backend/app/teams/models.py
+++ b/backend/app/teams/models.py
@@ -1,0 +1,10 @@
+from sqlmodel import Field
+
+from app.models import BaseDBModel
+
+
+class TeamDB(BaseDBModel, table=True):
+    __tablename__ = "teams"
+
+    name: str = Field(max_length=255, unique=True, index=True, nullable=False)
+    color: str | None = Field(default=None, max_length=7, nullable=True)

--- a/backend/app/teams/repository.py
+++ b/backend/app/teams/repository.py
@@ -1,0 +1,20 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from app.repository import BaseRepository
+from app.teams.models import TeamDB
+
+
+class TeamRepository(BaseRepository[TeamDB]):
+    def __init__(self, db: AsyncSession):
+        super().__init__(TeamDB, db)
+
+    async def list_all(self) -> list[TeamDB]:
+        stmt = select(TeamDB).order_by(TeamDB.name.asc())
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_by_name(self, name: str) -> TeamDB | None:
+        stmt = select(TeamDB).where(TeamDB.name == name)
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()

--- a/backend/app/teams/router.py
+++ b/backend/app/teams/router.py
@@ -1,0 +1,47 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from app.auth.dependencies import get_current_user, require_admin
+from app.teams.schemas import TeamCreate, TeamPatch, TeamResponse
+from app.teams.service import TeamService, get_team_service
+from app.users.models import UserDB
+
+
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+@router.get("/", response_model=list[TeamResponse])
+async def list_teams(
+    _: UserDB = Depends(get_current_user),
+    service: TeamService = Depends(get_team_service),
+) -> list[TeamResponse]:
+    return await service.list()
+
+
+@router.post("/", response_model=TeamResponse, status_code=201)
+async def create_team(
+    data: TeamCreate,
+    _: UserDB = Depends(require_admin),
+    service: TeamService = Depends(get_team_service),
+) -> TeamResponse:
+    return await service.create(data)
+
+
+@router.patch("/{team_id}", response_model=TeamResponse)
+async def update_team(
+    team_id: UUID,
+    data: TeamPatch,
+    _: UserDB = Depends(require_admin),
+    service: TeamService = Depends(get_team_service),
+) -> TeamResponse:
+    return await service.update(team_id, data)
+
+
+@router.delete("/{team_id}", status_code=204)
+async def delete_team(
+    team_id: UUID,
+    _: UserDB = Depends(require_admin),
+    service: TeamService = Depends(get_team_service),
+) -> None:
+    await service.delete(team_id)

--- a/backend/app/teams/schemas.py
+++ b/backend/app/teams/schemas.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import field_validator
+from sqlmodel import SQLModel
+
+from app.agents.models import ALLOWED_COLORS
+
+
+def _validate_color(v: str | None) -> str | None:
+    if v is not None and v not in ALLOWED_COLORS:
+        raise ValueError(f"color must be one of {sorted(ALLOWED_COLORS)}")
+    return v
+
+
+class TeamCreate(SQLModel):
+    name: str
+    color: str | None = None
+
+    @field_validator("color")
+    @classmethod
+    def validate_color(cls, v: str | None) -> str | None:
+        return _validate_color(v)
+
+
+class TeamPatch(SQLModel):
+    name: str | None = None
+    color: str | None = None
+
+    @field_validator("color")
+    @classmethod
+    def validate_color(cls, v: str | None) -> str | None:
+        return _validate_color(v)
+
+
+class TeamResponse(SQLModel):
+    id: UUID
+    name: str
+    color: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/teams/service.py
+++ b/backend/app/teams/service.py
@@ -1,10 +1,11 @@
 from uuid import UUID
 
 from fastapi import Depends
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.exceptions import AlreadyExistsError
+from app.exceptions import AlreadyExistsError, DomainValidationError
 from app.service import BaseService
 from app.teams.models import TeamDB
 from app.teams.repository import TeamRepository
@@ -28,16 +29,28 @@ class TeamService(BaseService[TeamDB, TeamRepository]):
         return await self.get_or_404(team_id)
 
     async def create(self, data: TeamCreate) -> TeamDB:
+        if not data.name or not data.name.strip():
+            raise DomainValidationError("Team name cannot be empty")
         await self._ensure_name_available(data.name)
-        return await self.repository.create(data)
+        try:
+            return await self.repository.create(data)
+        except IntegrityError as exc:
+            # Lost a race against a concurrent create with the same name.
+            raise AlreadyExistsError("Team name already exists") from exc
 
     async def update(self, team_id: UUID, data: TeamPatch) -> TeamDB:
         team = await self.get_or_404(team_id)
         update_data = data.model_dump(exclude_unset=True)
-        new_name = update_data.get("name")
-        if "name" in update_data and new_name is not None and new_name != team.name:
-            await self._ensure_name_available(new_name)
-        return await self.repository.update(team, data)
+        if "name" in update_data:
+            new_name = update_data["name"]
+            if not new_name or not new_name.strip():
+                raise DomainValidationError("Team name cannot be empty")
+            if new_name != team.name:
+                await self._ensure_name_available(new_name)
+        try:
+            return await self.repository.update(team, data)
+        except IntegrityError as exc:
+            raise AlreadyExistsError("Team name already exists") from exc
 
     async def delete(self, team_id: UUID) -> None:
         team = await self.get_or_404(team_id)

--- a/backend/app/teams/service.py
+++ b/backend/app/teams/service.py
@@ -1,0 +1,48 @@
+from uuid import UUID
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.exceptions import AlreadyExistsError
+from app.service import BaseService
+from app.teams.models import TeamDB
+from app.teams.repository import TeamRepository
+from app.teams.schemas import TeamCreate, TeamPatch
+
+
+class TeamService(BaseService[TeamDB, TeamRepository]):
+    not_found_message = "Team not found"
+
+    def __init__(self, db: AsyncSession):
+        super().__init__(db, TeamRepository(db))
+
+    async def _ensure_name_available(self, name: str) -> None:
+        if await self.repository.get_by_name(name):
+            raise AlreadyExistsError("Team name already exists")
+
+    async def list(self) -> list[TeamDB]:
+        return await self.repository.list_all()
+
+    async def get(self, team_id: UUID) -> TeamDB:
+        return await self.get_or_404(team_id)
+
+    async def create(self, data: TeamCreate) -> TeamDB:
+        await self._ensure_name_available(data.name)
+        return await self.repository.create(data)
+
+    async def update(self, team_id: UUID, data: TeamPatch) -> TeamDB:
+        team = await self.get_or_404(team_id)
+        update_data = data.model_dump(exclude_unset=True)
+        new_name = update_data.get("name")
+        if "name" in update_data and new_name is not None and new_name != team.name:
+            await self._ensure_name_available(new_name)
+        return await self.repository.update(team, data)
+
+    async def delete(self, team_id: UUID) -> None:
+        team = await self.get_or_404(team_id)
+        await self.repository.delete(team)
+
+
+def get_team_service(db: AsyncSession = Depends(get_db)) -> TeamService:
+    return TeamService(db)

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -22,6 +22,13 @@ class UserBase(SQLModel):
 class UserDB(UserBase, BaseDBModel, table=True):
     __tablename__ = "users"
 
+    team_id: UUID | None = Field(
+        default=None,
+        foreign_key="teams.id",
+        ondelete="SET NULL",
+        nullable=True,
+    )
+
     oauth_accounts: list["OAuthAccountDB"] = Relationship(back_populates="user")
 
 

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends
 
-from app.auth.dependencies import require_admin
+from app.auth.dependencies import get_current_user, require_admin
 from app.users.models import UserDB, WorkspaceRole
 from app.users.schemas import (
     UserCreate,
@@ -29,6 +29,7 @@ async def create_user(
 @router.get("/", response_model=list[UserResponse])
 async def get_users(
     role: WorkspaceRole | None = None,
+    _: UserDB = Depends(get_current_user),
     service: UserService = Depends(get_user_service),
 ) -> list[UserResponse]:
     return await service.list(role=role)
@@ -37,6 +38,7 @@ async def get_users(
 @router.get("/{user_id}", response_model=UserResponse)
 async def get_user(
     user_id: UUID,
+    _: UserDB = Depends(get_current_user),
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
     return await service.get(user_id)
@@ -45,6 +47,7 @@ async def get_user(
 @router.get("/email/{email}", response_model=UserResponse)
 async def get_user_by_email(
     email: str,
+    _: UserDB = Depends(get_current_user),
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
     return await service.get_by_email(email)

--- a/backend/app/users/router.py
+++ b/backend/app/users/router.py
@@ -4,7 +4,13 @@ from fastapi import APIRouter, Depends
 
 from app.auth.dependencies import require_admin
 from app.users.models import UserDB, WorkspaceRole
-from app.users.schemas import UserCreate, UserPatch, UserResponse, UserRolePatch
+from app.users.schemas import (
+    UserCreate,
+    UserPatch,
+    UserResponse,
+    UserRolePatch,
+    UserTeamPatch,
+)
 from app.users.service import UserService, get_user_service
 
 
@@ -48,6 +54,7 @@ async def get_user_by_email(
 async def update_user(
     user_id: UUID,
     user_update: UserPatch,
+    _: UserDB = Depends(require_admin),
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
     return await service.update(user_id, user_update)
@@ -57,9 +64,20 @@ async def update_user(
 async def update_user_role(
     user_id: UUID,
     role_update: UserRolePatch,
+    _: UserDB = Depends(require_admin),
     service: UserService = Depends(get_user_service),
 ) -> UserResponse:
     return await service.update_role(user_id, role_update)
+
+
+@router.patch("/{user_id}/team", response_model=UserResponse)
+async def update_user_team(
+    user_id: UUID,
+    team_update: UserTeamPatch,
+    _: UserDB = Depends(require_admin),
+    service: UserService = Depends(get_user_service),
+) -> UserResponse:
+    return await service.update_team(user_id, team_update)
 
 
 @router.delete("/{user_id}", status_code=204)

--- a/backend/app/users/schemas.py
+++ b/backend/app/users/schemas.py
@@ -23,11 +23,16 @@ class UserRolePatch(SQLModel):
     role: WorkspaceRole
 
 
+class UserTeamPatch(SQLModel):
+    team_id: UUID | None = None
+
+
 class UserResponse(SQLModel):
     id: UUID
     name: str | None
     email: str | None
     role: WorkspaceRole
+    team_id: UUID | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/users/service.py
+++ b/backend/app/users/service.py
@@ -6,9 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_db
 from app.exceptions import AlreadyExistsError, NotFoundError
 from app.service import BaseService
+from app.teams.repository import TeamRepository
 from app.users.models import UserDB, WorkspaceRole
 from app.users.repository import UserRepository
-from app.users.schemas import UserCreate, UserPatch, UserRolePatch
+from app.users.schemas import UserCreate, UserPatch, UserRolePatch, UserTeamPatch
 
 
 class UserService(BaseService[UserDB, UserRepository]):
@@ -16,6 +17,7 @@ class UserService(BaseService[UserDB, UserRepository]):
 
     def __init__(self, db: AsyncSession):
         super().__init__(db, UserRepository(db))
+        self.team_repository = TeamRepository(db)
 
     async def _ensure_email_available(self, email: str) -> None:
         if await self.repository.get_by_email(email):
@@ -48,6 +50,14 @@ class UserService(BaseService[UserDB, UserRepository]):
 
     async def update_role(self, user_id: UUID, data: UserRolePatch) -> UserDB:
         user = await self.get_or_404(user_id)
+        return await self.repository.update(user, data)
+
+    async def update_team(self, user_id: UUID, data: UserTeamPatch) -> UserDB:
+        user = await self.get_or_404(user_id)
+        if data.team_id is not None and not await self.team_repository.get(
+            data.team_id
+        ):
+            raise NotFoundError("Team not found")
         return await self.repository.update(user, data)
 
     async def delete(self, user_id: UUID) -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -96,3 +96,8 @@ known-third-party = ["fastapi", "sqlmodel", "psycopg", "redis", "langchain", "la
 combine-as-imports = true
 force-single-line = false
 lines-after-imports = 2
+
+[tool.ruff.lint.per-file-ignores]
+# pytest fixtures are injected by name and are often present only for their
+# side effects (auth overrides, DB session), so they read as "unused args".
+"tests/**" = ["ARG001"]

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -527,3 +527,85 @@ def test_list_agent_threads_as_workspace_admin(client: TestClient, mock_db):
 def test_list_agent_threads_requires_auth(client: TestClient):
     response = client.get(f"/agents/{uuid4()}/threads")
     assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# agent team bindings — authorization
+# ---------------------------------------------------------------------------
+
+
+def _agent_response(permission):
+    from app.agents.schemas import AgentResponse
+
+    return AgentResponse(
+        id=uuid4(),
+        name="A",
+        instructions="x",
+        owner_id=uuid4(),
+        emoji=None,
+        color=None,
+        description=None,
+        has_code_interpreter=False,
+        is_archived=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        current_user_permission=permission,
+    )
+
+
+def test_set_agent_teams_forbidden_for_non_editor(
+    client: TestClient, mock_db, current_user
+):
+    from unittest.mock import AsyncMock
+
+    from app.agents.core.service import get_agent_service
+    from app.main import app
+
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=_agent_response(None))  # no access
+    svc.set_teams = AsyncMock()
+    app.dependency_overrides[get_agent_service] = lambda: svc
+    try:
+        response = client.put(f"/agents/{uuid4()}/teams", json={"team_ids": []})
+        assert response.status_code == 403
+        svc.set_teams.assert_not_called()
+    finally:
+        app.dependency_overrides.pop(get_agent_service, None)
+
+
+def test_set_agent_teams_allows_editor(client: TestClient, mock_db, current_user):
+    from unittest.mock import AsyncMock
+
+    from app.agents.core.service import get_agent_service
+    from app.main import app
+
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=_agent_response("editor"))
+    svc.set_teams = AsyncMock(return_value=[])
+    app.dependency_overrides[get_agent_service] = lambda: svc
+    try:
+        response = client.put(f"/agents/{uuid4()}/teams", json={"team_ids": []})
+        assert response.status_code == 200
+        svc.set_teams.assert_awaited_once()
+    finally:
+        app.dependency_overrides.pop(get_agent_service, None)
+
+
+def test_get_agent_teams_forbidden_for_non_editor(
+    client: TestClient, mock_db, current_user
+):
+    from unittest.mock import AsyncMock
+
+    from app.agents.core.service import get_agent_service
+    from app.main import app
+
+    svc = MagicMock()
+    svc.get = AsyncMock(return_value=_agent_response(None))
+    svc.get_team_ids = AsyncMock(return_value=[])
+    app.dependency_overrides[get_agent_service] = lambda: svc
+    try:
+        response = client.get(f"/agents/{uuid4()}/teams")
+        assert response.status_code == 403
+        svc.get_team_ids.assert_not_called()
+    finally:
+        app.dependency_overrides.pop(get_agent_service, None)

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -45,6 +45,9 @@ def mock_repo():
     repo.delete_all_permissions = AsyncMock()
     repo.get_permissions = AsyncMock()
     repo.set_permissions = AsyncMock()
+    repo.get_team_ids = AsyncMock(return_value=[])
+    repo.set_teams = AsyncMock(return_value=[])
+    repo.delete_all_teams = AsyncMock()
     repo.list_with_permissions = AsyncMock(return_value=[])
     return repo
 
@@ -717,3 +720,117 @@ def test_resolve_permission_returns_none_when_no_user(service):
     result = service._resolve_permission(agent, None, None, {})
 
     assert result is None
+
+
+def test_resolve_permission_returns_member_when_team_granted(service):
+    agent = make_agent()
+
+    result = service._resolve_permission(
+        agent, uuid4(), WorkspaceRole.member, {}, {agent.id}
+    )
+
+    assert result == "member"
+
+
+def test_resolve_permission_explicit_grant_beats_team(service):
+    agent = make_agent()
+    granted = {agent.id: "editor"}
+
+    result = service._resolve_permission(
+        agent, uuid4(), WorkspaceRole.member, granted, {agent.id}
+    )
+
+    assert result == "editor"
+
+
+def test_resolve_permission_no_team_grant_when_agent_not_in_set(service):
+    agent = make_agent()
+
+    result = service._resolve_permission(
+        agent, uuid4(), WorkspaceRole.member, {}, {uuid4()}
+    )
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# team grants through list (4-tuple rows carry the team match)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_agents_team_member_gets_member(service, mock_repo):
+    agent = make_agent()
+    team_id = uuid4()
+    # 4th element = matching agent↔team link's team_id
+    mock_repo.list_with_permissions.return_value = [(agent, None, None, team_id)]
+
+    result = await service.list(
+        user_id=uuid4(), user_role=WorkspaceRole.member, user_team_id=team_id
+    )
+
+    assert result[0].current_user_permission == "member"
+
+
+async def test_list_agents_explicit_editor_beats_team(service, mock_repo):
+    agent = make_agent()
+    team_id = uuid4()
+    mock_repo.list_with_permissions.return_value = [
+        (agent, None, PermissionLevel.editor, team_id)
+    ]
+
+    result = await service.list(
+        user_id=uuid4(), user_role=WorkspaceRole.member, user_team_id=team_id
+    )
+
+    assert result[0].current_user_permission == "editor"
+
+
+async def test_list_agents_no_team_match_stays_none(service, mock_repo):
+    agent = make_agent()
+    mock_repo.list_with_permissions.return_value = [(agent, None, None, None)]
+
+    result = await service.list(
+        user_id=uuid4(), user_role=WorkspaceRole.member, user_team_id=uuid4()
+    )
+
+    assert result[0].current_user_permission is None
+
+
+# ---------------------------------------------------------------------------
+# agent team bindings
+# ---------------------------------------------------------------------------
+
+
+async def test_get_team_ids_delegates(service, mock_repo):
+    agent_id = uuid4()
+    team_ids = [uuid4(), uuid4()]
+    mock_repo.get_team_ids = AsyncMock(return_value=team_ids)
+
+    result = await service.get_team_ids(agent_id)
+
+    mock_repo.get_team_ids.assert_awaited_once_with(agent_id)
+    assert result == team_ids
+
+
+async def test_set_teams_delegates(service, mock_repo):
+    agent_id = uuid4()
+    team_ids = [uuid4()]
+    mock_repo.set_teams = AsyncMock(return_value=team_ids)
+
+    result = await service.set_teams(agent_id, team_ids)
+
+    mock_repo.set_teams.assert_awaited_once_with(agent_id, team_ids)
+    assert result == team_ids
+
+
+async def test_delete_permanently_cleans_team_links(
+    service, mock_repo, mock_subagent_service
+):
+    agent = make_agent(is_archived=True)
+    mock_repo.get.return_value = agent
+    mock_repo.list_with_permissions.return_value = [(agent, None)]
+    mock_repo.delete_all_teams = AsyncMock()
+
+    await service.delete_permanently(agent.id, user_id=agent.owner_id)
+
+    mock_repo.delete_all_teams.assert_awaited_once_with(agent.id)

--- a/backend/tests/invites/test_service.py
+++ b/backend/tests/invites/test_service.py
@@ -52,7 +52,10 @@ async def test_create_persists_team_id(service, mock_db, mock_repo):
     team_id = uuid4()
     no_user = MagicMock()
     no_user.scalar_one_or_none.return_value = None
-    mock_db.execute.return_value = no_user
+    team_found = MagicMock()
+    team_found.scalar_one_or_none.return_value = MagicMock()  # team exists
+    # 1st execute: email check; 2nd: TeamRepository.get for team validation.
+    mock_db.execute.side_effect = [no_user, team_found]
     mock_repo.create.return_value = make_invite(team_id=team_id)
 
     await service.create(
@@ -74,6 +77,27 @@ async def test_create_defaults_team_id_to_none(service, mock_db, mock_repo):
 
     data = mock_repo.create.call_args[0][0]
     assert data.team_id is None
+
+
+async def test_create_rejects_unknown_team(service, mock_db, mock_repo):
+    from app.exceptions import NotFoundError
+
+    no_user = MagicMock()
+    no_user.scalar_one_or_none.return_value = None
+    no_team = MagicMock()
+    no_team.scalar_one_or_none.return_value = None
+    # 1st execute: email-availability check; 2nd: TeamRepository.get lookup.
+    mock_db.execute.side_effect = [no_user, no_team]
+
+    with pytest.raises(NotFoundError):
+        await service.create(
+            email="new@test.com",
+            role="member",
+            invited_by=uuid4(),
+            team_id=uuid4(),
+        )
+
+    mock_repo.create.assert_not_called()
 
 
 def test_to_response_includes_team_id(service):

--- a/backend/tests/invites/test_service.py
+++ b/backend/tests/invites/test_service.py
@@ -1,0 +1,85 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.invites.models import InviteCreateDB, InviteDB, InviteStatus
+from app.invites.service import InviteService
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_repo():
+    repo = MagicMock()
+    repo.create = AsyncMock()
+    repo.revoke_pending_by_email = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def service(mock_db, mock_repo):
+    svc = InviteService(mock_db)
+    svc.repository = mock_repo
+    return svc
+
+
+def make_invite(**kwargs):
+    defaults = {
+        "id": uuid4(),
+        "email": "new@test.com",
+        "role": "member",
+        "token": "tok",
+        "status": InviteStatus.pending,
+        "invited_by": uuid4(),
+        "expires_at": datetime.now(UTC) + timedelta(days=7),
+        "team_id": None,
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    return InviteDB(**{**defaults, **kwargs})
+
+
+async def test_create_persists_team_id(service, mock_db, mock_repo):
+    team_id = uuid4()
+    no_user = MagicMock()
+    no_user.scalar_one_or_none.return_value = None
+    mock_db.execute.return_value = no_user
+    mock_repo.create.return_value = make_invite(team_id=team_id)
+
+    await service.create(
+        email="new@test.com", role="member", invited_by=uuid4(), team_id=team_id
+    )
+
+    data = mock_repo.create.call_args[0][0]
+    assert isinstance(data, InviteCreateDB)
+    assert data.team_id == team_id
+
+
+async def test_create_defaults_team_id_to_none(service, mock_db, mock_repo):
+    no_user = MagicMock()
+    no_user.scalar_one_or_none.return_value = None
+    mock_db.execute.return_value = no_user
+    mock_repo.create.return_value = make_invite()
+
+    await service.create(email="new@test.com", role="member", invited_by=uuid4())
+
+    data = mock_repo.create.call_args[0][0]
+    assert data.team_id is None
+
+
+def test_to_response_includes_team_id(service):
+    team_id = uuid4()
+    invite = make_invite(team_id=team_id)
+
+    response = service._to_response(invite)
+
+    assert response.team_id == team_id

--- a/backend/tests/teams/test_router.py
+++ b/backend/tests/teams/test_router.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from app.teams.models import TeamDB
+
+
+def test_create_team_as_admin(client: TestClient, mock_db, admin_user):
+    """Admin can create a team."""
+    name_lookup = MagicMock()
+    name_lookup.scalar_one_or_none.return_value = None  # name available
+    mock_db.execute.return_value = name_lookup
+
+    async def mock_refresh(obj):
+        obj.id = uuid4()
+        obj.created_at = datetime.now()
+        obj.updated_at = datetime.now()
+
+    mock_db.refresh = mock_refresh
+
+    response = client.post("/teams/", json={"name": "Marketing", "color": "#6C5CE7"})
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Marketing"
+    assert data["color"] == "#6C5CE7"
+    assert "id" in data
+
+
+def test_create_team_rejects_invalid_color(client: TestClient, mock_db, admin_user):
+    response = client.post("/teams/", json={"name": "X", "color": "#123456"})
+    assert response.status_code == 422
+
+
+def test_create_team_duplicate_name(client: TestClient, mock_db, admin_user):
+    existing = TeamDB(
+        id=uuid4(),
+        name="Marketing",
+        color=None,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    name_lookup = MagicMock()
+    name_lookup.scalar_one_or_none.return_value = existing
+    mock_db.execute.return_value = name_lookup
+
+    response = client.post("/teams/", json={"name": "Marketing"})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Team name already exists"
+
+
+def test_create_team_requires_admin(client: TestClient, mock_db):
+    """Without an authenticated admin the create endpoint is rejected."""
+    response = client.post("/teams/", json={"name": "Marketing"})
+    assert response.status_code in (401, 403)
+
+
+def test_list_teams(client: TestClient, mock_db, current_user):
+    team1 = TeamDB(
+        id=uuid4(),
+        name="Alpha",
+        color="#6C5CE7",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    team2 = TeamDB(
+        id=uuid4(),
+        name="Beta",
+        color=None,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = [team1, team2]
+    result.scalars.return_value = scalars
+    mock_db.execute.return_value = result
+
+    response = client.get("/teams/")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_delete_team_as_admin(client: TestClient, mock_db, admin_user):
+    team = TeamDB(
+        id=uuid4(),
+        name="Gone",
+        color=None,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = team
+    mock_db.execute.return_value = result
+
+    response = client.delete(f"/teams/{team.id}")
+
+    assert response.status_code == 204
+    mock_db.delete.assert_called_once()

--- a/backend/tests/teams/test_service.py
+++ b/backend/tests/teams/test_service.py
@@ -1,0 +1,140 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.exceptions import AlreadyExistsError, NotFoundError
+from app.teams.models import TeamDB
+from app.teams.schemas import TeamCreate, TeamPatch
+from app.teams.service import TeamService
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = AsyncMock()
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_repo():
+    repo = MagicMock()
+    repo.get = AsyncMock()
+    repo.create = AsyncMock()
+    repo.update = AsyncMock()
+    repo.delete = AsyncMock()
+    repo.list_all = AsyncMock(return_value=[])
+    repo.get_by_name = AsyncMock(return_value=None)
+    return repo
+
+
+@pytest.fixture
+def service(mock_db, mock_repo):
+    svc = TeamService(mock_db)
+    svc.repository = mock_repo
+    return svc
+
+
+def make_team(**kwargs):
+    defaults = {
+        "id": uuid4(),
+        "name": "Marketing",
+        "color": "#6C5CE7",
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
+    }
+    return TeamDB(**{**defaults, **kwargs})
+
+
+async def test_create_delegates_to_repository(service, mock_repo):
+    team = make_team()
+    mock_repo.create.return_value = team
+    data = TeamCreate(name="Marketing", color="#6C5CE7")
+
+    result = await service.create(data)
+
+    mock_repo.get_by_name.assert_awaited_once_with("Marketing")
+    mock_repo.create.assert_awaited_once_with(data)
+    assert result is team
+
+
+async def test_create_raises_when_name_taken(service, mock_repo):
+    mock_repo.get_by_name.return_value = make_team(name="Marketing")
+
+    with pytest.raises(AlreadyExistsError):
+        await service.create(TeamCreate(name="Marketing"))
+
+    mock_repo.create.assert_not_called()
+
+
+async def test_update_raises_when_renaming_to_taken_name(service, mock_repo):
+    team = make_team(name="Old")
+    mock_repo.get.return_value = team
+    mock_repo.get_by_name.return_value = make_team(name="Taken")
+
+    with pytest.raises(AlreadyExistsError):
+        await service.update(team.id, TeamPatch(name="Taken"))
+
+    mock_repo.update.assert_not_called()
+
+
+async def test_update_allows_same_name(service, mock_repo):
+    team = make_team(name="Marketing")
+    mock_repo.get.return_value = team
+
+    await service.update(team.id, TeamPatch(name="Marketing", color="#00B894"))
+
+    mock_repo.get_by_name.assert_not_called()
+    mock_repo.update.assert_awaited_once()
+
+
+async def test_update_color_only_skips_name_check(service, mock_repo):
+    team = make_team(name="Marketing")
+    mock_repo.get.return_value = team
+
+    await service.update(team.id, TeamPatch(color="#00B894"))
+
+    mock_repo.get_by_name.assert_not_called()
+    mock_repo.update.assert_awaited_once()
+
+
+async def test_get_raises_404_when_missing(service, mock_repo):
+    mock_repo.get.return_value = None
+
+    with pytest.raises(NotFoundError) as exc_info:
+        await service.get(uuid4())
+
+    assert exc_info.value.detail == "Team not found"
+
+
+async def test_delete_delegates_to_repository(service, mock_repo):
+    team = make_team()
+    mock_repo.get.return_value = team
+
+    await service.delete(team.id)
+
+    mock_repo.delete.assert_awaited_once_with(team)
+
+
+async def test_delete_raises_404_when_missing(service, mock_repo):
+    mock_repo.get.return_value = None
+
+    with pytest.raises(NotFoundError):
+        await service.delete(uuid4())
+
+    mock_repo.delete.assert_not_called()
+
+
+async def test_list_delegates_to_repository(service, mock_repo):
+    teams = [make_team(name="A"), make_team(name="B")]
+    mock_repo.list_all.return_value = teams
+
+    result = await service.list()
+
+    assert result == teams

--- a/backend/tests/teams/test_service.py
+++ b/backend/tests/teams/test_service.py
@@ -4,7 +4,11 @@ from uuid import uuid4
 
 import pytest
 
-from app.exceptions import AlreadyExistsError, NotFoundError
+from app.exceptions import (
+    AlreadyExistsError,
+    DomainValidationError,
+    NotFoundError,
+)
 from app.teams.models import TeamDB
 from app.teams.schemas import TeamCreate, TeamPatch
 from app.teams.service import TeamService
@@ -102,6 +106,23 @@ async def test_update_color_only_skips_name_check(service, mock_repo):
 
     mock_repo.get_by_name.assert_not_called()
     mock_repo.update.assert_awaited_once()
+
+
+async def test_update_rejects_empty_name(service, mock_repo):
+    team = make_team(name="Marketing")
+    mock_repo.get.return_value = team
+
+    with pytest.raises(DomainValidationError):
+        await service.update(team.id, TeamPatch(name="   "))
+
+    mock_repo.update.assert_not_called()
+
+
+async def test_create_rejects_empty_name(service, mock_repo):
+    with pytest.raises(DomainValidationError):
+        await service.create(TeamCreate(name="  "))
+
+    mock_repo.create.assert_not_called()
 
 
 async def test_get_raises_404_when_missing(service, mock_repo):

--- a/backend/tests/users/test_users_router.py
+++ b/backend/tests/users/test_users_router.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
+from app.teams.models import TeamDB
 from app.users.models import UserDB, WorkspaceRole
 
 
@@ -163,8 +164,8 @@ def test_get_user_by_email_not_found(client: TestClient, mock_db):
     assert response.json()["detail"] == "User not found"
 
 
-def test_update_user(client: TestClient, mock_db):
-    """Test updating a user."""
+def test_update_user(client: TestClient, mock_db, admin_user):
+    """Test updating a user (admin only)."""
     user_id = uuid4()
     user = UserDB(
         id=user_id,
@@ -226,7 +227,7 @@ def test_update_user_role_not_found(client: TestClient, mock_db, admin_user):
     assert response.json()["detail"] == "User not found"
 
 
-def test_update_user_duplicate_email(client: TestClient, mock_db):
+def test_update_user_duplicate_email(client: TestClient, mock_db, admin_user):
     """Test updating a user with an email that already exists fails."""
     user_id = uuid4()
     user = UserDB(
@@ -260,7 +261,7 @@ def test_update_user_duplicate_email(client: TestClient, mock_db):
     assert response.json()["detail"] == "Email already registered"
 
 
-def test_update_user_not_found(client: TestClient, mock_db):
+def test_update_user_not_found(client: TestClient, mock_db, admin_user):
     """Test updating a non-existent user returns 404."""
     fake_id = uuid4()
 
@@ -306,3 +307,86 @@ def test_delete_user_not_found(client: TestClient, mock_db, admin_user):
     response = client.delete(f"/users/{fake_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == "User not found"
+
+
+def test_update_user_team(client: TestClient, mock_db, admin_user):
+    """Admin can assign a user to an existing team."""
+    user_id = uuid4()
+    team_id = uuid4()
+    user = UserDB(
+        id=user_id,
+        name="Test User",
+        email="teamuser@example.com",
+        role=WorkspaceRole.member,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    team = TeamDB(
+        id=team_id,
+        name="Marketing",
+        color=None,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+    team_result = MagicMock()
+    team_result.scalar_one_or_none.return_value = team
+    mock_db.execute.side_effect = [user_result, team_result]
+
+    response = client.patch(f"/users/{user_id}/team", json={"team_id": str(team_id)})
+
+    assert response.status_code == 200
+    assert response.json()["team_id"] == str(team_id)
+
+
+def test_update_user_team_unassign(client: TestClient, mock_db, admin_user):
+    """Passing a null team_id clears the user's team."""
+    user_id = uuid4()
+    user = UserDB(
+        id=user_id,
+        name="Test User",
+        email="teamuser@example.com",
+        role=WorkspaceRole.member,
+        team_id=uuid4(),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+    mock_db.execute.return_value = user_result
+
+    response = client.patch(f"/users/{user_id}/team", json={"team_id": None})
+
+    assert response.status_code == 200
+    assert response.json()["team_id"] is None
+
+
+def test_update_user_team_team_not_found(client: TestClient, mock_db, admin_user):
+    """Assigning a non-existent team returns 404."""
+    user_id = uuid4()
+    user = UserDB(
+        id=user_id,
+        name="Test User",
+        email="teamuser@example.com",
+        role=WorkspaceRole.member,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+    team_result = MagicMock()
+    team_result.scalar_one_or_none.return_value = None
+    mock_db.execute.side_effect = [user_result, team_result]
+
+    response = client.patch(f"/users/{user_id}/team", json={"team_id": str(uuid4())})
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Team not found"
+
+
+def test_update_user_team_requires_admin(client: TestClient, mock_db):
+    """The team endpoint is admin-gated."""
+    response = client.patch(f"/users/{uuid4()}/team", json={"team_id": None})
+    assert response.status_code in (401, 403)

--- a/backend/tests/users/test_users_router.py
+++ b/backend/tests/users/test_users_router.py
@@ -64,8 +64,8 @@ def test_create_user_duplicate_email(client: TestClient, mock_db, admin_user):
     assert response.json()["detail"] == "Email already registered"
 
 
-def test_get_users(client: TestClient, mock_db):
-    """Test getting all users."""
+def test_get_users(client: TestClient, mock_db, current_user):
+    """Test getting all users (requires authentication)."""
     user1 = UserDB(
         id=uuid4(),
         name="User 1",
@@ -95,7 +95,7 @@ def test_get_users(client: TestClient, mock_db):
     assert len(data) == 2
 
 
-def test_get_user(client: TestClient, mock_db):
+def test_get_user(client: TestClient, mock_db, current_user):
     """Test getting a single user by ID."""
     user_id = uuid4()
     user = UserDB(
@@ -118,7 +118,7 @@ def test_get_user(client: TestClient, mock_db):
     assert data["email"] == user.email
 
 
-def test_get_user_not_found(client: TestClient, mock_db):
+def test_get_user_not_found(client: TestClient, mock_db, current_user):
     """Test getting a non-existent user returns 404."""
     fake_id = uuid4()
 
@@ -131,7 +131,7 @@ def test_get_user_not_found(client: TestClient, mock_db):
     assert response.json()["detail"] == "User not found"
 
 
-def test_get_user_by_email(client: TestClient, mock_db):
+def test_get_user_by_email(client: TestClient, mock_db, current_user):
     """Test getting a user by email."""
     user = UserDB(
         id=uuid4(),
@@ -153,7 +153,7 @@ def test_get_user_by_email(client: TestClient, mock_db):
     assert data["name"] == user.name
 
 
-def test_get_user_by_email_not_found(client: TestClient, mock_db):
+def test_get_user_by_email_not_found(client: TestClient, mock_db, current_user):
     """Test getting a non-existent user by email returns 404."""
     mock_result = MagicMock()
     mock_result.scalar_one_or_none.return_value = None

--- a/teams-feature-plan.md
+++ b/teams-feature-plan.md
@@ -1,0 +1,275 @@
+# Teams feature — implementation plan
+
+## Goal & model
+
+Introduce **teams** as a workspace-admin-defined grouping that grants **member-level usage** of agents.
+
+Confirmed constraints (from product discussion):
+
+- A **user belongs to at most one team** → single nullable FK on the user, **no membership join table**.
+- An **agent can be assigned to many teams** → `AgentTeamDB` join table.
+- A team has a **name** and a **color** (reuses the agent background palette, `web/src/lib/colors.ts → AGENT_COLORS`).
+- **No `is_public` column** for now.
+- Team membership grants only **`member`** on agents linked to that team. Higher levels still come from the existing `AgentUserPermissionDB`.
+- Invites may carry a team → the invited user lands already in a team with usable agents.
+- Per-user permission **always wins** over team permission in resolution (and team only ever grants `member`, so redundancy is harmless).
+
+### Permission resolution (the core change)
+
+`AgentService._resolve_permission` (`app/agents/core/service.py:46`) gains one branch, ordered so a real grant always beats the team floor:
+
+```
+1. owner of the agent                      → "owner"
+2. workspace admin                         → "admin"
+3. explicit AgentUserPermissionDB grant    → member | editor | admin
+4. user's team is linked to the agent      → "member"     ← NEW
+5. otherwise                               → None
+```
+
+Because a user has **exactly one** `team_id`, the "is this agent linked to my team" check matches **at most one** `AgentTeamDB` row per agent — so it can be folded directly into the existing `list_with_permissions` join **without cartesian fan-out** (this is why the one-team constraint matters: it keeps the query flat).
+
+---
+
+## Backend
+
+### 1. New module `app/teams/`
+
+Follows `router → service → repository → model`, mirroring `app/invites/` and `app/agents/core/`.
+
+#### `app/teams/models.py`
+
+```python
+from uuid import UUID
+from sqlmodel import Field, SQLModel
+from app.models import BaseDBModel, TimestampMixin
+
+
+class TeamBase(SQLModel):
+    name: str = Field(max_length=255, nullable=False)
+    color: str | None = Field(default=None, max_length=7, nullable=True)  # hex "#RRGGBB"
+
+
+class TeamDB(TeamBase, BaseDBModel, table=True):
+    __tablename__ = "teams"
+
+    name: str = Field(max_length=255, nullable=False)
+    color: str | None = Field(default=None, max_length=7, nullable=True)
+
+
+class AgentTeamDB(TimestampMixin, SQLModel, table=True):
+    __tablename__ = "agent_teams"
+    __table_args__ = (UniqueConstraint("agent_id", "team_id", name="uq_agent_team"),)
+
+    agent_id: UUID = Field(foreign_key="agents.id", primary_key=True, nullable=False)
+    team_id: UUID = Field(foreign_key="teams.id", primary_key=True, nullable=False)
+```
+
+- `AgentTeamDB` uses the composite-PK join-table pattern (like the convention doc prescribes), no surrogate UUID.
+- `team_id` on the **user** lives on `UserDB`, not here (one team per user) — see step 3.
+
+#### `app/teams/schemas.py`
+
+```python
+class TeamCreate(BaseModel):
+    name: str
+    color: str | None = None
+
+class TeamPatch(SQLModel):           # partial update
+    name: str | None = None
+    color: str | None = None
+
+class TeamResponse(SQLModel):
+    id: UUID
+    name: str
+    color: str | None
+    created_at: datetime
+    updated_at: datetime
+```
+
+#### `app/teams/repository.py`
+
+`TeamRepository(BaseRepository[TeamDB])` — inherits `get/create/update/delete`. Add:
+
+- `list_all() -> list[TeamDB]`
+- `get_by_name(name) -> TeamDB | None` (for uniqueness check / create-on-the-fly)
+
+Plus a small `AgentTeamRepository` (or methods on the agents repository — see step 5) for the agent↔team link:
+
+- `set_agent_teams(agent_id, team_ids)` — replace-set semantics, mirroring `AgentRepository.set_permissions` (`app/agents/core/repository.py:90`).
+- `team_agent_ids(team_id) -> set[UUID]` — used by resolution if we go the separate-query route (we won't; see step 5).
+
+#### `app/teams/service.py`
+
+`TeamService(BaseService[TeamDB, TeamRepository])`:
+
+- `create(TeamCreate)` — raise `AlreadyExistsError` if name taken (if we enforce uniqueness — see Open Questions).
+- `update(team_id, TeamPatch)` — `get_or_404` then repo update.
+- `delete(team_id)` — `get_or_404` then delete. Deletion side-effects handled by FK rules (see Open Questions).
+- `list()` → `list[TeamResponse]`.
+
+#### `app/teams/router.py`  (`prefix="/teams"`)
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| `GET` | `/teams` | `get_current_user` | list teams (needed by Users-page select, invite dialog, agent perms modal) |
+| `POST` | `/teams` | `require_admin` | create team |
+| `PATCH` | `/teams/{id}` | `require_admin` | rename / recolor |
+| `DELETE` | `/teams/{id}` | `require_admin` | delete |
+
+Register in `app/main.py` alongside the other routers.
+
+### 2. `app/agents/` — assign teams to an agent
+
+This is the agent side of the link (used later by the "Manage permissions" modal, but the model/endpoint belong in the backend foundation now).
+
+- `AgentTeamDB` lives in `app/teams/models.py` (above) to avoid an import cycle, or in `app/agents/models.py` next to `AgentMCPServerDB` / `AgentUserPermissionDB` — **decision: put it in `app/agents/models.py`** since it's conceptually an agent binding and that's where `AgentUserPermissionDB` already lives. (Adjust the import in step 1 accordingly.)
+- Repository: add `get_team_ids(agent_id)` and `set_teams(agent_id, team_ids)` to `AgentRepository`, mirroring `get_permissions`/`set_permissions`.
+- Service: `AgentService.get_teams(agent_id)` / `set_teams(agent_id, team_ids)`.
+- Router: `GET /agents/{id}/teams` and `PUT /agents/{id}/teams` mirroring the existing `GET|PUT /agents/{id}/permissions` (`app/agents/router.py:117`).
+
+### 3. `app/users/` — user's team
+
+- **Model** (`app/users/models.py`): add to `UserBase` (so it flows into create schemas) **or** directly on `UserDB`. Since invites/signup set it server-side, put it on `UserDB`:
+
+  ```python
+  team_id: UUID | None = Field(default=None, foreign_key="teams.id", nullable=True)
+  ```
+
+- **Schemas** (`app/users/schemas.py`):
+  - `UserResponse` gains `team_id: UUID | None`. (Frontend joins against `GET /teams` for name/color — see Open Questions on whether to embed the full team.)
+  - New `UserTeamPatch(SQLModel): team_id: UUID | None` (nullable to support un-assigning).
+- **Service** (`app/users/service.py`): `update_team(user_id, UserTeamPatch)` — `get_or_404`, validate `team_id` exists if not null, repo update. Mirrors `update_role`.
+- **Router** (`app/users/router.py`): `PATCH /users/{id}/team` mirroring `PATCH /users/{id}/role`.
+  - ⚠️ **Auth note:** the existing `PATCH /users/{id}` and `PATCH /users/{id}/role` have **no auth dependency** today (only `create`/`delete` require admin). I recommend gating the new `/team` endpoint with `require_admin` (team assignment is an admin action) and, separately, flagging the ungated role endpoint as a pre-existing gap. See Open Questions.
+
+### 4. `app/invites/` — invite with team
+
+- **Model** (`app/invites/models.py`): `InviteDB` gains `team_id: UUID | None = Field(default=None, foreign_key="teams.id", nullable=True)`.
+- **Schemas**: `InviteCreate` gains `team_id: UUID | None = None`; `InviteResponse` gains `team_id`.
+- **Service** (`app/invites/service.py`): `create()` persists `team_id`.
+- **Accept flow** (`app/auth/service.py`): both `accept_invite` (~line 87) and the Google OAuth branch (~line 147) set `team_id=invite.team_id` on the new `UserDB`.
+
+### 5. Permission resolution wiring
+
+- **`AgentRepository.list_with_permissions`** (`app/agents/core/repository.py:20`): when `include_permissions` is true (user set & not admin), accept a `user_team_id: UUID | None` arg and add a second `outerjoin`:
+
+  ```python
+  if include_permissions and user_team_id is not None:
+      columns.append(AgentTeamDB.team_id.label("team_match"))
+      stmt = stmt.outerjoin(
+          AgentTeamDB,
+          (AgentDB.id == AgentTeamDB.agent_id)
+          & (AgentTeamDB.team_id == user_team_id),
+      )
+  ```
+
+  Filtering the join on the user's single `team_id` guarantees ≤1 matching row per agent → no fan-out.
+
+- **`AgentService._resolve_permission`** gains a `team_granted: bool` param; insert the branch between the explicit-grant lookup and the `None` fallback.
+- **`AgentService.list` / `get` / `update`** thread a new `user_team_id` param.
+- **All call sites** must pass `current_user.team_id`:
+  - `app/agents/router.py` (list/get/update endpoints) — `current_user.team_id`.
+  - `app/integrations/slack/commands/chat.py:32` `list_pickable_agents` — pass the resolved internal user's `team_id` (already loads a `UserDB`). The existing `current_user_permission is not None` filter then automatically includes team-granted agents. ✅
+
+### 6. Migrations (Alembic)
+
+One revision (or split if cleaner), `uv run alembic revision --autogenerate -m "add teams"`:
+
+1. `create table teams` (id, name, color, timestamps).
+2. `create table agent_teams` (agent_id, team_id composite PK, FKs, timestamps, `uq_agent_team`).
+3. `add column users.team_id` (nullable FK → teams.id, `ondelete=SET NULL`).
+4. `add column invites.team_id` (nullable FK → teams.id, `ondelete=SET NULL`).
+
+Verify the autogenerated FK `ondelete` rules — autogenerate often omits them; set them explicitly (see Open Questions for the desired semantics).
+
+### 7. Tests (`backend/tests/`)
+
+Mirror the `app/` layout:
+
+- `tests/teams/test_repository.py` — CRUD, `get_by_name`, agent↔team set/replace.
+- `tests/teams/test_service.py` — create/duplicate-name, update, delete.
+- `tests/teams/test_router.py` — endpoint auth (admin gates), happy paths.
+- `tests/agents/` — **resolution cases** (the important ones):
+  - user in team linked to agent → `current_user_permission == "member"`.
+  - user has explicit `editor` **and** team link → stays `editor` (per-user wins).
+  - user in a team **not** linked to the agent → `None`.
+  - owner / workspace-admin unaffected.
+  - agent listing for a team member surfaces the agent (the Slack/`list` path).
+- `tests/users/` — `PATCH /users/{id}/team` assigns & un-assigns; `UserResponse.team_id` present.
+- `tests/invites/` + `tests/auth/` — invite with `team_id`; accepting it sets `user.team_id` (password and Google flows).
+
+---
+
+## Frontend (later steps — included for completeness)
+
+### Step A — Users table team select (the requested first UI slice)
+
+`web/src/app/(protected)/users/page.tsx`:
+
+- Add a **Team column** after Role in the grid templates (`page.tsx:245`); widen the `md` grid cols (e.g. `[1fr_230px_130px_160px_34px]`).
+- Render a team picker per row mirroring the Role `SageDropdownMenu` (`page.tsx:338`):
+  - Items = teams from `GET /teams`, each with a color dot (`style={{ background: team.color }}`) like `ROLE_DOT`.
+  - **Empty state** (user has no team): show a muted pill — e.g. a dashed-border chip reading "No team" with a neutral dot — rather than a blank cell. Keep it visually consistent with the Role pill.
+  - Footer item **"+ New team"** inside the dropdown → opens the create dialog (step B).
+  - `handleTeamChange(userId, teamId | null)` → `api.patch('/users/${userId}/team', { teamId })`, optimistic local update (same shape as `handleRoleChange`, `page.tsx:161`).
+
+### Step B — "New team" dialog
+
+New component mirroring `RenameThreadDialog` (`web/src/components/layout/app-sidebar/rename-thread-dialog.tsx`):
+
+- `Dialog` + `SageInput` for the name.
+- Color picker = the swatch grid from `agent-editor.tsx:206` (`AGENT_COLORS.map(...)`).
+- Submit → `api.post('/teams', { name, color })`; on success, append to the team list and select it for the current row.
+- Props `{ open, onOpenChange, onTeamCreated }`.
+
+### Step C — Invite dialog team select
+
+`web/src/app/(protected)/users/invite-dialog.tsx`: add a team `<select>` after the role select (`invite-dialog.tsx:85`); include `teamId` in the `POST /invites/` payload (`invite-dialog.tsx:38`).
+
+### Step D — Agent "Manage permissions" modal (team grants)
+
+From the agent editor menu, the Manage permissions modal additionally lists **teams** (multi-select) and writes via `PUT /agents/{id}/teams`. Per-user grants and team grants coexist; the UI should note team grants are member-only.
+
+---
+
+## Suggested PR sequencing
+
+1. **PR 1 — Backend foundation** (this step's deliverable): models, migration, `app/teams/` module, `users.team_id` + `/users/{id}/team`, resolution wiring, invite `team_id`, tests. No UI.
+2. **PR 2 — Users page**: team select column + empty state + New-team dialog + invite team select (frontend steps A–C).
+3. **PR 3 — Agent team permissions**: `PUT /agents/{id}/teams` UI in the Manage permissions modal (step D).
+
+---
+
+## Implementation status — PR 1 (backend foundation) ✅ done
+
+Implemented on `main` working tree:
+
+- `app/teams/` module: `TeamDB` (unique `name` + `color`), `TeamCreate/Patch/Response`, `TeamRepository`, `TeamService` (dup-name → `AlreadyExistsError`), admin-gated CRUD router + open `GET /teams`. Registered in `main.py`.
+- `AgentTeamDB` join in `app/agents/models.py` (composite uniqueness, `ondelete=CASCADE`). Repo `get_team_ids` / `set_teams` / `delete_all_teams`; service `get_team_ids` / `set_teams`; `GET|PUT /agents/{id}/teams`.
+- Resolution: `_resolve_permission` team branch (`member`, below explicit grant); `list_with_permissions` adds the team `outerjoin` filtered on the user's single `team_id` (no fan-out); `user_team_id` threaded through `get/list/update/restore/delete_permanently` and both Slack call sites.
+- `users.team_id` (FK `SET NULL`) + `UserResponse.team_id` + `UserTeamPatch` + `update_team` (validates team) + admin-gated `PATCH /users/{id}/team`; retrofitted `require_admin` onto `PATCH /users/{id}` and `/role`.
+- `invites.team_id` (FK `SET NULL`) through `InviteDB/Create/Response/service/router`; both accept flows (password + Google) set `user.team_id`.
+- Migration `f3c2b1a09d8e_add_teams` (single head). Offline SQL verified correct. **Live apply not yet run** — local Docker postgres is crash-looping on a host `No space left on device`; apply once disk is freed.
+- Tests: `tests/teams/`, `tests/invites/test_service.py`, resolution + binding cases in `tests/agents/core/test_service.py`, `/team` endpoint + admin-gate cases in `tests/users/`. **Full suite: 316 passed.** `ruff check` clean on new code.
+
+## Implementation status — PR 2 (Users page) ✅ done
+
+- **Migration applied** to the dev DB (`alembic current` → `f3c2b1a09d8e (head)`; `teams`, `agent_teams`, `users.team_id`, `invites.team_id` all verified present).
+- **Users table team column** (`web/.../users/page.tsx`): new "Team" column after Role (md+; folds out on mobile like Email). Each row has a `SageDropdownMenu` listing teams (color dot + active check), a "No team" entry to unassign, and a "+ New team" footer item. Empty state = dashed-border "No team" pill. Writes via `PATCH /users/{id}/team` with optimistic update. Fetches `GET /teams`.
+- **New-team dialog** (`web/.../users/new-team-dialog.tsx`): mirrors `RenameThreadDialog` (Dialog + `SageInput` + `SageButton`) with the `AGENT_COLORS` swatch picker. `POST /teams`; on success the team is added to the list and auto-assigned to the row that opened it.
+- **Invite dialog** (`web/.../users/invite-dialog.tsx`): optional Team select; `teamId` sent in the `POST /invites/` payload.
+- `tsc` + `eslint` clean on all three files (the one repo-wide tsc error is pre-existing and unrelated).
+
+## Implementation status — PR 3 (agent team grants) ✅ done
+
+- **Manage permissions modal** (`web/.../agents/components/agent-permissions-dialog.tsx`): added a **People / Teams** segmented toggle. The Teams view loads `GET /agents/{id}/teams`, lists all teams (`GET /teams`) as toggleable chips (color dot + check when selected), with the note "Everyone in a selected team gets Member access." Save now PUTs **both** `/permissions` and `/teams` (`{ teamIds }`) in parallel. Per-user and team grants coexist; team grants are member-only by construction.
+- No menu change needed — the same modal opens from the agent editor's "Manage permissions" item (owner/admin gated).
+- `tsc` + `eslint` clean.
+
+## Decisions (confirmed)
+
+1. **Team deletion semantics** → **SET NULL + cascade.** `users.team_id` is set NULL for members; `agent_teams` rows for the team are deleted. Deletion always succeeds. Implement via FK `ondelete="SET NULL"` (users, invites) and `ondelete="CASCADE"` (agent_teams).
+2. **Team name uniqueness** → **unique.** Unique constraint on `teams.name`; `TeamService.create` raises `AlreadyExistsError` on collision.
+3. **User-mutation authz** → **gate all + fix the gap.** Add `require_admin` to the new `PATCH /users/{id}/team`, and retrofit `require_admin` onto the existing ungated `PATCH /users/{id}` and `PATCH /users/{id}/role`.
+4. **`UserResponse` shape** → **just `team_id`** (UUID only; frontend resolves name/color from `GET /teams`).
+5. **`AgentTeamDB` home** → **`app/agents/models.py`**, next to `AgentUserPermissionDB`.

--- a/web/src/app/(protected)/agents/components/agent-permissions-dialog.tsx
+++ b/web/src/app/(protected)/agents/components/agent-permissions-dialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Trash2, ChevronDown } from "lucide-react";
+import { Trash2, ChevronDown, Check, Plus } from "lucide-react";
 import { api } from "@/lib/api/client";
+import { cn } from "@/lib/utils";
 import {
 	Dialog,
 	DialogContent,
@@ -20,6 +21,12 @@ interface User {
 	id: string;
 	name: string | null;
 	email: string | null;
+}
+
+interface Team {
+	id: string;
+	name: string;
+	color: string | null;
 }
 
 interface PermissionRow {
@@ -58,6 +65,9 @@ export default function AgentPermissionsDialog({
 }: AgentPermissionsDialogProps) {
 	const [allUsers, setAllUsers] = useState<User[]>([]);
 	const [permissions, setPermissions] = useState<PermissionRow[]>([]);
+	const [allTeams, setAllTeams] = useState<Team[]>([]);
+	const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+	const [view, setView] = useState<"people" | "teams">("people");
 	const [search, setSearch] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
@@ -67,8 +77,14 @@ export default function AgentPermissionsDialog({
 
 		setIsLoading(true);
 		setSearch("");
-		Promise.all([api.get("/users"), api.get(`/agents/${agentId}/permissions`)])
-			.then(([usersRes, permsRes]) => {
+		setView("people");
+		Promise.all([
+			api.get("/users"),
+			api.get(`/agents/${agentId}/permissions`),
+			api.get("/teams/"),
+			api.get(`/agents/${agentId}/teams`),
+		])
+			.then(([usersRes, permsRes, teamsRes, agentTeamsRes]) => {
 				setAllUsers(usersRes.data);
 				setPermissions(
 					(permsRes.data as PermissionRow[]).map((p) => ({
@@ -76,9 +92,13 @@ export default function AgentPermissionsDialog({
 						permission: p.permission,
 					})),
 				);
+				setAllTeams(teamsRes.data);
+				setSelectedTeamIds(
+					(agentTeamsRes.data as { teamIds: string[] }).teamIds,
+				);
 			})
-			.catch((err) => console.error("Failed to load permissions:", err))
-			.finally(() => setIsLoading(false));
+			.catch((err) => { console.error("Failed to load permissions:", err); })
+			.finally(() => { setIsLoading(false); });
 	}, [open, agentId]);
 
 	const owner = useMemo(
@@ -123,10 +143,21 @@ export default function AgentPermissionsDialog({
 		);
 	};
 
+	const toggleTeam = (teamId: string) => {
+		setSelectedTeamIds((prev) =>
+			prev.includes(teamId)
+				? prev.filter((id) => id !== teamId)
+				: [...prev, teamId],
+		);
+	};
+
 	const handleSave = async () => {
 		setIsSaving(true);
 		try {
-			await api.put(`/agents/${agentId}/permissions`, permissions);
+			await Promise.all([
+				api.put(`/agents/${agentId}/permissions`, permissions),
+				api.put(`/agents/${agentId}/teams`, { teamIds: selectedTeamIds }),
+			]);
 			onOpenChange(false);
 		} catch (err) {
 			console.error("Failed to save permissions:", err);
@@ -149,141 +180,216 @@ export default function AgentPermissionsDialog({
 					<DialogTitle>Manage permissions</DialogTitle>
 				</DialogHeader>
 
-				<div className="relative">
-					<SearchBar
-						placeholder="Search users by name or email..."
-						value={search}
-						onChange={setSearch}
-					/>
-
-					{search.trim() && searchResults.length > 0 && (
-						<div className="absolute top-full left-0 right-0 mt-2 z-10 bg-white dark:bg-[#1C1C1C] border-[1.5px] border-[#E0E8E4] dark:border-white/10 rounded-[18px] max-h-[160px] overflow-y-auto shadow-[0_8px_24px_-6px_rgba(0,0,0,0.08)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-							{searchResults.map((user) => (
-								<button
-									key={user.id}
-									type="button"
-									className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-[#F8FAF9] dark:hover:bg-white/5 transition-colors cursor-pointer first:rounded-t-[16px] last:rounded-b-[16px]"
-									onClick={() => addUser(user.id)}
-								>
-									<div className="shrink-0 w-[34px] h-[34px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[12px] font-bold text-[#6B7F76] dark:text-muted-foreground">
-										{getInitials(user.name)}
-									</div>
-									<div className="flex-1 min-w-0">
-										<p className="font-[family-name:var(--font-dm-sans)] text-[13.5px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
-											{user.name || "Unnamed"}
-										</p>
-										<p className="font-[family-name:var(--font-dm-sans)] text-[12px] text-[#8FA89E] dark:text-muted-foreground truncate">
-											{user.email}
-										</p>
-									</div>
-								</button>
-							))}
-						</div>
-					)}
-
-					{search.trim() && searchResults.length === 0 && !isLoading && (
-						<div className="absolute top-full left-0 right-0 mt-2 z-10 bg-white dark:bg-[#1C1C1C] border-[1.5px] border-[#E0E8E4] dark:border-white/10 rounded-[18px] shadow-[0_8px_24px_-6px_rgba(0,0,0,0.08)]">
-							<p className="font-[family-name:var(--font-dm-sans)] text-[13px] text-[#A3B5AD] dark:text-muted-foreground text-center py-4">
-								No users found.
-							</p>
-						</div>
-					)}
+				{/* People / Teams toggle */}
+				<div className="flex shrink-0 w-fit gap-1 rounded-full bg-[#F0F3F2] dark:bg-white/5 p-1">
+					{(["people", "teams"] as const).map((tab) => (
+						<button
+							key={tab}
+							type="button"
+							onClick={() => {
+								setView(tab);
+							}}
+							className={cn(
+								"rounded-full px-4 py-1.5 text-[13px] font-semibold font-[family-name:var(--font-dm-sans)] cursor-pointer transition-colors",
+								view === tab
+									? "bg-white dark:bg-white/10 text-[#1E2D28] dark:text-foreground shadow-[0_1px_3px_rgba(0,0,0,0.06)]"
+									: "text-[#8FA89E] hover:text-[#6B7F76]",
+							)}
+						>
+							{tab === "people" ? "People" : "Teams"}
+						</button>
+					))}
 				</div>
 
-				<div className="flex flex-1 flex-col min-h-0">
-					{/* Table header */}
-					<div className="flex shrink-0 items-center py-2 px-5 pl-[58px] font-[family-name:var(--font-dm-sans)]">
-						<div className="flex-1 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
-							Name
-						</div>
-						<div className="flex-[1.2] text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
-							Email
-						</div>
-						<div className="min-w-[100px] text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
-							Role
-						</div>
-						<div className="w-[40px]" />
-					</div>
+				{view === "people" ? (
+					<>
+						<div className="relative">
+							<SearchBar
+								placeholder="Search users by name or email..."
+								value={search}
+								onChange={setSearch}
+							/>
 
-					{/* Rows */}
-					<div className="min-h-0 flex-1 overflow-y-auto pb-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-						{owner && (
-							<div className="flex items-center py-3 px-5 rounded-[16px] transition-all duration-200 hover:bg-[#F8FAF9] dark:hover:bg-white/5">
-								<div className="shrink-0 w-[34px] h-[34px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[12px] font-bold text-[#6B7F76] dark:text-muted-foreground">
-									{getInitials(owner.name)}
+							{search.trim() && searchResults.length > 0 && (
+								<div className="absolute top-full left-0 right-0 mt-2 z-10 bg-white dark:bg-[#1C1C1C] border-[1.5px] border-[#E0E8E4] dark:border-white/10 rounded-[18px] max-h-[160px] overflow-y-auto shadow-[0_8px_24px_-6px_rgba(0,0,0,0.08)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+									{searchResults.map((user) => (
+										<button
+											key={user.id}
+											type="button"
+											className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-[#F8FAF9] dark:hover:bg-white/5 transition-colors cursor-pointer first:rounded-t-[16px] last:rounded-b-[16px]"
+											onClick={() => { addUser(user.id); }}
+										>
+											<div className="shrink-0 w-[34px] h-[34px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[12px] font-bold text-[#6B7F76] dark:text-muted-foreground">
+												{getInitials(user.name)}
+											</div>
+											<div className="flex-1 min-w-0">
+												<p className="font-[family-name:var(--font-dm-sans)] text-[13.5px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
+													{user.name || "Unnamed"}
+												</p>
+												<p className="font-[family-name:var(--font-dm-sans)] text-[12px] text-[#8FA89E] dark:text-muted-foreground truncate">
+													{user.email}
+												</p>
+											</div>
+										</button>
+									))}
 								</div>
-								<div className="flex-1 min-w-0 ml-3 font-[family-name:var(--font-dm-sans)]">
-									<span className="text-[13.5px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
-										{owner.name || "Unnamed"}
-									</span>
+							)}
+
+							{search.trim() && searchResults.length === 0 && !isLoading && (
+								<div className="absolute top-full left-0 right-0 mt-2 z-10 bg-white dark:bg-[#1C1C1C] border-[1.5px] border-[#E0E8E4] dark:border-white/10 rounded-[18px] shadow-[0_8px_24px_-6px_rgba(0,0,0,0.08)]">
+									<p className="font-[family-name:var(--font-dm-sans)] text-[13px] text-[#A3B5AD] dark:text-muted-foreground text-center py-4">
+										No users found.
+									</p>
 								</div>
-								<div className="flex-[1.2] min-w-0 font-[family-name:var(--font-dm-sans)] text-[13px] text-[#8FA89E] dark:text-muted-foreground font-medium truncate">
-									{owner.email}
+							)}
+						</div>
+
+						<div className="flex flex-1 flex-col min-h-0">
+							{/* Table header */}
+							<div className="flex shrink-0 items-center py-2 px-5 pl-[66px] font-[family-name:var(--font-dm-sans)]">
+								<div className="flex-1 text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+									Name
 								</div>
-								<div className="min-w-[100px]">
-									<span className="font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#6B7F76] dark:text-muted-foreground px-4 py-1.5">
-										Owner
-									</span>
+								<div className="flex-[1.2] text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+									Email
+								</div>
+								<div className="min-w-[100px] text-[11px] font-semibold text-[#B8C8C0] dark:text-muted-foreground uppercase tracking-[0.06em]">
+									Role
 								</div>
 								<div className="w-[40px]" />
 							</div>
-						)}
 
-						{permittedUsers.map((user) => (
-							<div
-								key={user.id}
-								className="group flex items-center py-3 px-5 rounded-[16px] transition-all duration-200 hover:bg-[#F8FAF9] dark:hover:bg-white/5"
-							>
-								<div className="shrink-0 w-[34px] h-[34px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[12px] font-bold text-[#6B7F76] dark:text-muted-foreground">
-									{getInitials(user.name)}
-								</div>
-								<div className="flex-1 min-w-0 ml-3 font-[family-name:var(--font-dm-sans)]">
-									<span className="text-[13.5px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
-										{user.name || "Unnamed"}
-									</span>
-								</div>
-								<div className="flex-[1.2] min-w-0 font-[family-name:var(--font-dm-sans)] text-[13px] text-[#8FA89E] dark:text-muted-foreground font-medium truncate">
-									{user.email}
-								</div>
-								<div className="min-w-[100px]">
-									<SageDropdownMenu
-										trigger={
-											<button className="w-[100px] rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent text-[13px] font-semibold font-[family-name:var(--font-dm-sans)] text-[#1E2D28] dark:text-foreground h-auto py-1.5 px-4 flex items-center justify-between gap-1 cursor-pointer hover:border-[#A3B5AD] transition-colors">
-												<span>{PERMISSION_LABELS[user.permission]}</span>
-												<ChevronDown className="size-3.5 text-[#8FA89E] shrink-0" />
-											</button>
-										}
-										items={[
-											{ label: "Admin", onClick: () => updatePermission(user.id, "admin"), active: user.permission === "admin" },
-											{ label: "Editor", onClick: () => updatePermission(user.id, "editor"), active: user.permission === "editor" },
-											{ label: "Member", onClick: () => updatePermission(user.id, "member"), active: user.permission === "member" },
-										]}
-									/>
-								</div>
-								<div className="w-[40px] flex justify-center">
-									<button
-										className="w-8 h-8 rounded-xl flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all duration-200 hover:bg-[#F0F3F2] dark:hover:bg-white/10 cursor-pointer"
-										onClick={() => removeUser(user.id)}
+							{/* Rows */}
+							<div className="min-h-0 flex-1 overflow-y-auto pb-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+								{owner && (
+									<div className="flex items-center py-3 px-5 rounded-[16px] transition-all duration-200 hover:bg-[#F8FAF9] dark:hover:bg-white/5">
+										<div className="shrink-0 w-[34px] h-[34px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[12px] font-bold text-[#6B7F76] dark:text-muted-foreground">
+											{getInitials(owner.name)}
+										</div>
+										<div className="flex-1 min-w-0 ml-3 font-[family-name:var(--font-dm-sans)]">
+											<span className="text-[13.5px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
+												{owner.name || "Unnamed"}
+											</span>
+										</div>
+										<div className="flex-[1.2] min-w-0 font-[family-name:var(--font-dm-sans)] text-[13px] text-[#8FA89E] dark:text-muted-foreground font-medium truncate">
+											{owner.email}
+										</div>
+										<div className="min-w-[100px]">
+											<span className="font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#6B7F76] dark:text-muted-foreground px-4 py-1.5">
+												Owner
+											</span>
+										</div>
+										<div className="w-[40px]" />
+									</div>
+								)}
+
+								{permittedUsers.map((user) => (
+									<div
+										key={user.id}
+										className="group flex items-center py-3 px-5 rounded-[16px] transition-all duration-200 hover:bg-[#F8FAF9] dark:hover:bg-white/5"
 									>
-										<Trash2 className="h-[15px] w-[15px] text-[#A3B5AD]" />
-									</button>
-								</div>
-							</div>
-						))}
+										<div className="shrink-0 w-[34px] h-[34px] rounded-full bg-[#F0F3F2] dark:bg-white/10 border-[1.5px] border-[#E0E8E4] dark:border-white/10 flex items-center justify-center text-[12px] font-bold text-[#6B7F76] dark:text-muted-foreground">
+											{getInitials(user.name)}
+										</div>
+										<div className="flex-1 min-w-0 ml-3 font-[family-name:var(--font-dm-sans)]">
+											<span className="text-[13.5px] font-semibold text-[#1E2D28] dark:text-foreground truncate">
+												{user.name || "Unnamed"}
+											</span>
+										</div>
+										<div className="flex-[1.2] min-w-0 font-[family-name:var(--font-dm-sans)] text-[13px] text-[#8FA89E] dark:text-muted-foreground font-medium truncate">
+											{user.email}
+										</div>
+										<div className="min-w-[100px]">
+											<SageDropdownMenu
+												trigger={
+													<button className="w-[100px] rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-white dark:bg-transparent text-[13px] font-semibold font-[family-name:var(--font-dm-sans)] text-[#1E2D28] dark:text-foreground h-auto py-1.5 px-4 flex items-center justify-between gap-1 cursor-pointer hover:border-[#A3B5AD] transition-colors">
+														<span>{PERMISSION_LABELS[user.permission]}</span>
+														<ChevronDown className="size-3.5 text-[#8FA89E] shrink-0" />
+													</button>
+												}
+												items={[
+													{ label: "Admin", onClick: () => { updatePermission(user.id, "admin"); }, active: user.permission === "admin" },
+													{ label: "Editor", onClick: () => { updatePermission(user.id, "editor"); }, active: user.permission === "editor" },
+													{ label: "Member", onClick: () => { updatePermission(user.id, "member"); }, active: user.permission === "member" },
+												]}
+											/>
+										</div>
+										<div className="w-[40px] flex justify-center">
+											<button
+												className="w-8 h-8 rounded-xl flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all duration-200 hover:bg-[#F0F3F2] dark:hover:bg-white/10 cursor-pointer"
+												onClick={() => { removeUser(user.id); }}
+											>
+												<Trash2 className="h-[15px] w-[15px] text-[#A3B5AD]" />
+											</button>
+										</div>
+									</div>
+								))}
 
-						{!owner && permittedUsers.length === 0 && !isLoading && (
-							<div className="text-center py-12 font-[family-name:var(--font-dm-sans)] text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium">
-								No permissions set. Search for users to add.
+								{!owner && permittedUsers.length === 0 && !isLoading && (
+									<div className="text-center py-12 font-[family-name:var(--font-dm-sans)] text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium">
+										No permissions set. Search for users to add.
+									</div>
+								)}
 							</div>
-						)}
+						</div>
+					</>
+				) : (
+					<div className="flex flex-1 flex-col min-h-0">
+						<p className="shrink-0 px-1 pb-3 font-[family-name:var(--font-dm-sans)] text-[13px] text-[#8FA89E] dark:text-muted-foreground">
+							Select teams to grant their members{" "}
+							<span className="font-semibold text-[#6B7F76] dark:text-foreground">
+								Member
+							</span>{" "}
+							access to this agent.
+						</p>
+
+						<div className="min-h-0 flex-1 overflow-y-auto pb-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+							{allTeams.length === 0 ? (
+								<div className="text-center py-12 font-[family-name:var(--font-dm-sans)] text-[14px] text-[#A3B5AD] dark:text-muted-foreground font-medium">
+									No teams yet. Create one from the Users page.
+								</div>
+							) : (
+								<div className="flex flex-wrap gap-2 px-1">
+									{allTeams.map((team) => {
+										const selected = selectedTeamIds.includes(team.id);
+										return (
+											<button
+												key={team.id}
+												type="button"
+												onClick={() => {
+													toggleTeam(team.id);
+												}}
+												className={cn(
+													"inline-flex items-center gap-2 rounded-full border-[1.5px] px-3.5 py-2 text-[13px] font-semibold font-[family-name:var(--font-dm-sans)] cursor-pointer transition-colors",
+													selected
+														? "border-[#4CA882] bg-[#EDF4F0] dark:bg-emerald-950/40 text-[#1E2D28] dark:text-foreground"
+														: "border-dashed border-[#CBD8D2] dark:border-white/15 text-[#6B7F76] dark:text-muted-foreground hover:border-[#A3B5AD] hover:bg-[#F8FAF9] dark:hover:bg-white/5",
+												)}
+											>
+												<span
+													className="size-2 shrink-0 rounded-full"
+													style={{ background: team.color ?? "#9E9E9E" }}
+												/>
+												{team.name}
+												{selected ? (
+													<Check className="size-3.5 shrink-0 text-[#4CA882]" />
+												) : (
+													<Plus className="size-3.5 shrink-0 text-[#8FA89E]" />
+												)}
+											</button>
+										);
+									})}
+								</div>
+							)}
+						</div>
 					</div>
-				</div>
+				)}
 
 				<DialogFooter className="shrink-0">
 					<SageButton color="outline" onClick={handleCancel}>
 						Cancel
 					</SageButton>
-					<SageButton onClick={handleSave} disabled={isSaving}>
+					<SageButton onClick={() => { void handleSave(); }} disabled={isSaving}>
 						{isSaving ? "Saving..." : "Save"}
 					</SageButton>
 				</DialogFooter>

--- a/web/src/app/(protected)/agents/components/agent-permissions-dialog.tsx
+++ b/web/src/app/(protected)/agents/components/agent-permissions-dialog.tsx
@@ -78,6 +78,11 @@ export default function AgentPermissionsDialog({
 		setIsLoading(true);
 		setSearch("");
 		setView("people");
+		// Clear prior agent's data so stale teams/permissions can't linger or be
+		// saved if this load is slow or fails.
+		setPermissions([]);
+		setAllTeams([]);
+		setSelectedTeamIds([]);
 		Promise.all([
 			api.get("/users"),
 			api.get(`/agents/${agentId}/permissions`),

--- a/web/src/app/(protected)/users/invite-dialog.tsx
+++ b/web/src/app/(protected)/users/invite-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Copy, Check, X } from "lucide-react";
 import { api } from "@/lib/api/client";
+import { type Team } from "./new-team-dialog";
 
 type Role = "member" | "editor" | "admin";
 
@@ -18,16 +19,19 @@ interface Invite {
 interface InviteDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	teams: Team[];
 	onInviteCreated?: (invite: Invite) => void;
 }
 
 export default function InviteDialog({
 	open,
 	onOpenChange,
+	teams,
 	onInviteCreated,
 }: InviteDialogProps) {
 	const [email, setEmail] = useState("");
 	const [role, setRole] = useState<Role>("member");
+	const [teamId, setTeamId] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [inviteUrl, setInviteUrl] = useState<string | null>(null);
@@ -39,7 +43,11 @@ export default function InviteDialog({
 		setIsLoading(true);
 
 		try {
-			const response = await api.post("/invites/", { email, role });
+			const response = await api.post("/invites/", {
+				email,
+				role,
+				teamId: teamId || null,
+			});
 			setInviteUrl(response.data.inviteUrl);
 			onInviteCreated?.(response.data);
 		} catch (err: unknown) {
@@ -60,12 +68,13 @@ export default function InviteDialog({
 		if (!inviteUrl) return;
 		await navigator.clipboard.writeText(inviteUrl);
 		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
+		setTimeout(() => { setCopied(false); }, 2000);
 	};
 
 	const handleClose = () => {
 		setEmail("");
 		setRole("member");
+		setTeamId("");
 		setError(null);
 		setInviteUrl(null);
 		setCopied(false);
@@ -81,7 +90,7 @@ export default function InviteDialog({
 		>
 			<div
 				className="bg-white dark:bg-card rounded-[28px] p-8 w-[420px] max-w-[90vw] shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] animate-in slide-in-from-bottom-4 zoom-in-[0.97] duration-300"
-				onClick={(e) => e.stopPropagation()}
+				onClick={(e) => { e.stopPropagation(); }}
 			>
 				{/* Header */}
 				<div className="flex items-center justify-between mb-7">
@@ -112,7 +121,7 @@ export default function InviteDialog({
 								className="flex-1 min-w-0 px-4.5 py-3 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 font-[family-name:var(--font-dm-sans)] text-[14px] font-medium text-[#1E2D28] dark:text-white truncate focus:outline-none"
 							/>
 							<button
-								onClick={handleCopy}
+								onClick={() => { void handleCopy(); }}
 								className={`shrink-0 flex items-center gap-1.5 px-4 py-3 rounded-full border-[1.5px] font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold cursor-pointer transition-all duration-200 ${
 									copied
 										? "bg-[#EDF4F0] dark:bg-white/10 text-[#3D8B63] dark:text-emerald-400 border-[#3D8B63]/20"
@@ -135,7 +144,7 @@ export default function InviteDialog({
 						</button>
 					</div>
 				) : (
-					<form onSubmit={handleSubmit}>
+					<form onSubmit={(e) => { void handleSubmit(e); }}>
 						{error && (
 							<div className="mb-5 p-3.5 rounded-2xl bg-red-50 dark:bg-red-950/30 text-[13px] font-medium text-red-600 dark:text-red-400 font-[family-name:var(--font-dm-sans)]">
 								{error}
@@ -151,25 +160,45 @@ export default function InviteDialog({
 								type="email"
 								placeholder="colleague@example.com"
 								value={email}
-								onChange={(e) => setEmail(e.target.value)}
+								onChange={(e) => { setEmail(e.target.value); }}
 								required
 								className="w-full px-4.5 py-3 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 font-[family-name:var(--font-dm-sans)] text-[14px] font-medium text-[#1E2D28] dark:text-white placeholder:text-[#A3B5AD] dark:placeholder:text-white/30 focus:outline-none focus:border-[#4CA882] transition-colors"
 							/>
 						</div>
 
 						{/* Role */}
-						<div className="mb-7">
+						<div className="mb-5">
 							<label className="block font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#1E2D28] dark:text-foreground mb-2">
 								Role
 							</label>
 							<select
 								value={role}
-								onChange={(e) => setRole(e.target.value as Role)}
+								onChange={(e) => { setRole(e.target.value as Role); }}
 								className="w-auto px-4.5 py-3 pr-9 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-white cursor-pointer appearance-none focus:outline-none focus:border-[#4CA882] transition-colors bg-[url('data:image/svg+xml,%3Csvg%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%238FA89E%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%3E%3Cpolyline%20points%3D%276%209%2012%2015%2018%209%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_14px_center]"
 							>
 								<option value="member">Member</option>
 								<option value="editor">Editor</option>
 								<option value="admin">Admin</option>
+							</select>
+						</div>
+
+						{/* Team */}
+						<div className="mb-7">
+							<label className="block font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#1E2D28] dark:text-foreground mb-2">
+								Team{" "}
+								<span className="font-medium text-[#A3B5AD]">(optional)</span>
+							</label>
+							<select
+								value={teamId}
+								onChange={(e) => { setTeamId(e.target.value); }}
+								className="w-auto px-4.5 py-3 pr-9 rounded-full border-[1.5px] border-[#E0E8E4] dark:border-white/10 bg-[#FAFCFB] dark:bg-white/5 font-[family-name:var(--font-dm-sans)] text-[14px] font-semibold text-[#1E2D28] dark:text-white cursor-pointer appearance-none focus:outline-none focus:border-[#4CA882] transition-colors bg-[url('data:image/svg+xml,%3Csvg%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%20stroke%3D%27%238FA89E%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%3E%3Cpolyline%20points%3D%276%209%2012%2015%2018%209%27/%3E%3C/svg%3E')] bg-no-repeat bg-[right_14px_center]"
+							>
+								<option value="">No team</option>
+								{teams.map((t) => (
+									<option key={t.id} value={t.id}>
+										{t.name}
+									</option>
+								))}
 							</select>
 						</div>
 

--- a/web/src/app/(protected)/users/new-team-dialog.tsx
+++ b/web/src/app/(protected)/users/new-team-dialog.tsx
@@ -97,6 +97,7 @@ export default function NewTeamDialog({
 						</div>
 						<button
 							type="button"
+							aria-label="Close"
 							onClick={() => {
 								onOpenChange(false);
 							}}
@@ -138,6 +139,9 @@ export default function NewTeamDialog({
 								<button
 									key={c}
 									type="button"
+									aria-label={`Color ${c}`}
+									aria-pressed={color === c}
+									title={c}
 									onClick={() => {
 										setColor(c);
 									}}

--- a/web/src/app/(protected)/users/new-team-dialog.tsx
+++ b/web/src/app/(protected)/users/new-team-dialog.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { SageInput } from "@/components/ui/sage-input";
+import { SageButton } from "@/components/ui/sage-button";
+import { AGENT_COLORS } from "@/lib/colors";
+import { api } from "@/lib/api/client";
+
+export interface Team {
+	id: string;
+	name: string;
+	color: string | null;
+}
+
+interface NewTeamDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	team?: Team | null;
+	onTeamCreated?: (team: Team) => void;
+	onTeamUpdated?: (team: Team) => void;
+}
+
+export default function NewTeamDialog({
+	open,
+	onOpenChange,
+	team,
+	onTeamCreated,
+	onTeamUpdated,
+}: NewTeamDialogProps) {
+	const isEdit = !!team;
+	const [name, setName] = useState("");
+	const [color, setColor] = useState<string>(AGENT_COLORS[0]);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (open) {
+			setName(team?.name ?? "");
+			setColor(team?.color ?? AGENT_COLORS[0]);
+			setError(null);
+			setIsSubmitting(false);
+		}
+	}, [open, team]);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		const trimmed = name.trim();
+		if (!trimmed) return;
+		setError(null);
+		setIsSubmitting(true);
+		try {
+			if (team) {
+				const response = await api.patch(`/teams/${team.id}`, {
+					name: trimmed,
+					color,
+				});
+				onTeamUpdated?.(response.data as Team);
+			} else {
+				const response = await api.post("/teams/", { name: trimmed, color });
+				onTeamCreated?.(response.data as Team);
+			}
+			onOpenChange(false);
+		} catch (err: unknown) {
+			if (err && typeof err === "object" && "response" in err) {
+				const axiosError = err as { response?: { data?: { detail?: string } } };
+				setError(axiosError.response?.data?.detail || "An error occurred");
+			} else {
+				setError("An error occurred");
+			}
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="sm:max-w-[460px] rounded-[28px] p-0 gap-0 overflow-hidden"
+				showCloseButton={false}
+			>
+				<form
+					onSubmit={(e) => {
+						void handleSubmit(e);
+					}}
+				>
+					{/* Header */}
+					<div className="flex items-start justify-between px-8 pt-7 pb-0">
+						<div>
+							<DialogTitle className="font-[family-name:var(--font-jakarta-sans)] text-[22px] font-extrabold text-[#111111] dark:text-white tracking-[-0.02em]">
+								{isEdit ? "Edit team" : "New team"}
+							</DialogTitle>
+							<p className="font-[family-name:var(--font-dm-sans)] text-[14px] text-[#8FA89E] dark:text-muted-foreground font-medium mt-1">
+								Group members so they share a set of agents
+							</p>
+						</div>
+						<button
+							type="button"
+							onClick={() => {
+								onOpenChange(false);
+							}}
+							className="shrink-0 flex items-center justify-center w-9 h-9 rounded-full bg-[#F5F8F6] dark:bg-white/10 text-[#6B7F76] hover:bg-[#EDF4F0] dark:hover:bg-white/15 transition-colors cursor-pointer"
+						>
+							<X className="w-4 h-4" />
+						</button>
+					</div>
+
+					{/* Content */}
+					<div className="px-8 pt-6 pb-2">
+						{error && (
+							<div className="mb-5 p-3.5 rounded-2xl bg-red-50 dark:bg-red-950/30 text-[13px] font-medium text-red-600 dark:text-red-400 font-[family-name:var(--font-dm-sans)]">
+								{error}
+							</div>
+						)}
+
+						<label
+							htmlFor="team-name"
+							className="block font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#1E2D28] dark:text-foreground mb-2"
+						>
+							Name
+						</label>
+						<SageInput
+							id="team-name"
+							autoFocus
+							placeholder="e.g. Marketing"
+							value={name}
+							onChange={(e) => {
+								setName(e.target.value);
+							}}
+						/>
+
+						<label className="block font-[family-name:var(--font-dm-sans)] text-[13px] font-semibold text-[#1E2D28] dark:text-foreground mt-5 mb-2.5">
+							Color
+						</label>
+						<div className="flex items-center gap-2.5">
+							{AGENT_COLORS.map((c) => (
+								<button
+									key={c}
+									type="button"
+									onClick={() => {
+										setColor(c);
+									}}
+									style={{ backgroundColor: c }}
+									className={`w-7 h-7 rounded-full cursor-pointer transition-transform hover:scale-110 ${
+										color === c
+											? "ring-2 ring-offset-2 ring-gray-400 dark:ring-offset-[#222]"
+											: ""
+									}`}
+								/>
+							))}
+						</div>
+					</div>
+
+					{/* Footer */}
+					<div className="flex items-center justify-end gap-2.5 px-8 pt-5 pb-6 mt-4 border-t border-[#F0F3F2] dark:border-white/5">
+						<SageButton
+							type="button"
+							color="outline"
+							onClick={() => {
+								onOpenChange(false);
+							}}
+						>
+							Cancel
+						</SageButton>
+						<SageButton type="submit" disabled={isSubmitting || !name.trim()}>
+							{isSubmitting
+								? "Saving..."
+								: isEdit
+									? "Save"
+									: "Create team"}
+						</SageButton>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -130,9 +130,9 @@ export default function UsersPage() {
 				console.error("Error fetching teams:", error);
 			}
 		};
-		fetchUsers();
-		fetchInvites();
-		fetchTeams();
+		void fetchUsers();
+		void fetchInvites();
+		void fetchTeams();
 	}, []);
 
 	const teamsById = useMemo(

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import { Trash2, Plus, Copy, Check, Mail, ChevronDown } from "lucide-react";
+import {
+	Trash2,
+	Plus,
+	Copy,
+	Check,
+	Mail,
+	ChevronDown,
+	MoreVertical,
+	Pencil,
+} from "lucide-react";
 import ForbiddenErrorDialog from "@/components/forbidden-error-dialog";
 import InviteDialog from "./invite-dialog";
+import NewTeamDialog, { type Team } from "./new-team-dialog";
 import { SearchBar } from "@/components/ui/search-bar";
 import { Button } from "@/components/ui/button";
 import { PageContainer } from "@/components/layout/page-container";
@@ -16,6 +26,7 @@ interface User {
 	name: string | null;
 	email: string | null;
 	role: "member" | "editor" | "admin";
+	teamId: string | null;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -81,11 +92,15 @@ export default function UsersPage() {
 	const currentUser = useUserStore((state) => state.user);
 	const [users, setUsers] = useState<User[]>([]);
 	const [invites, setInvites] = useState<Invite[]>([]);
+	const [teams, setTeams] = useState<Team[]>([]);
 	const [search, setSearch] = useState("");
 	const [roleFilter, setRoleFilter] = useState<"all" | Role>("all");
 	const [isLoading, setIsLoading] = useState(true);
 	const [errorDialogOpen, setErrorDialogOpen] = useState(false);
 	const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
+	const [newTeamDialogOpen, setNewTeamDialogOpen] = useState(false);
+	const [pendingTeamUserId, setPendingTeamUserId] = useState<string | null>(null);
+	const [editingTeam, setEditingTeam] = useState<Team | null>(null);
 	const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -107,14 +122,28 @@ export default function UsersPage() {
 				console.error("Error fetching invites:", error);
 			}
 		};
+		const fetchTeams = async () => {
+			try {
+				const response = await api.get("/teams/");
+				setTeams(response.data);
+			} catch (error) {
+				console.error("Error fetching teams:", error);
+			}
+		};
 		fetchUsers();
 		fetchInvites();
+		fetchTeams();
 	}, []);
+
+	const teamsById = useMemo(
+		() => new Map(teams.map((t) => [t.id, t])),
+		[teams],
+	);
 
 	const handleCopyInviteLink = async (invite: Invite) => {
 		await navigator.clipboard.writeText(invite.inviteUrl);
 		setCopiedInviteId(invite.id);
-		setTimeout(() => setCopiedInviteId(null), 2000);
+		setTimeout(() => { setCopiedInviteId(null); }, 2000);
 	};
 
 	const handleDeleteInvite = async (inviteId: string) => {
@@ -177,6 +206,92 @@ export default function UsersPage() {
 		}
 	};
 
+	const handleTeamChange = async (userId: string, teamId: string | null) => {
+		try {
+			await api.patch(`/users/${userId}/team`, { teamId });
+			setUsers((prev) =>
+				prev.map((u) => (u.id === userId ? { ...u, teamId } : u)),
+			);
+		} catch (error: unknown) {
+			if (
+				error instanceof Object &&
+				"status" in error &&
+				error.status === 403
+			) {
+				setErrorDialogOpen(true);
+			} else {
+				console.error("Error updating team:", error);
+			}
+		}
+	};
+
+	const handleOpenNewTeam = (userId: string) => {
+		setEditingTeam(null);
+		setPendingTeamUserId(userId);
+		setNewTeamDialogOpen(true);
+	};
+
+	const handleTeamCreated = (team: Team) => {
+		setTeams((prev) =>
+			[...prev, team].sort((a, b) => a.name.localeCompare(b.name)),
+		);
+		if (pendingTeamUserId) {
+			void handleTeamChange(pendingTeamUserId, team.id);
+			setPendingTeamUserId(null);
+		}
+	};
+
+	const handleTeamUpdated = (team: Team) => {
+		setTeams((prev) =>
+			prev
+				.map((t) => (t.id === team.id ? team : t))
+				.sort((a, b) => a.name.localeCompare(b.name)),
+		);
+	};
+
+	const openCreateTeam = () => {
+		setEditingTeam(null);
+		setPendingTeamUserId(null);
+		setNewTeamDialogOpen(true);
+	};
+
+	const openEditTeam = (team: Team) => {
+		setEditingTeam(team);
+		setPendingTeamUserId(null);
+		setNewTeamDialogOpen(true);
+	};
+
+	const handleDeleteTeam = async (team: Team) => {
+		const memberCount = users.filter((u) => u.teamId === team.id).length;
+		const confirmed = window.confirm(
+			`Delete "${team.name}"?${
+				memberCount > 0
+					? ` ${memberCount} member${memberCount === 1 ? "" : "s"} will be unassigned`
+					: ""
+			} and its agent links will be removed.`,
+		);
+		if (!confirmed) return;
+
+		try {
+			await api.delete(`/teams/${team.id}`);
+			setTeams((prev) => prev.filter((t) => t.id !== team.id));
+			// Mirror the DB's ON DELETE SET NULL so the table reflects reality.
+			setUsers((prev) =>
+				prev.map((u) => (u.teamId === team.id ? { ...u, teamId: null } : u)),
+			);
+		} catch (error: unknown) {
+			if (
+				error instanceof Object &&
+				"status" in error &&
+				error.status === 403
+			) {
+				setErrorDialogOpen(true);
+			} else {
+				console.error("Error deleting team:", error);
+			}
+		}
+	};
+
 	const handleRemoveUser = async (userId: string, userName: string | null) => {
 		const confirmed = window.confirm(
 			`Are you sure you want to remove ${userName || "this user"} from the workspace?`,
@@ -210,7 +325,21 @@ export default function UsersPage() {
 			<InviteDialog
 				open={inviteDialogOpen}
 				onOpenChange={setInviteDialogOpen}
-				onInviteCreated={(invite) => setInvites((prev) => [...prev, invite])}
+				teams={teams}
+				onInviteCreated={(invite) => { setInvites((prev) => [...prev, invite]); }}
+			/>
+			<NewTeamDialog
+				open={newTeamDialogOpen}
+				onOpenChange={(open) => {
+					setNewTeamDialogOpen(open);
+					if (!open) {
+						setPendingTeamUserId(null);
+						setEditingTeam(null);
+					}
+				}}
+				team={editingTeam}
+				onTeamCreated={handleTeamCreated}
+				onTeamUpdated={handleTeamUpdated}
 			/>
 			<div className="flex flex-col gap-5 my-8 sm:flex-row sm:items-start sm:justify-between">
 				<div className="min-w-0">
@@ -232,7 +361,7 @@ export default function UsersPage() {
 					/>
 					<Button
 						className="flex items-center gap-2 px-6! py-3! h-auto! bg-[#111111] dark:bg-white dark:text-[#111111] text-[14px] font-semibold font-[family-name:var(--font-dm-sans)] text-white rounded-full hover:bg-[#222222] dark:hover:bg-gray-100 transition-all cursor-pointer shadow-[0_4px_12px_-2px_rgba(0,0,0,0.15)] border-none whitespace-nowrap"
-						onClick={() => setInviteDialogOpen(true)}
+						onClick={() => { setInviteDialogOpen(true); }}
 					>
 						<Plus className="w-4 h-4" />
 						Invite user
@@ -269,7 +398,7 @@ export default function UsersPage() {
 
 					{/* Member list panel */}
 					<div className="overflow-hidden rounded-[14px] border border-[#e1ebe6] bg-white dark:border-white/10 dark:bg-card">
-						<div className="grid grid-cols-[1fr_auto_34px] md:grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] dark:border-white/5">
+						<div className="grid grid-cols-[1fr_auto_34px] md:grid-cols-[1fr_200px_120px_150px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] dark:border-white/5">
 							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
 								Name
 							</span>
@@ -278,6 +407,9 @@ export default function UsersPage() {
 							</span>
 							<span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
 								Role
+							</span>
+							<span className="hidden md:block text-[10px] font-semibold uppercase tracking-[0.1em] text-[#94a59d]">
+								Team
 							</span>
 							<span />
 						</div>
@@ -294,7 +426,7 @@ export default function UsersPage() {
 								return (
 									<div
 										key={user.id}
-										className="group grid grid-cols-[1fr_auto_34px] md:grid-cols-[1fr_230px_130px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] transition-colors duration-[110ms] last:border-b-0 hover:bg-[#eff4f1] dark:border-white/5 dark:hover:bg-white/5"
+										className="group grid grid-cols-[1fr_auto_34px] md:grid-cols-[1fr_200px_120px_150px_34px] items-center gap-4 border-b border-[#edf2ef] px-[18px] py-[11px] transition-colors duration-[110ms] last:border-b-0 hover:bg-[#eff4f1] dark:border-white/5 dark:hover:bg-white/5"
 									>
 										{/* Identity */}
 										<div className="flex min-w-0 items-center gap-3">
@@ -347,12 +479,75 @@ export default function UsersPage() {
 														</button>
 													}
 													items={[
-														{ label: "Admin", onClick: () => handleRoleChange(user.id, "admin"), active: user.role === "admin" },
-														{ label: "Editor", onClick: () => handleRoleChange(user.id, "editor"), active: user.role === "editor" },
-														{ label: "Member", onClick: () => handleRoleChange(user.id, "member"), active: user.role === "member" },
+														{ label: "Admin", onClick: () => { void handleRoleChange(user.id, "admin"); }, active: user.role === "admin" },
+														{ label: "Editor", onClick: () => { void handleRoleChange(user.id, "editor"); }, active: user.role === "editor" },
+														{ label: "Member", onClick: () => { void handleRoleChange(user.id, "member"); }, active: user.role === "member" },
 													]}
 												/>
 											)}
+										</div>
+
+										{/* Team */}
+										<div className="hidden md:block min-w-0">
+											{(() => {
+												const team = user.teamId
+													? teamsById.get(user.teamId)
+													: undefined;
+												return (
+													<SageDropdownMenu
+														align="start"
+														trigger={
+															team ? (
+																<button className="inline-flex max-w-full items-center gap-2 rounded-lg border border-[#e1ebe6] bg-white px-2.5 py-[5px] font-[family-name:var(--font-dm-sans)] text-[13px] font-medium text-[#1e2d28] cursor-pointer transition-colors hover:border-[#A3B5AD] dark:border-white/10 dark:bg-transparent dark:text-foreground">
+																	<span
+																		className="size-1.5 shrink-0 rounded-full"
+																		style={{ background: team.color ?? "#9E9E9E" }}
+																	/>
+																	<span className="truncate">{team.name}</span>
+																	<ChevronDown className="size-3.5 shrink-0 text-[#94a59d]" />
+																</button>
+															) : (
+																<button className="inline-flex items-center gap-2 rounded-lg border border-dashed border-[#d8e3dd] bg-transparent px-2.5 py-[5px] font-[family-name:var(--font-dm-sans)] text-[13px] font-medium text-[#94a59d] cursor-pointer transition-colors hover:border-[#A3B5AD] hover:text-[#5f7068] dark:border-white/15">
+																	<span className="size-1.5 shrink-0 rounded-full border border-[#c3d2cb] dark:border-white/20" />
+																	No team
+																	<ChevronDown className="size-3.5 shrink-0 text-[#94a59d]" />
+																</button>
+															)
+														}
+														items={[
+															{
+																label: "No team",
+																icon: (
+																	<span className="block size-2 rounded-full border border-[#c3d2cb] dark:border-white/25" />
+																),
+																onClick: () => {
+													void handleTeamChange(user.id, null);
+												},
+																active: !user.teamId,
+															},
+															...teams.map((t) => ({
+																label: t.name,
+																icon: (
+																	<span
+																		className="block size-2 rounded-full"
+																		style={{ background: t.color ?? "#9E9E9E" }}
+																	/>
+																),
+																onClick: () => {
+													void handleTeamChange(user.id, t.id);
+												},
+																active: user.teamId === t.id,
+															})),
+															{ separator: true as const },
+															{
+																label: "New team",
+																icon: <Plus />,
+																onClick: () => { handleOpenNewTeam(user.id); },
+															},
+														]}
+													/>
+												);
+											})()}
 										</div>
 
 										{/* Remove */}
@@ -360,7 +555,7 @@ export default function UsersPage() {
 											{!isCurrentUser && (
 												<button
 													className="flex size-7 items-center justify-center rounded-[7px] text-[#94a59d] opacity-100 transition-all hover:bg-[#fbe5e3] hover:text-[#b03a30] cursor-pointer md:opacity-0 md:group-hover:opacity-100 dark:hover:bg-rose-950"
-													onClick={() => handleRemoveUser(user.id, user.name)}
+													onClick={() => { void handleRemoveUser(user.id, user.name); }}
 												>
 													<Trash2 className="size-[15px]" />
 												</button>
@@ -371,6 +566,77 @@ export default function UsersPage() {
 							})
 						)}
 					</div>
+
+					{/* Teams */}
+					<div className="flex items-baseline gap-2.5 pt-6 pb-3">
+						<span className="font-[family-name:var(--font-jakarta-sans)] text-[14px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
+							Teams
+						</span>
+						<span className="text-[11.5px] text-[#94a59d]">
+							{teams.length}
+						</span>
+						<span className="h-px flex-1 self-center bg-[#e1ebe6] dark:bg-white/10" />
+						<button
+							onClick={openCreateTeam}
+							className="inline-flex items-center gap-1.5 rounded-lg border border-[#e1ebe6] px-3 py-1.5 font-[family-name:var(--font-dm-sans)] text-[12px] font-medium text-[#5f7068] cursor-pointer transition-colors hover:bg-[#f8faf9] dark:border-white/10 dark:text-muted-foreground dark:hover:bg-white/5"
+						>
+							<Plus className="size-3.5" />
+							New team
+						</button>
+					</div>
+
+					{teams.length === 0 ? (
+						<div className="rounded-[14px] border border-dashed border-[#d8e3dd] bg-transparent px-[18px] py-8 text-center text-[14px] font-medium text-[#A3B5AD] dark:border-white/10 dark:text-muted-foreground">
+							No teams yet. Create one to group members.
+						</div>
+					) : (
+						<div className="overflow-hidden rounded-[14px] border border-[#e1ebe6] bg-white dark:border-white/10 dark:bg-card">
+							{teams.map((team) => {
+								const memberCount = users.filter(
+									(u) => u.teamId === team.id,
+								).length;
+								return (
+									<div
+										key={team.id}
+										className="group flex items-center gap-3 border-b border-[#edf2ef] px-[18px] py-[11px] transition-colors duration-[110ms] last:border-b-0 hover:bg-[#eff4f1] dark:border-white/5 dark:hover:bg-white/5"
+									>
+										<span
+											className="block size-2.5 shrink-0 rounded-full"
+											style={{ background: team.color ?? "#9E9E9E" }}
+										/>
+										<span className="flex-1 truncate font-[family-name:var(--font-jakarta-sans)] text-[13.5px] font-semibold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
+											{team.name}
+										</span>
+										<span className="shrink-0 text-[11.5px] text-[#94a59d]">
+											{memberCount} member{memberCount > 1 ? "s" : ""}
+										</span>
+										<SageDropdownMenu
+											trigger={
+												<button className="flex size-7 items-center justify-center rounded-[7px] text-[#94a59d] cursor-pointer transition-all hover:bg-[#edf2ef] md:opacity-0 md:group-hover:opacity-100 dark:hover:bg-white/10">
+													<MoreVertical className="size-[18px]" />
+												</button>
+											}
+											items={[
+												{
+													label: "Rename",
+													icon: <Pencil />,
+													onClick: () => { openEditTeam(team); },
+												},
+												{
+													label: "Delete",
+													icon: <Trash2 />,
+													destructive: true,
+													onClick: () => {
+														void handleDeleteTeam(team);
+													},
+												},
+											]}
+										/>
+									</div>
+								);
+							})}
+						</div>
+					)}
 
 					{/* Pending invites */}
 					{invites.length > 0 && (
@@ -420,7 +686,7 @@ export default function UsersPage() {
 										<div className="flex items-center gap-1.5">
 											<button
 												className="flex items-center gap-1.5 rounded-lg border border-[#e1ebe6] px-3 py-1.5 font-[family-name:var(--font-dm-sans)] text-[12px] font-medium text-[#5f7068] cursor-pointer transition-colors hover:bg-[#f8faf9] dark:border-white/10 dark:text-muted-foreground dark:hover:bg-white/5"
-												onClick={() => handleCopyInviteLink(invite)}
+												onClick={() => { void handleCopyInviteLink(invite); }}
 											>
 												{copiedInviteId === invite.id ? (
 													<Check className="size-3.5" />
@@ -431,7 +697,7 @@ export default function UsersPage() {
 											</button>
 											<button
 												className="rounded-lg border border-[#e1ebe6] px-3 py-1.5 font-[family-name:var(--font-dm-sans)] text-[12px] font-medium text-[#b03a30] cursor-pointer transition-colors hover:bg-[#fbe5e3] dark:border-white/10 dark:hover:bg-rose-950"
-												onClick={() => handleDeleteInvite(invite.id)}
+												onClick={() => { void handleDeleteInvite(invite.id); }}
 											>
 												Revoke
 											</button>


### PR DESCRIPTION
## Summary

Introduces **teams**: a workspace admin groups users so that **team membership grants Member-level usage** of any agent bound to the team. Higher access (editor/admin/owner) still comes from per-user grants, which always win in resolution — so a user + team grant is harmless redundancy.

A user belongs to **one** team; an agent can be bound to **many** teams.

## Backend

- New `app/teams/` module — `TeamDB` (unique `name` + `color`), CRUD service/repo/router (admin-gated writes, open `GET /teams`). `AgentTeamDB` binding (agent → many teams).
- `users.team_id` and `invites.team_id` (FK `ON DELETE SET NULL`); `agent_teams` (`ON DELETE CASCADE`). So deleting a team unassigns its members and drops its agent links at the DB level. Invite accept (password + Google) applies the team.
- `AgentService._resolve_permission` gains a team branch (`member`), ordered **below** explicit grants. `list_with_permissions` folds the team match into the query, filtered on the user's single `team_id` (matches ≤1 row/agent → no fan-out). `user_team_id` threaded through `get`/`list`/`update`/`restore`/`delete_permanently` and the Slack agent picker.
- `PATCH /users/{id}/team` (admin). Closed a pre-existing gap: `require_admin` retrofitted onto the previously ungated `PATCH /users/{id}` and `/role`.
- Alembic migration `f3c2b1a09d8e` (applied to dev DB).

## Frontend

- **Users page**: Team column (assign via dropdown w/ color dots + empty state), New-team dialog (name + agent color palette), and a **Teams panel** with per-team rename/delete via a kebab menu (mirrors the sidebar threads pattern). Deleting reflects the DB cascade locally.
- **Invite dialog**: optional team select.
- **Agent → Manage permissions modal**: People / Teams toggle; team chips grant Member access — dashed "+" = grant, green check = granted.

## Tests

`tests/teams`, `tests/invites`, resolution + binding cases in `tests/agents/core`, and `/team` + admin-gate cases in `tests/users`. Full backend suite green (316 passed). Ruff + strict pre-commit eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds teams to control agent access. Team membership gives Member-level usage on any agent linked to that team, while per-user grants still override.

- **New Features**
  - Backend: `teams` module with CRUD (`TeamDB` name+color). Validates non-empty names; unique-name conflicts return 409. Open `GET /teams`, admin-only writes.
  - Data model: one team per user (`users.team_id`), many teams per agent (`agent_teams` with cascade and indexed `team_id`).
  - Permissions: team-based Member access below explicit grants; `user_team_id` flows through agent list/get and the Slack agent picker. Agent team-binding API added: `GET/PUT /agents/{id}/teams` (owner/admin/editor only).
  - Invites: optional `team_id`; accepted invites assign the team (password or Google). Validates `team_id` exists.
  - API: `PATCH /users/{id}/team` (admin). Added admin guard to `PATCH /users/{id}` and `PATCH /users/{id}/role`. `GET /users` and `GET /users/{id}` now require authentication.
  - Frontend: Users page adds a Team column and a Teams panel (create/rename/delete). Invite dialog can pick a team. Agent permissions modal adds a People/Teams toggle with team chips; clears stale state on open. New-team dialog includes a11y fixes. Users page effect voids floating fetches to avoid warnings/leaks.

- **Migration**
  - Run Alembic `f3c2b1a09d8e`.
  - Deleting a team unassigns members (`ON DELETE SET NULL`) and removes agent links (`ON DELETE CASCADE`).
  - Note: updating users and roles is now admin-only via `PATCH /users/{id}` and `PATCH /users/{id}/role`.

<sup>Written for commit 671500686237397c3c09c2acb749e32b5f157748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

