### PR TITLE
feat(model-providers): disable Claude Opus models

### DIFF
--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -22,52 +22,63 @@ class Model(BaseModel):
 # `{"type": "enabled", "budget_tokens": ...}` format. Everything else uses
 # the legacy `enabled` format.
 ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
-    {"claude-opus-4-6", "claude-opus-4-8"})
+    {"claude-opus-4-6", "claude-opus-4-8"}
+)
 
 LLM_PROVIDERS: list[ModelProvider] = []
 MODELS: list[Model] = []
 
 if model_provider_settings.openai_api_key:
-    LLM_PROVIDERS.append(ModelProvider(
-        name="openai", api_key=model_provider_settings.openai_api_key))
+    LLM_PROVIDERS.append(
+        ModelProvider(name="openai", api_key=model_provider_settings.openai_api_key)
+    )
     MODELS.append(Model(name="gpt-4o-mini", provider="openai"))
 
 if model_provider_settings.deepseek_api_key:
-    LLM_PROVIDERS.append(ModelProvider(
-        name="deepseek", api_key=model_provider_settings.deepseek_api_key))
+    LLM_PROVIDERS.append(
+        ModelProvider(name="deepseek", api_key=model_provider_settings.deepseek_api_key)
+    )
     MODELS.append(Model(name="deepseek-v4-flash", provider="deepseek"))
     MODELS.append(Model(name="deepseek-v4-pro", provider="deepseek"))
 
 if model_provider_settings.anthropic_api_key:
-    LLM_PROVIDERS.append(ModelProvider(
-        name="anthropic", api_key=model_provider_settings.anthropic_api_key))
+    LLM_PROVIDERS.append(
+        ModelProvider(
+            name="anthropic", api_key=model_provider_settings.anthropic_api_key
+        )
+    )
     MODELS.append(Model(name="claude-haiku-4-5", provider="anthropic"))
     MODELS.append(Model(name="claude-sonnet-4-6", provider="anthropic"))
-    MODELS.append(Model(name="claude-opus-4-6", provider="anthropic"))
-    MODELS.append(Model(name="claude-opus-4-8", provider="anthropic"))
+    # Claude Opus temporarily disabled.
+    # MODELS.append(Model(name="claude-opus-4-6", provider="anthropic"))
+    # MODELS.append(Model(name="claude-opus-4-8", provider="anthropic"))
 
 if model_provider_settings.google_api_key:
-    LLM_PROVIDERS.append(ModelProvider(
-        name="google", api_key=model_provider_settings.google_api_key))
+    LLM_PROVIDERS.append(
+        ModelProvider(name="google", api_key=model_provider_settings.google_api_key)
+    )
     MODELS.append(Model(name="gemini-3-flash-preview", provider="google"))
     MODELS.append(Model(name="gemini-3-pro-preview", provider="google"))
 
 if model_provider_settings.xiaomi_api_key:
-    LLM_PROVIDERS.append(ModelProvider(
-        name="xiaomi", api_key=model_provider_settings.xiaomi_api_key
-    ))
+    LLM_PROVIDERS.append(
+        ModelProvider(name="xiaomi", api_key=model_provider_settings.xiaomi_api_key)
+    )
     MODELS.append(Model(name="mimo-v2.5-pro", provider="xiaomi"))
     MODELS.append(Model(name="mimo-v2.5", provider="xiaomi"))
 
 
 class ChatModelFactory:
-
     def create(self, provider: str, model_id: str, api_key: str):
         match provider:
             case "openai":
                 return ChatOpenAI(model=model_id, api_key=api_key)
             case "deepseek":
-                return ChatDeepSeek(model=model_id, api_key=api_key, extra_body={"thinking": {"type": "disabled"}})
+                return ChatDeepSeek(
+                    model=model_id,
+                    api_key=api_key,
+                    extra_body={"thinking": {"type": "disabled"}},
+                )
             case "anthropic":
                 kwargs: dict = {}
                 if model_id in ADAPTIVE_THINKING_MODELS:
@@ -78,12 +89,10 @@ class ChatModelFactory:
                     # `content.0.thinking.thinking: Field required`. Requesting
                     # "summarized" keeps the field populated so it survives the
                     # round-trip (and surfaces reasoning to the UI).
-                    kwargs["thinking"] = {
-                        "type": "adaptive", "display": "summarized"}
+                    kwargs["thinking"] = {"type": "adaptive", "display": "summarized"}
                     kwargs["effort"] = "medium"
                 else:
