### PR TITLE
refactor(triggers): remove Draft badge from new trigger header

### DIFF
--- a/web/src/app/(protected)/triggers/components/trigger-editor.tsx
+++ b/web/src/app/(protected)/triggers/components/trigger-editor.tsx
@@ -15,7 +15,6 @@ import { useTriggersStore } from "@/stores/triggers-store";
 import { useModelsStore } from "@/stores/models-store";
 import { EditorHeader } from "@/components/editor/editor-header";
 import { EditorSection } from "@/components/editor/editor-section";
-import { StatusPill } from "@/components/editor/status-pill";
 import { SaveActions } from "@/components/editor/save-actions";
 import { AgentPicker } from "@/components/editor/agent-picker";
 import { ModelPickerChip } from "@/components/editor/model-picker-chip";
@@ -161,9 +160,7 @@ export default function TriggerEditor({
 						<span className="font-[family-name:var(--font-dm-sans)] text-[12.5px] font-medium text-[#94A59D] dark:text-muted-foreground">
 							{trigger.name}
 						</span>
-					) : (
-						<StatusPill tone="amber" label="Draft" />
-					)
+					) : undefined
 				}
 				actions={
 					<SaveActions


### PR DESCRIPTION
Aligns the new-trigger editor header with the Paper design reference, which does not include a status badge on the create screen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the “Draft” badge from the new trigger editor header to match the Paper design and avoid showing a status on the create screen. For new triggers, no status/subtitle is rendered; once a trigger exists, the header shows its name only.

<sup>Written for commit c62767d6694856f7506ca122dd8811c0fd574f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

