### PR TITLE
fix(agents): validate structured output instead of returning empty results

### DIFF
--- a/backend/app/agents/runs/router.py
+++ b/backend/app/agents/runs/router.py
@@ -13,8 +13,14 @@ from app.agents.runs.schemas import RunCreate, RunResponse
 from app.agents.runs.service import RunService
 from app.agents.runs.state import RunStatus
 from app.agents.runtime import read_run_result
+from app.agents.structured_output import validate_structured_response
 from app.auth.dependencies import get_current_user
-from app.exceptions import DomainError, NotFoundError, PermissionDeniedError
+from app.exceptions import (
+    DomainError,
+    NotFoundError,
+    PermissionDeniedError,
+    StructuredOutputError,
+)
 from app.redis_client import get_redis
 from app.threads.schemas import ThreadResponse
 from app.threads.service import ThreadService, get_thread_service
@@ -126,7 +132,18 @@ async def invoke_run(
         raise DomainError(
             record.error or f"Run did not complete ({record.status.value})"
         )
-    return await read_run_result(thread_id)
+    result = await read_run_result(thread_id)
+    # Backstop for paths where the formatting turn never ran (e.g. recursion
+    # fallback): the schema contract must hold on everything returned here.
+    if output_schema is not None and (
+        error := validate_structured_response(
+            result["structured_response"], output_schema
+        )
+    ):
+        raise StructuredOutputError(
+            f"Run completed without a valid structured response: {error}"
+        )
+    return result
 
 
 @router.post("", status_code=201)

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -407,6 +407,13 @@ class Agent:
             stream_input,
             config,
         ):
