### PR TITLE
feat(agents): display agent owner on card and dialog

### DIFF
--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -18,6 +18,7 @@ from app.agents.models import (
 from app.agents.schemas import (
     AgentCreateDB,
     AgentMCPServerResponse,
+    AgentOwnerInfo,
     AgentPatch,
     AgentPermissionCreate,
     AgentResponse,
@@ -32,6 +33,7 @@ from app.service import BaseService
 from app.tags.service import TagService
 from app.threads.service import ThreadService
 from app.users.models import WorkspaceRole
+from app.users.service import UserService
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +47,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         self.subagent_service = SubagentService(db)
         self.thread_service = ThreadService(db)
         self.tag_service = TagService(db)
+        self.user_service = UserService(db)
         self.mcp_server_repository = AgentMCPServerRepository(db)
 
     @staticmethod
@@ -82,6 +85,8 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         ) = await self.subagent_service.list_all_subagent_data(agent_ids)
         tag_ids = list({a.tag_id for a in agents if a.tag_id is not None})
         tags_by_id = {t.id: t for t in await self.tag_service.list_by_ids(tag_ids)}
+        owner_ids = list({a.owner_id for a in agents})
+        owners_by_id = {u.id: u for u in await self.user_service.list_by_ids(owner_ids)}
         return [
             AgentResponse(
                 **agent.model_dump(),
@@ -90,6 +95,11 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                 tag=(
                     TagInfo(id=tag.id, name=tag.name)
                     if (tag := tags_by_id.get(agent.tag_id)) is not None
+                    else None
+                ),
+                owner=(
+                    AgentOwnerInfo(id=owner.id, name=owner.name, email=owner.email)
+                    if (owner := owners_by_id.get(agent.owner_id)) is not None
                     else None
                 ),
                 is_subagent=agent.id in is_subagent_ids,

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -113,6 +113,12 @@ class TagInfo(SQLModel):
     name: str
 
 
+class AgentOwnerInfo(SQLModel):
+    id: UUID
+    name: str | None = None
+    email: str | None = None
+
+
 class AgentResponse(SQLModel):
     id: UUID
     name: str
@@ -128,5 +134,6 @@ class AgentResponse(SQLModel):
     mcp_servers: list[AgentMCPServerResponse] | None = None
     subagents: list[SubagentResponse] | None = None
     tag: TagInfo | None = None
+    owner: AgentOwnerInfo | None = None
     is_subagent: bool = False
     current_user_permission: str | None = None

--- a/backend/app/users/repository.py
+++ b/backend/app/users/repository.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -8,6 +10,13 @@ from app.users.models import UserDB, WorkspaceRole
 class UserRepository(BaseRepository[UserDB]):
     def __init__(self, db: AsyncSession):
         super().__init__(UserDB, db)
+
+    async def list_by_ids(self, user_ids: list[UUID]) -> list[UserDB]:
+        if not user_ids:
+            return []
+        stmt = select(UserDB).where(UserDB.id.in_(user_ids))
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
 
     async def get_by_email(self, email: str) -> UserDB | None:
         stmt = select(UserDB).where(UserDB.email == email)

--- a/backend/app/users/service.py
+++ b/backend/app/users/service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from uuid import UUID
 
 from fastapi import Depends
@@ -39,6 +41,9 @@ class UserService(BaseService[UserDB, UserRepository]):
 
     async def list(self, role: WorkspaceRole | None = None) -> list[UserDB]:
         return await self.repository.list(role=role)
+
+    async def list_by_ids(self, user_ids: list[UUID]) -> list[UserDB]:
+        return await self.repository.list_by_ids(user_ids)
 
     async def update(self, user_id: UUID, data: UserPatch) -> UserDB:
         user = await self.get_or_404(user_id)

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -158,9 +158,11 @@ def test_update_agent(client: TestClient, mock_db, current_user):
     mock_db.execute.side_effect = [
         make_result(rows=[(agent, None)]),  # get_agent (auth): list_with_permissions
         make_result(scalars_list=[]),  # get_agent (auth): list_all_subagent_data
+        make_result(scalars_list=[]),  # get_agent (auth): owner list_by_ids
         make_result(scalar=agent),  # get_or_404: repository.get
         make_result(rows=[(agent, None)]),  # get_agent (return): list_with_permissions
         make_result(scalars_list=[]),  # get_agent (return): list_all_subagent_data
+        make_result(scalars_list=[]),  # get_agent (return): owner list_by_ids
     ]
 
     update_data = {
@@ -217,6 +219,7 @@ def test_update_agent_forbidden_for_non_owner(
     mock_db.execute.side_effect = [
         make_result(rows=[(agent, None, None)]),  # list_with_permissions: no grant
         make_result(scalars_list=[]),  # list_all_subagent_data
+        make_result(scalars_list=[]),  # owner list_by_ids
     ]
 
     response = client.patch(f"/agents/{agent_id}", json={"name": "Pwned"})
@@ -426,6 +429,8 @@ def test_list_agent_threads_as_owner(client: TestClient, mock_db, current_user):
         make_result(rows=[(agent, None, None)]),
         # get_agent: list_all_subagent_data
         make_result(scalars_list=[]),
+        # get_agent: owner list_by_ids
+        make_result(scalars_list=[]),
         # ThreadRepository.list_for_agent
         make_result(
             rows=[
@@ -476,6 +481,7 @@ def test_list_agent_threads_forbidden_for_member(
         # list_with_permissions returns the agent but no permission grant
         make_result(rows=[(agent, None, None)]),
         make_result(scalars_list=[]),  # list_all_subagent_data
+        make_result(scalars_list=[]),  # owner list_by_ids
     ]
 
     response = client.get(f"/agents/{agent_id}/threads")
@@ -506,6 +512,7 @@ def test_list_agent_threads_as_workspace_admin(client: TestClient, mock_db):
     mock_db.execute.side_effect = [
         make_result(rows=[(agent, None, None)]),
         make_result(scalars_list=[]),  # list_all_subagent_data
+        make_result(scalars_list=[]),  # owner list_by_ids
         make_result(
             rows=[
                 (

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -88,12 +88,20 @@ def mock_tag_service():
 
 
 @pytest.fixture
+def mock_user_service():
+    svc = MagicMock()
+    svc.list_by_ids = AsyncMock(return_value=[])
+    return svc
+
+
+@pytest.fixture
 def service(
     mock_db,
     mock_repo,
     mock_subagent_service,
     mock_thread_service,
     mock_tag_service,
+    mock_user_service,
     mock_agent_mcp_repo,
 ):
     svc = AgentService(mock_db)
@@ -101,6 +109,7 @@ def service(
     svc.subagent_service = mock_subagent_service
     svc.thread_service = mock_thread_service
     svc.tag_service = mock_tag_service
+    svc.user_service = mock_user_service
     svc.mcp_server_repository = mock_agent_mcp_repo
     return svc
 

--- a/web/src/app/(protected)/agents/components/agent-card.tsx
+++ b/web/src/app/(protected)/agents/components/agent-card.tsx
@@ -112,6 +112,7 @@ export default function AgentCard({
 
 	const color = agent.color || "#9E9E9E";
 	const pastel = agentPastel(color);
+	const ownerName = agent.owner?.name || agent.owner?.email;
 
 	return (
 		<>
@@ -135,9 +136,11 @@ export default function AgentCard({
 						<div className="truncate font-[family-name:var(--font-jakarta-sans)] text-[14.5px] font-bold tracking-[-0.01em] text-[#1e2d28] dark:text-foreground">
 							{agent.name}
 						</div>
-						<div className="mt-px truncate font-mono text-[11px] text-[#94a59d] dark:text-muted-foreground">
-							@{agent.name.toLowerCase().replace(/\s+/g, "_")}
-						</div>
+						{ownerName && (
+							<div className="mt-px truncate text-[11px] text-[#94a59d] dark:text-muted-foreground">
+								by {ownerName}
+							</div>
+						)}
 					</div>
 					{(() => {
 						const badge = agent.currentUserPermission
@@ -231,7 +234,7 @@ export default function AgentCard({
 			{open && !archived && (
 				<AgentDialogShell
 					agent={agent}
-					subtitle={`@${agent.name.toLowerCase().replace(/\s+/g, "_")}`}
+					subtitle={ownerName ? `by ${ownerName}` : null}
 					onClose={() => {
 						setOpen(false);
 					}}

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -236,9 +236,6 @@ export default function AgentEditor({ agent }: AgentEditorProps) {
 							placeholder="Agent name"
 							className="font-[family-name:var(--font-jakarta-sans)] text-[22px] font-bold text-[#1E2D28] dark:text-foreground leading-tight tracking-[-0.025em] truncate w-full bg-transparent border-none focus:outline-none focus:ring-0 p-0"
 						/>
-						<p className="font-mono text-[11.5px] text-[#94a59d] dark:text-muted-foreground mt-0.5 truncate w-full">
-							@{name.toLowerCase().replace(/\s+/g, "_") || "agent_name"}
-						</p>
 					</div>
 				</div>
 

--- a/web/src/types/agents.ts
+++ b/web/src/types/agents.ts
@@ -22,6 +22,12 @@ export interface AgentTag {
 	name: string;
 }
 
+export interface AgentOwner {
+	id: string;
+	name?: string | null;
+	email?: string | null;
+}
+
 export interface Agent {
 	id: string;
 	name: string;
@@ -35,6 +41,7 @@ export interface Agent {
 	mcpServers: AgentMCPServer[];
 	subagents: SubagentInfo[];
 	tag?: AgentTag | null;
+	owner?: AgentOwner | null;
 	isSubagent: boolean;
 	currentUserPermission?: AgentPermission | null;
 }


### PR DESCRIPTION
## Summary

- `AgentResponse` now includes an `owner` object (`id`, `name`, `email`), resolved in `AgentService._assemble` with a single batched user query (same pattern as the tag lookup).
- The agent card shows `by <owner>` under the agent name; the agent dialog shows it as the header subtitle.
- Removes the fabricated `@handle` alias (derived from the agent name, not used anywhere) from the agent card, the agent dialog subtitle, and the agent editor.

## Implementation notes

- New `AgentOwnerInfo` schema; owner falls back to email when the user has no name, and the line is hidden when the owner can't be resolved.
- Added `list_by_ids` to `UserRepository`/`UserService`. `app/users/service.py` gains `from __future__ import annotations` because the `list[UUID]` annotation otherwise resolves to the class's own `list` method at class-definition time.
- Agent service/router tests stub `db.execute` as an ordered sequence, so the affected tests gained the extra owner-lookup result, plus a `mock_user_service` fixture.

## Testing

- `uv run pytest` — 354 passed
- ESLint clean on touched frontend files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the agent owner in the card and dialog by adding owner info to the API and resolving it with a single batched lookup.

- **New Features**
  - Backend: Added `owner` to `AgentResponse` (id, name, email). Resolved via one `list_by_ids` user query; falls back to email; hidden if not found.
  - Frontend: Displays "by <owner>" under the agent name and as the dialog subtitle.

- **Refactors**
  - Removed the fabricated `@handle` alias from the card, dialog subtitle, and editor.

<sup>Written for commit f52e99d7ffdc77d4640105edb8b3aeb6345e8116. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

