### PR TITLE
feat(triggers): add border to trigger thread icon in sidebar

### DIFF
--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -229,7 +229,7 @@ export function AppSidebar() {
 												>
 													{thread.source === "trigger" ? (
 														<div
-															className={`flex items-center justify-center shrink-0 w-[34px] h-[34px] rounded-full bg-[#EDF4F0] dark:bg-emerald-950/40 ${
+															className={`flex items-center justify-center shrink-0 w-[34px] h-[34px] rounded-full border border-[#3D8B63]/15 bg-[#EDF4F0] dark:border-emerald-400/15 dark:bg-emerald-950/40 ${
 																isActive
 																	? "group-data-[collapsible=icon]:ring-2 group-data-[collapsible=icon]:ring-sidebar-primary"
 																	: ""


### PR DESCRIPTION
## What

Adds a subtle green border to the circular icon badge that wraps the alarm-clock SVG for trigger-sourced threads in the sidebar, matching the Paper design.

## Change

- `web/src/components/layout/app-sidebar/index.tsx` — the trigger icon `div` now has `border border-[#3D8B63]/15` (light) and `dark:border-emerald-400/15` (dark). Background, size and shape are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a subtle green border around the trigger thread icon in the sidebar to match the Paper design. Improves visual distinction of trigger-sourced threads in light and dark modes.

<sup>Written for commit 462d602822a6ddc963195d14f4200003f5ab0cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