+            if output_schema is not None and command is None:
+                # `structured_response` is a persistent channel: if this turn's
+                # formatting never runs (e.g. recursion fallback), a previous
+                # turn's value would otherwise be read back as this run's result.
+                state = await agent.aget_state(config)
+                if state.values.get("structured_response") is not None:
+                    await agent.aupdate_state(config, {"structured_response": None})
             langchain_stream = agent.astream(
                 stream_input,
                 config=config,

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -22,6 +22,14 @@ of the returned messages, so it does not pollute the thread history. The
 agent must still be built with ``response_format`` set — that is what registers
 the structured-output machinery this middleware re-enables on the last turn.
 
+The formatting turn's result is validated against the JSON schema before it is
+accepted: langchain returns raw-JSON-schema payloads verbatim (no validation),
+so a model that answers the formatting turn with an empty or partial tool call
+would otherwise surface ``{}`` as a successful structured response. An invalid
+result gets one retry with the rejection fed back (the failed attempt's
+messages are discarded); a second failure raises ``StructuredOutputError`` so
+the run fails loudly instead of returning garbage.
+
 Every message the formatting turn produces is tagged with
 ``STRUCTURED_OUTPUT_FLAG`` in ``response_metadata`` (checkpointed, but never
 sent back to the provider), so read paths can recognize formatting artifacts —
@@ -34,6 +42,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import jsonschema
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     ModelRequest,
@@ -41,11 +50,20 @@ from langchain.agents.middleware.types import (
 )
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
+from app.exceptions import StructuredOutputError
+
 
 FORMAT_INSTRUCTION = (
     "Based on your answer above, provide the final response in the requested "
     "structured format. Use only information from this conversation; do not "
     "invent values."
+)
+
+FORMAT_RETRY_INSTRUCTION = (
+    "Based on your answer above, provide the final response in the requested "
+    "structured format. Your previous attempt was rejected: {error}. Fill in "
+    "every required field, using only information from this conversation; do "
+    "not invent values."
 )
 
 STRUCTURED_OUTPUT_FLAG = "structured_output"
@@ -55,6 +73,32 @@ def is_structured_output_artifact(message: Any) -> bool:
     """True for messages produced by the formatting turn (chat-history noise)."""
     metadata = getattr(message, "response_metadata", None) or {}
     return bool(metadata.get(STRUCTURED_OUTPUT_FLAG))
+
+
+def validate_structured_response(value: Any, response_format: Any) -> str | None:
+    """Return why ``value`` is not a valid structured response, or None if it is.
+
+    ``response_format`` is either the raw JSON Schema dict or a langchain
+    strategy (``ToolStrategy`` / ``ProviderStrategy``) wrapping one. langchain
+    validates pydantic/dataclass schemas itself but passes raw-JSON-schema
+    payloads through verbatim (``_parse_with_schema``), so an empty tool call
+    (``{}``) would otherwise count as a successful structured response — this
+    is the check that rejects it. Non-dict schemas are left to langchain.
+    """
+    if value is None:
+        return "no structured response was produced"
+    schema = (
+        response_format
+        if isinstance(response_format, dict)
+        else getattr(response_format, "schema", None)
+    )
+    if not isinstance(schema, dict):
+        return None
+    try:
+        jsonschema.validate(value, schema)
+    except jsonschema.ValidationError as exc:
+        return exc.message
+    return None
 
 
 def _tag(message: BaseMessage) -> BaseMessage:
@@ -95,14 +139,32 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
         # Final answer reached: one constrained call formats it. The original
         # response_format object is passed through untouched so the strategy
         # (and ToolStrategy tool names) resolved at agent setup still apply.
-        format_request = request.override(
-            messages=[
-                *request.messages,
-                *response.result,
-                HumanMessage(FORMAT_INSTRUCTION),
-            ],
+        conversation = [*request.messages, *response.result]
+        format_response = await handler(
+            request.override(messages=[*conversation, HumanMessage(FORMAT_INSTRUCTION)])
         )
-        format_response = await handler(format_request)
+        error = validate_structured_response(
+            format_response.structured_response, request.response_format
+        )
+        if error is not None:
+            # One retry with the rejection fed back. The failed attempt's
+            # messages are dropped entirely — they may carry a dangling
+            # structured-output tool call that must not reach state.
+            format_response = await handler(
+                request.override(
+                    messages=[
+                        *conversation,
+                        HumanMessage(FORMAT_RETRY_INSTRUCTION.format(error=error)),
+                    ]
+                )
+            )
+            error = validate_structured_response(
+                format_response.structured_response, request.response_format
+            )
+            if error is not None:
+                raise StructuredOutputError(
+                    f"Model failed to produce a valid structured response: {error}"
+                )
         return ModelResponse(
             result=[*response.result, *(_tag(m) for m in format_response.result)],
             structured_response=format_response.structured_response,

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -28,3 +28,7 @@ class InvalidCredentialsError(DomainError):
 
 class NoInviteError(DomainError):
     """OAuth signup attempted with no matching invite."""
+
+
+class StructuredOutputError(DomainError):
+    """A run with an output schema failed to produce a valid structured response."""

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "langchain-ai-sdk-adapter",
     "deepagents>=0.5.6",
     "opensandbox>=0.1.6",
+    "jsonschema>=4.26.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/agents/runs/test_router.py
+++ b/backend/tests/agents/runs/test_router.py
@@ -107,6 +107,38 @@ def test_invoke_without_output_schema(
     assert fake.create_kwargs["output_schema"] is None
 
 
+@patch("app.agents.runs.router.read_run_result", new_callable=AsyncMock)
+def test_invoke_schema_violating_result_is_500(
+    mock_read, client: TestClient, mock_db, current_user
+):
+    """A run that ends success without a schema-valid structured response must
+    error out, not hand the caller an empty/stale object."""
+    thread = _owned_thread(current_user)
+    _mock_thread_lookup(mock_db, thread)
+    mock_read.return_value = {"content": "prose", "structured_response": {}}
+    fake = _FakeRunService()
+    app.dependency_overrides[get_run_service] = lambda: fake
+
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+    }
+    try:
+        response = client.post(
+            f"/threads/{thread.id}/runs/invoke",
+            json={
+                "input": {"messages": [{"type": "human", "content": "hi"}]},
+                "output_schema": schema,
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_run_service, None)
+
+    assert response.status_code == 500
+    assert "valid structured response" in response.json()["detail"]
+
+
 def test_invoke_failed_run_is_500(client: TestClient, mock_db, current_user):
     thread = _owned_thread(current_user)
     _mock_thread_lookup(mock_db, thread)

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -1,13 +1,18 @@
 from unittest.mock import MagicMock
 
+import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.agents.structured_output import ToolStrategy
 from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel
 
 from app.agents.structured_output import (
     FORMAT_INSTRUCTION,
     DeferredStructuredOutputMiddleware,
     is_structured_output_artifact,
+    validate_structured_response,
 )
+from app.exceptions import StructuredOutputError
 
 
 SCHEMA = {
@@ -139,3 +144,86 @@ async def test_final_turn_adds_constrained_formatting_call():
     # rendered chat history; the prose answer is not.
     assert is_structured_output_artifact(structured)
     assert not is_structured_output_artifact(prose)
+
+
+async def test_invalid_formatting_result_retries_with_error_feedback():
+    """An empty structured response (e.g. an empty tool call) triggers one
+    retry whose instruction carries the rejection; the failed attempt's
+    messages never reach state."""
+    middleware = DeferredStructuredOutputMiddleware()
+    request = _make_request()
+    final_answer = AIMessage("2 + 2 = 4")
+    failed_attempt = AIMessage(
+        "", tool_calls=[{"name": "response_format", "args": {}, "id": "call_1"}]
+    )
+    formatted = AIMessage('{"answer": 4}')
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[final_answer]),
+                ModelResponse(result=[failed_attempt], structured_response={}),
+                ModelResponse(result=[formatted], structured_response={"answer": 4}),
+            ],
+            calls,
+        ),
+    )
+
+    assert len(calls) == 3
+    # The retry replaces the plain instruction with one carrying the rejection,
+    # on the same conversation (no trace of the failed attempt).
+    retry_instruction = calls[2].messages[-1]
+    assert "rejected" in retry_instruction.content
+    assert "'answer' is a required property" in retry_instruction.content
+    assert failed_attempt not in calls[2].messages
+    # Only the prose answer and the successful attempt land in state.
+    assert response.structured_response == {"answer": 4}
+    assert failed_attempt not in response.result
+    assert [m.content for m in response.result] == [
+        final_answer.content,
+        formatted.content,
+    ]
+
+
+async def test_invalid_formatting_result_twice_raises():
+    """A second invalid structured response fails the run instead of
+    silently returning garbage to the caller."""
+    middleware = DeferredStructuredOutputMiddleware()
+    request = _make_request()
+    empty = ModelResponse(
+        result=[AIMessage("")],
+        structured_response={},
+    )
+    calls: list[ModelRequest] = []
+
+    with pytest.raises(StructuredOutputError, match="required property"):
+        await middleware.awrap_model_call(
+            request,
+            _handler_recording(
+                [ModelResponse(result=[AIMessage("4")]), empty, empty], calls
+            ),
+        )
+    assert len(calls) == 3
+
+
+class _Answer(BaseModel):
+    answer: int
+
+
+@pytest.mark.parametrize(
+    ("value", "response_format", "is_valid"),
+    [
+        (None, SCHEMA, False),  # formatting turn produced nothing
+        ({}, SCHEMA, False),  # empty tool-call args (the deepseek incident)
+        ({"answer": "four"}, SCHEMA, False),  # wrong type
+        ({"answer": 4}, SCHEMA, True),
+        ({}, ToolStrategy(schema=SCHEMA), False),  # schema wrapped in a strategy
+        ({"answer": 4}, ToolStrategy(schema=SCHEMA), True),
+        ({}, ToolStrategy(schema=_Answer), True),  # pydantic: langchain validates
+    ],
+)
+def test_validate_structured_response(value, response_format, is_valid):
+    error = validate_structured_response(value, response_format)
+    assert (error is None) is is_valid

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -269,7 +269,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "0.4.12"
+version = "0.4.13"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -280,6 +280,7 @@ dependencies = [
     { name = "greenlet" },
     { name = "h2" },
     { name = "itsdangerous" },
+    { name = "jsonschema" },
     { name = "langchain" },
     { name = "langchain-ai-sdk-adapter" },
     { name = "langchain-anthropic" },
@@ -320,6 +321,7 @@ requires-dist = [
     { name = "greenlet", specifier = ">=3.1.1" },
     { name = "h2", specifier = ">=4.3.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "langchain", specifier = ">=1.2.6" },
     { name = "langchain-ai-sdk-adapter", git = "https://github.com/keurcien/langchain-ai-sdk-adapter.git" },
     { name = "langchain-anthropic", specifier = ">=1.4.3" },


### PR DESCRIPTION
## Problem

A run invoked with an `output_schema` could return `200` with an **empty or stale** `structured_response`. Observed in production (trace `0653b09359836744aa6936efac0bea06`): deepseek-v4-flash answered the deferred formatting turn with an empty tool call (`response_format_8bdc` with args `{}`), and since langchain returns raw-JSON-schema payloads verbatim without validation (`_parse_with_schema`: `if schema_kind == "json_schema": return data`), the calling server received `structured_response: {}` as a success.

Two more silent paths existed:
- **Recursion fallback**: a `GraphRecursionError` run ends `success` without the formatting turn ever running.
- **Stale channel**: `structured_response` persists in the thread checkpoint across turns, so a turn that never wrote one could surface a *previous* turn's value.

## Fix (three layers)

1. **Middleware validation + retry** — `DeferredStructuredOutputMiddleware` validates the formatting turn's result against the JSON schema (`jsonschema`), retries once with the rejection fed back (the failed attempt's messages are discarded so no dangling tool call reaches state), and raises `StructuredOutputError` on a second failure so the run finalizes as `error` with a precise message.
2. **Router backstop** — `/runs/invoke` re-validates the result it is about to return whenever `output_schema` was given, guaranteeing the contract: schema-valid structured response or an error status, never a silent `{}`/`null`.
3. **Channel reset** — `Agent.stream` clears the persistent `structured_response` channel at the start of a schema run (fresh turns only, not HITL resumes).

`jsonschema` was already a transitive dependency; it is now declared explicitly.

## Tests

- Middleware: retry-with-feedback success path, double-failure raise, `validate_structured_response` matrix (None / empty / wrong type / valid / strategy-wrapped / pydantic passthrough).
- Router: schema-violating result returns 500 with detail.
- Full suite: 354 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure runs with an `output_schema` return a schema-valid `structured_response` or an error, never an empty or stale object. Adds validation with a single retry and a clear failure mode.

- **Bug Fixes**
  - Validate the formatting turn with `jsonschema`; retry once with error feedback, then raise `StructuredOutputError` on a second failure.
  - Re-validate in `/threads/{id}/runs/invoke` before responding to catch paths where the formatting turn never ran.
  - Clear the persistent `structured_response` channel at the start of schema runs to prevent stale values from leaking.

- **Dependencies**
  - Declare `jsonschema>=4.26.0`.

<sup>Written for commit 1ef6275b17982013e890f5108ff1853f7f69a573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