-                    kwargs["thinking"] = {
-                        "type": "enabled", "budget_tokens": 1024}
+                    kwargs["thinking"] = {"type": "enabled", "budget_tokens": 1024}
                 return ChatAnthropic(
                     model=model_id,
                     temperature=1,
@@ -110,7 +119,7 @@ class ChatModelFactory:
                 return ChatOpenAI(
                     base_url="https://api.xiaomimimo.com/v1",
                     model=model_id,
-                    api_key=api_key
+                    api_key=api_key,
                 )
             case _:
                 raise ValueError(f"Provider {provider} not supported")

--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -22,7 +22,7 @@ class Model(BaseModel):
 # `{"type": "enabled", "budget_tokens": ...}` format. Everything else uses
 # the legacy `enabled` format.
 ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
-    {"claude-opus-4-6", "claude-opus-4-8"}
+    {"claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-5"}
 )
 
 LLM_PROVIDERS: list[ModelProvider] = []
@@ -49,6 +49,7 @@ if model_provider_settings.anthropic_api_key:
     )
     MODELS.append(Model(name="claude-haiku-4-5", provider="anthropic"))
     MODELS.append(Model(name="claude-sonnet-4-6", provider="anthropic"))
+    MODELS.append(Model(name="claude-sonnet-5", provider="anthropic"))
     # Claude Opus temporarily disabled.
     # MODELS.append(Model(name="claude-opus-4-6", provider="anthropic"))
     # MODELS.append(Model(name="claude-opus-4-8", provider="anthropic"))

--- a/backend/app/model_providers/router.py
+++ b/backend/app/model_providers/router.py
@@ -77,6 +77,13 @@ async def get_models() -> list[ModelResponse]:
                     chef="Anthropic",
                     chefSlug="anthropic",
                 ),
+                ModelResponse(
+                    name="Claude Sonnet 5",
+                    providers=[ModelProviderType.anthropic],
+                    id="claude-sonnet-5",
+                    chef="Anthropic",
+                    chefSlug="anthropic",
+                ),
                 # Claude Opus temporarily disabled.
                 # ModelResponse(name="Claude Opus 4.6", providers=[
                 #     ModelProviderType.anthropic], id="claude-opus-4-6", chef="Anthropic", chefSlug="anthropic"),

--- a/backend/app/model_providers/router.py
+++ b/backend/app/model_providers/router.py
@@ -14,17 +14,13 @@ async def get_model_providers() -> list[ModelProviderResponse]:
     """List all model providers."""
     model_providers = []
     if model_provider_settings.openai_api_key:
-        model_providers.append(ModelProviderResponse(
-            name=ModelProviderType.openai))
+        model_providers.append(ModelProviderResponse(name=ModelProviderType.openai))
     if model_provider_settings.deepseek_api_key:
-        model_providers.append(ModelProviderResponse(
-            name=ModelProviderType.deepseek))
+        model_providers.append(ModelProviderResponse(name=ModelProviderType.deepseek))
     if model_provider_settings.anthropic_api_key:
-        model_providers.append(ModelProviderResponse(
-            name=ModelProviderType.anthropic))
+        model_providers.append(ModelProviderResponse(name=ModelProviderType.anthropic))
     if model_provider_settings.google_api_key:
-        model_providers.append(ModelProviderResponse(
-            name=ModelProviderType.google))
+        model_providers.append(ModelProviderResponse(name=ModelProviderType.google))
 
     return list(model_providers)
 
@@ -34,39 +30,97 @@ async def get_models() -> list[ModelResponse]:
     """List all models available."""
     models = []
     if model_provider_settings.openai_api_key:
-        models.extend([ModelResponse(name="GPT-4o mini", providers=[ModelProviderType.openai],
-                      id="gpt-4o-mini", chef="OpenAI", chefSlug="openai")])
+        models.extend(
+            [
+                ModelResponse(
+                    name="GPT-4o mini",
+                    providers=[ModelProviderType.openai],
+                    id="gpt-4o-mini",
+                    chef="OpenAI",
+                    chefSlug="openai",
+                )
+            ]
+        )
     if model_provider_settings.deepseek_api_key:
-        models.extend([
-            ModelResponse(name="DeepSeek v4 Flash", providers=[
-                ModelProviderType.deepseek], id="deepseek-v4-flash", chef="DeepSeek", chefSlug="deepseek"),
-            ModelResponse(name="DeepSeek v4 Pro", providers=[
-                ModelProviderType.deepseek], id="deepseek-v4-pro", chef="DeepSeek", chefSlug="deepseek"),
-        ])
+        models.extend(
+            [
+                ModelResponse(
+                    name="DeepSeek v4 Flash",
+                    providers=[ModelProviderType.deepseek],
+                    id="deepseek-v4-flash",
+                    chef="DeepSeek",
+                    chefSlug="deepseek",
+                ),
+                ModelResponse(
+                    name="DeepSeek v4 Pro",
+                    providers=[ModelProviderType.deepseek],
+                    id="deepseek-v4-pro",
+                    chef="DeepSeek",
+                    chefSlug="deepseek",
+                ),
+            ]
+        )
     if model_provider_settings.anthropic_api_key:
