### PR TITLE
fix(runs): lower Redis run retention default from 24h to 1h

### DIFF
--- a/backend/app/agents/runs/SPEC.md
+++ b/backend/app/agents/runs/SPEC.md
@@ -91,13 +91,13 @@ composes them. Documented here so the deviation is intentional, not drift.
 
 | Key                              | Type   | Contents                                              | TTL  |
 | -------------------------------- | ------ | ----------------------------------------------------- | ---- |
-| `run:{run_id}`                   | hash   | serialized `RunRecord`                                | 24h  |
-| `run:{run_id}:events`            | stream | append-only SSE chunks (`{"data": "<sse>"}`)          | 24h  |
-| `run:{run_id}:control`           | list   | cancel signal (polled via non-blocking `LPOP`)        | 24h  |
+| `run:{run_id}`                   | hash   | serialized `RunRecord`                                | 1h   |
+| `run:{run_id}:events`            | stream | append-only SSE chunks (`{"data": "<sse>"}`)          | 1h   |
+| `run:{run_id}:control`           | list   | cancel signal (polled via non-blocking `LPOP`)        | 1h   |
 | `runs:queue`                     | list   | FIFO of `run_id`s awaiting a dispatcher (`BRPOP`)     | —    |
 | `runs:active`                    | set    | run_ids in a non-terminal state — the reaper's worklist | live |
 | `thread:{thread_id}:active_run`  | string | the active `run_id` — the per-thread mutex (`SET NX`) | live |
-| `thread:{thread_id}:runs`        | zset   | `run_id`s by `created_at` (for `list_for_thread`)     | 24h  |
+| `thread:{thread_id}:runs`        | zset   | `run_id`s by `created_at` (for `list_for_thread`)     | 1h   |
 
 The event-stream entry IDs (Redis Stream `XADD` ids) are the **resume cursor**:
 `subscribe(last_event_id)` does `XREAD` from that id, so reattach replays only
@@ -187,7 +187,7 @@ of scope for v1; document if/when added.)
 | `RUN_HEARTBEAT_INTERVAL_SECONDS` | 5     | worker heartbeat cadence                 |
 | `RUN_HEARTBEAT_TIMEOUT_SECONDS`  | 30    | reaper threshold for stale `running`     |
 | `RUN_PENDING_TIMEOUT_SECONDS`  | 600     | reaper threshold for stuck `pending`     |
-| `RUN_TTL_SECONDS`              | 86400   | Redis retention for run keys             |
+| `RUN_TTL_SECONDS`              | 3600    | Redis retention for run keys (> max duration) |
 | `RUN_DISPATCHER_ENABLED`       | true    | run the in-process dispatcher + reaper   |
 
 ## Deployment (portable; Cloud Run focus)

--- a/backend/app/agents/runs/settings.py
+++ b/backend/app/agents/runs/settings.py
@@ -24,8 +24,10 @@ class RunSettings(BaseSettings):
     heartbeat_timeout_seconds: int = 30
     # Reaper threshold: a `pending` run older than this (a queued zombie) is reaped to `error`.
     pending_timeout_seconds: int = 600
-    # Redis retention for run keys (record, events, control).
-    ttl_seconds: int = 86400
+    # Redis retention for run keys (record, events, control). Applied at
+    # creation (crash backstop) and re-applied at finalize, so it must stay
+    # comfortably above `max_duration_seconds` or keys expire mid-run.
+    ttl_seconds: int = 3600
     # How often the reaper sweeps for orphans.
     reaper_interval_seconds: int = 15
     # Whether this process runs the in-process dispatcher + reaper. Set false on


### PR DESCRIPTION
## Why

The durable runtime keeps every run's Redis keys (record hash, SSE event log, control channel) for `RUN_TTL_SECONDS` after the run finishes. At the 24h default, event logs accumulated ~1GB/day and saturated our 1GB Memorystore instance (single runs can log 10MB+ of SSE chunks).

Terminal runs are effectively never read back: the frontend discovers reattachable runs via `GET /runs/active`, which reads the per-thread mutex — a key that dies within seconds of the run finishing. So a finished run's event log has no consumer after the first few minutes; a 24h window only buys debugging convenience.

## What

- `RunSettings.ttl_seconds` default: 86400 → **3600**
- SPEC.md key-schema and settings tables updated to match

1h keeps a 2x margin over the floor: the TTL is also applied at run *creation* as a crash backstop, so it must stay comfortably above `RUN_MAX_DURATION_SECONDS` (1800) or keys would expire mid-run. Deployments that want longer debugging retention can still set `RUN_TTL_SECONDS` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lower Redis run retention default from 24h to 1h to cut memory use from accumulated event logs without affecting active or reattach flows. Updated `RunSettings.ttl_seconds` and SPEC key TTLs to 1h; this stays above the 30‑min max run duration and is applied at creation and finalize.

- **Migration**
  - Set `RUN_TTL_SECONDS` higher if you need longer debugging retention.

<sup>Written for commit d84b60ed7e0c7a6d588dcb17e2cfbbf4d7120c6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

