### PR TITLE
fix: address Cubic review comments from #176

### DIFF
--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -206,6 +206,8 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         try:
             await self.repository.update(agent, data)
         except IntegrityError as exc:
+            if "fk_agents_tag_id_tags" not in str(getattr(exc, "orig", exc)):
+                raise
             # The tag existed at validation time but was deleted before the
             # flush — surface the same 404 the validation would have raised.
             raise NotFoundError("Tag not found") from exc

--- a/backend/tests/tags/test_router.py
+++ b/backend/tests/tags/test_router.py
@@ -90,4 +90,4 @@ def test_delete_tag_as_admin(client: TestClient, mock_db, admin_user):
     response = client.delete(f"/tags/{tag.id}")
 
     assert response.status_code == 204
-    mock_db.delete.assert_called_once()
+    mock_db.delete.assert_awaited_once()

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -111,6 +111,9 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 		liveAgent.currentUserPermission === "owner" ||
 		liveAgent.currentUserPermission === "admin";
 
+	const canEditAgent =
+		canManageAgent || liveAgent.currentUserPermission === "editor";
+
 	const handleDeleteAgent = async () => {
 		if (
 			!confirm(
@@ -274,6 +277,10 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 								? [
 									{ label: "View thread history", icon: <History />, onClick: handleViewThreads },
 									{ label: "Manage permissions", icon: <ShieldCheck />, onClick: handleManagePermissions },
+								]
+								: []),
+							...(canEditAgent
+								? [
 									{ label: "Assign tag", icon: <Tag />, onClick: () => { setTagsOpen(true); } },
 									{ separator: true as const },
 								]


### PR DESCRIPTION
Addresses the three unresolved Cubic review comments on #176:

1. **Over-broad `IntegrityError` handling** (`backend/app/agents/core/service.py`) — any integrity failure during an agent PATCH (e.g. `{"name": null}` tripping the NOT NULL constraint) was misreported as `404 Tag not found`. The handler now only translates the tag FK violation (`fk_agents_tag_id_tags`) and re-raises everything else.

2. **Async assertion in tag delete test** (`backend/tests/tags/test_router.py`) — `mock_db.delete` is an `AsyncMock`, so `assert_called_once()` would pass even if `db.delete(...)` were never awaited. Switched to `assert_awaited_once()`.

3. **"Assign tag" hidden from editors** (`web/.../agent-editor.tsx`) — the backend allows `owner/admin/editor` to PATCH `tag_id`, but the menu item was gated behind the owner/admin-only `canManageAgent`. Added a `canEditAgent` gate matching the backend authorization.

Tests: `pytest tests/tags/ tests/agents/` passes (232), ruff clean, ESLint clean on the edited component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misreported 404s on agent updates, corrects an async test assertion, and lets editors assign tags to match backend rules.

- **Bug Fixes**
  - Only translate the tag FK violation `fk_agents_tag_id_tags` into a 404; re-raise other `IntegrityError`s.
  - Use `assert_awaited_once()` for `mock_db.delete` (`AsyncMock`) in the tag delete test.
  - Gate "Assign tag" on `canEditAgent` (owner/admin/editor) instead of `canManageAgent` so editors can assign tags.

<sup>Written for commit 7428e071f614c7265306713af0cc012079e580c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