-        models.extend([
-            ModelResponse(name="Claude Haiku 4.5", providers=[
-                      ModelProviderType.anthropic], id="claude-haiku-4-5", chef="Anthropic", chefSlug="anthropic"),
-            ModelResponse(name="Claude Sonnet 4.6", providers=[
-                ModelProviderType.anthropic], id="claude-sonnet-4-6", chef="Anthropic", chefSlug="anthropic"),
-            ModelResponse(name="Claude Opus 4.6", providers=[
-                ModelProviderType.anthropic], id="claude-opus-4-6", chef="Anthropic", chefSlug="anthropic"),
-            ModelResponse(name="Claude Opus 4.8", providers=[
-                ModelProviderType.anthropic], id="claude-opus-4-8", chef="Anthropic", chefSlug="anthropic"),
-        ])
+        models.extend(
+            [
+                ModelResponse(
+                    name="Claude Haiku 4.5",
+                    providers=[ModelProviderType.anthropic],
+                    id="claude-haiku-4-5",
+                    chef="Anthropic",
+                    chefSlug="anthropic",
+                ),
+                ModelResponse(
+                    name="Claude Sonnet 4.6",
+                    providers=[ModelProviderType.anthropic],
+                    id="claude-sonnet-4-6",
+                    chef="Anthropic",
+                    chefSlug="anthropic",
+                ),
+                # Claude Opus temporarily disabled.
+                # ModelResponse(name="Claude Opus 4.6", providers=[
+                #     ModelProviderType.anthropic], id="claude-opus-4-6", chef="Anthropic", chefSlug="anthropic"),
+                # ModelResponse(name="Claude Opus 4.8", providers=[
+                #     ModelProviderType.anthropic], id="claude-opus-4-8", chef="Anthropic", chefSlug="anthropic"),
+            ]
+        )
     if model_provider_settings.google_api_key:
-        models.extend([
-            ModelResponse(name="Gemini 3 Flash Preview", providers=[
-                      ModelProviderType.google], id="gemini-3-flash-preview", chef="Google", chefSlug="google"),
-            ModelResponse(name="Gemini 3 Pro Preview", providers=[
-                ModelProviderType.google], id="gemini-3-pro-preview", chef="Google", chefSlug="google"),
-        ])
+        models.extend(
+            [
+                ModelResponse(
+                    name="Gemini 3 Flash Preview",
+                    providers=[ModelProviderType.google],
+                    id="gemini-3-flash-preview",
+                    chef="Google",
+                    chefSlug="google",
+                ),
+                ModelResponse(
+                    name="Gemini 3 Pro Preview",
+                    providers=[ModelProviderType.google],
+                    id="gemini-3-pro-preview",
+                    chef="Google",
+                    chefSlug="google",
+                ),
+            ]
+        )
     if model_provider_settings.xiaomi_api_key:
-        models.extend([
-            ModelResponse(name="MiMo-V2.5-Pro", providers=[
-                      ModelProviderType.xiaomi], id="mimo-v2.5-pro", chef="Xiaomi", chefSlug="xiaomi"),
-            ModelResponse(name="MiMo-V2.5", providers=[
-                ModelProviderType.xiaomi], id="mimo-v2.5", chef="Xiaomi", chefSlug="xiaomi"),
-        ])
+        models.extend(
+            [
+                ModelResponse(
+                    name="MiMo-V2.5-Pro",
+                    providers=[ModelProviderType.xiaomi],
+                    id="mimo-v2.5-pro",
+                    chef="Xiaomi",
+                    chefSlug="xiaomi",
+                ),
+                ModelResponse(
+                    name="MiMo-V2.5",
+                    providers=[ModelProviderType.xiaomi],
+                    id="mimo-v2.5",
+                    chef="Xiaomi",
+                    chefSlug="xiaomi",
+                ),
+            ]
+        )
 
     return list(models)


### PR DESCRIPTION
## Summary

Temporarily disables the Claude Opus models so they no longer appear as selectable options.

- Comments out `claude-opus-4-6` and `claude-opus-4-8` in the backend model catalog (`app/model_providers/catalog.py`).
- Comments out the matching `ModelResponse` entries in the `/model-providers/models` endpoint (`app/model_providers/router.py`).

The frontend renders the model picker dynamically from `/model-providers/models`, so removing them from that endpoint disables Opus in the UI as well — there is no hardcoded model list in `web/`.

Uses a `feat` conventional commit so release-please picks it up.

> Note: the repo's `ruff-format` pre-commit hook reformatted the two touched files, which accounts for most of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disables Claude Opus models and adds `claude-sonnet-5` with adaptive thinking support. Comments out `claude-opus-4-6`/`4-8` in the backend catalog and excludes them from `/model-providers/models`, while registering `claude-sonnet-5` in both and adding it to `ADAPTIVE_THINKING_MODELS`.

<sup>Written for commit bf7ebb5566d4cc2503b420dcc0c7862fdd3d5477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

