### PR TITLE
feat(triggers): link trigger name in chat header to trigger detail

### DIFF
--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -1,72 +1,77 @@
 "use client";
 
 import {
-	Fragment,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 import Image from "next/image";
 import {
-	MessageActions,
-	MessageAction,
-	Message,
-	MessageContent,
-	MessageResponse,
+  MessageActions,
+  MessageAction,
+  Message,
+  MessageContent,
+  MessageResponse,
 } from "@/components/ai-elements/message";
 import {
-	Reasoning,
-	ReasoningTrigger,
-	ReasoningContent,
+  Reasoning,
+  ReasoningTrigger,
+  ReasoningContent,
 } from "@/components/ai-elements/reasoning";
 import {
-	Tool,
-	ToolContent,
-	ToolContentInner,
-	ToolFooter,
-	ToolHeader,
-	ToolInput,
-	ToolOutput,
+  Tool,
+  ToolContent,
+  ToolContentInner,
+  ToolFooter,
+  ToolHeader,
+  ToolInput,
+  ToolOutput,
 } from "@/components/ai-elements/tool";
 import type { AttachmentData } from "@/components/ai-elements/attachments";
 import {
-	Conversation,
-	ConversationContent,
-	ConversationScrollButton,
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
 import {
-	Error,
-	ErrorContent,
-	ErrorDetails,
+  Error,
+  ErrorContent,
+  ErrorDetails,
 } from "@/components/ai-elements/error";
 import {
-	Attachment,
-	AttachmentPreview,
-	AttachmentHoverCard,
-	AttachmentHoverCardTrigger,
-	AttachmentInfo,
-	AttachmentHoverCardContent,
-	getMediaCategory,
-	getAttachmentLabel,
-	Attachments,
+  Attachment,
+  AttachmentPreview,
+  AttachmentHoverCard,
+  AttachmentHoverCardTrigger,
+  AttachmentInfo,
+  AttachmentHoverCardContent,
+  getMediaCategory,
+  getAttachmentLabel,
+  Attachments,
 } from "@/components/ai-elements/attachments";
 import { type PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { extractToolErrorText } from "@/lib/utils/tool-content";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import ChatPromptInput from "../components/prompt-input";
-import { RefreshCcwIcon, CopyIcon, ArchiveIcon, ShieldCheck } from "lucide-react";
 import {
-	useStream,
-	FetchStreamTransport,
+  RefreshCcwIcon,
+  CopyIcon,
+  ArchiveIcon,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  useStream,
+  FetchStreamTransport,
 } from "@langchain/langgraph-sdk/react";
 import type { SubagentApi } from "@langchain/langgraph-sdk/ui";
 import {
-	SubAgentCard,
-	SubAgentProgress,
-	SynthesisIndicator,
+  SubAgentCard,
+  SubAgentProgress,
+  SynthesisIndicator,
 } from "@/components/ai-elements/subagent";
 import { TodoList } from "@/components/ai-elements/todo-list";
 import type { Todo } from "@/components/ai-elements/todo-list";
@@ -81,8 +86,8 @@ import { useThrottledValue } from "@/hooks/use-throttled-value";
 import { useDurableRun, REATTACH_RUN_FIELD } from "@/hooks/use-durable-run";
 import { useChatHeaderStore } from "@/stores/chat-header-store";
 import {
-	McpAppWidget,
-	type McpAppToolInfo,
+  McpAppWidget,
+  type McpAppToolInfo,
 } from "../components/mcp-app-widget";
 
 // ---------------------------------------------------------------------------
@@ -90,91 +95,91 @@ import {
 // ---------------------------------------------------------------------------
 
 type LCToolCallEntry = {
-	name: string;
-	args: Record<string, unknown>;
-	id?: string;
+  name: string;
+  args: Record<string, unknown>;
+  id?: string;
 };
 
 type LCMessage = {
-	type: string;
-	content: string | Array<Record<string, unknown>>;
-	id?: string;
-	name?: string;
-	// snake_case (from stream / raw API)
-	tool_calls?: LCToolCallEntry[];
-	tool_call_id?: string;
-	// camelCase (after Axios interceptor)
-	toolCalls?: LCToolCallEntry[];
-	toolCallId?: string;
-	status?: string;
-	additional_kwargs?: Record<string, unknown>;
-	response_metadata?: Record<string, unknown>;
-	artifact?: Record<string, unknown>;
-	[key: string]: unknown;
+  type: string;
+  content: string | Array<Record<string, unknown>>;
+  id?: string;
+  name?: string;
+  // snake_case (from stream / raw API)
+  tool_calls?: LCToolCallEntry[];
+  tool_call_id?: string;
+  // camelCase (after Axios interceptor)
+  toolCalls?: LCToolCallEntry[];
+  toolCallId?: string;
+  status?: string;
+  additional_kwargs?: Record<string, unknown>;
+  response_metadata?: Record<string, unknown>;
+  artifact?: Record<string, unknown>;
+  [key: string]: unknown;
 };
 
 function getTextContent(message: LCMessage): string {
-	if (typeof message.content === "string") return message.content;
-	if (Array.isArray(message.content)) {
-		return message.content
-			.filter((c) => c.type === "text")
-			.map((c) => c.text as string)
-			.join("");
-	}
-	return "";
+  if (typeof message.content === "string") return message.content;
+  if (Array.isArray(message.content)) {
+    return message.content
+      .filter((c) => c.type === "text")
+      .map((c) => c.text as string)
+      .join("");
+  }
+  return "";
 }
 
 function getReasoningContent(message: LCMessage): string | null {
-	if (!Array.isArray(message.content)) return null;
-	const thinking = message.content.filter((c) => c.type === "thinking");
-	if (thinking.length === 0) return null;
-	return thinking.map((c) => (c.thinking as string) || "").join("\n");
+  if (!Array.isArray(message.content)) return null;
+  const thinking = message.content.filter((c) => c.type === "thinking");
+  if (thinking.length === 0) return null;
+  return thinking.map((c) => (c.thinking as string) || "").join("\n");
 }
 
 function getFileAttachments(message: LCMessage): AttachmentData[] {
-	if (!Array.isArray(message.content)) return [];
-	const attachments: AttachmentData[] = [];
-	let idx = 0;
+  if (!Array.isArray(message.content)) return [];
+  const attachments: AttachmentData[] = [];
+  let idx = 0;
 
-	for (const block of message.content) {
-		// Image blocks: "image_url" (snake_case from stream) or "imageUrl" (camelCase from Axios)
-		if (block.type === "image_url" || block.type === "imageUrl") {
-			const imgField = block.image_url ?? block.imageUrl;
-			const url =
-				typeof imgField === "string"
-					? imgField
-					: (imgField as Record<string, string>)?.url || "";
-			const dataUrl = url.startsWith("data:")
-				? url
-				: `data:image/jpeg;base64,${url}`;
-			attachments.push({
-				id: `${message.id}-file-${idx++}`,
-				url: dataUrl,
-				type: "file" as const,
-				filename: "Image.jpg",
-				mediaType: "image/jpeg",
-			});
-		}
+  for (const block of message.content) {
+    // Image blocks: "image_url" (snake_case from stream) or "imageUrl" (camelCase from Axios)
+    if (block.type === "image_url" || block.type === "imageUrl") {
+      const imgField = block.image_url ?? block.imageUrl;
+      const url =
+        typeof imgField === "string"
+          ? imgField
+          : (imgField as Record<string, string>)?.url || "";
+      const dataUrl = url.startsWith("data:")
+        ? url
+        : `data:image/jpeg;base64,${url}`;
+      attachments.push({
+        id: `${message.id}-file-${idx++}`,
+        url: dataUrl,
+        type: "file" as const,
+        filename: "Image.jpg",
+        mediaType: "image/jpeg",
+      });
+    }
 
-		// File blocks: {"type": "file", "mime_type"/"mimeType": "...", "base64": "...", "filename": "..."}
-		if (block.type === "file") {
-			const mimeType = (block.mime_type ??
-				block.mimeType ??
-				"application/octet-stream") as string;
-			const base64 = (block.base64 ?? "") as string;
-			const filename = (block.filename ?? "file") as string;
-			const dataUrl = `data:${mimeType};base64,${base64}`;
-			attachments.push({
-				id: `${message.id}-file-${idx++}`,
-				url: dataUrl,
-				type: "file" as const,
-				filename,
-				mediaType: mimeType,
-			});
-		}
-	}
+    // File blocks: {"type": "file", "mime_type"/"mimeType": "...", "base64": "...", "filename": "..."}
+    if (block.type === "file") {
+      const mimeType = (block.mime_type ??
+        block.mimeType ??
+        "application/octet-stream") as string;
+      const base64 = (block.base64 ?? "") as string;
+      const filename = (block.filename ?? "file") as string;
+      const dataUrl = `data:${mimeType};base64,${base64}`;
+      attachments.push({
+        id: `${message.id}-file-${idx++}`,
+        url: dataUrl,
+        type: "file" as const,
+        filename,
+        mediaType: mimeType,
+      });
+    }
+  }
 
-	return attachments;
+  return attachments;
 }
 
 // ---------------------------------------------------------------------------
@@ -182,31 +187,31 @@ function getFileAttachments(message: LCMessage): AttachmentData[] {
 // ---------------------------------------------------------------------------
 
 const sanitizeToolIdentifier = (value: string): string => {
-	const sanitized = value
-		.replace(/[^a-zA-Z0-9_-]/g, "_")
-		.replace(/^_+|_+$/g, "");
-	return sanitized || "tool";
+  const sanitized = value
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return sanitized || "tool";
 };
 
 const getToolMetadata = (toolName: string, knownServerNames: string[]) => {
-	for (const serverName of knownServerNames) {
-		const aliases = [serverName, sanitizeToolIdentifier(serverName)];
-		for (const alias of aliases) {
-			if (toolName === alias || toolName.startsWith(`${alias}_`)) {
-				const suffix = toolName.slice(alias.length);
-				const name = suffix.startsWith("_") ? suffix.slice(1) : suffix;
-				return { serverName, toolName: name || toolName };
-			}
-		}
-	}
-	const separatorIndex = toolName.indexOf("_");
-	if (separatorIndex === -1) {
-		return { serverName: toolName, toolName };
-	}
-	return {
-		serverName: toolName.slice(0, separatorIndex),
-		toolName: toolName.slice(separatorIndex + 1),
-	};
+  for (const serverName of knownServerNames) {
+    const aliases = [serverName, sanitizeToolIdentifier(serverName)];
+    for (const alias of aliases) {
+      if (toolName === alias || toolName.startsWith(`${alias}_`)) {
+        const suffix = toolName.slice(alias.length);
+        const name = suffix.startsWith("_") ? suffix.slice(1) : suffix;
+        return { serverName, toolName: name || toolName };
+      }
+    }
+  }
+  const separatorIndex = toolName.indexOf("_");
+  if (separatorIndex === -1) {
+    return { serverName: toolName, toolName };
+  }
+  return {
+    serverName: toolName.slice(0, separatorIndex),
+    toolName: toolName.slice(separatorIndex + 1),
+  };
 };
 
 // ---------------------------------------------------------------------------
@@ -214,12 +219,12 @@ const getToolMetadata = (toolName: string, knownServerNames: string[]) => {
 // ---------------------------------------------------------------------------
 
 type LocalToolCall = {
-	id: string;
-	call: { name: string; args: Record<string, unknown>; id?: string };
-	result: LCMessage | undefined;
-	aiMessage: LCMessage;
-	index: number;
-	state: "pending" | "completed" | "error";
+  id: string;
+  call: { name: string; args: Record<string, unknown>; id?: string };
+  result: LCMessage | undefined;
+  aiMessage: LCMessage;
+  index: number;
+  state: "pending" | "completed" | "error";
 };
 
 // The LangGraph SDK reconstructs subagent containers from history, but it reads
@@ -230,84 +235,86 @@ type LocalToolCall = {
 // before handing it the initial values. Streaming is unaffected (SSE bypasses the
 // interceptor and is already snake_case).
 function toSdkMessages(messages: LCMessage[]): LCMessage[] {
-	return messages.map((msg) => {
-		const m = msg as unknown as Record<string, unknown>;
-		const out: Record<string, unknown> = { ...m };
+  return messages.map((msg) => {
+    const m = msg as unknown as Record<string, unknown>;
+    const out: Record<string, unknown> = { ...m };
 
-		if ("toolCallId" in out) {
-			out.tool_call_id = out.toolCallId;
-			delete out.toolCallId;
-		}
+    if ("toolCallId" in out) {
+      out.tool_call_id = out.toolCallId;
+      delete out.toolCallId;
+    }
 
-		const toolCalls = (m.toolCalls ?? m.tool_calls) as
-			| Array<Record<string, unknown>>
-			| undefined;
-		if (Array.isArray(toolCalls)) {
-			out.tool_calls = toolCalls.map((tc) => {
-				// Subagent (task) args carry `subagent_type`; the interceptor
-				// camelCased it to `subagentType`. Restore it so the SDK's
-				// isValidSubagentType() check passes during reconstruction.
-				if (tc.name === "task" && tc.args && typeof tc.args === "object") {
-					const args = tc.args as Record<string, unknown>;
-					return {
-						...tc,
-						args: { ...args, subagent_type: args.subagent_type ?? args.subagentType },
-					};
-				}
-				return tc;
-			});
-			delete out.toolCalls;
-		}
+    const toolCalls = (m.toolCalls ?? m.tool_calls) as
+      Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(toolCalls)) {
+      out.tool_calls = toolCalls.map((tc) => {
+        // Subagent (task) args carry `subagent_type`; the interceptor
+        // camelCased it to `subagentType`. Restore it so the SDK's
+        // isValidSubagentType() check passes during reconstruction.
+        if (tc.name === "task" && tc.args && typeof tc.args === "object") {
+          const args = tc.args as Record<string, unknown>;
+          return {
+            ...tc,
+            args: {
+              ...args,
+              subagent_type: args.subagent_type ?? args.subagentType,
+            },
+          };
+        }
+        return tc;
+      });
+      delete out.toolCalls;
+    }
 
-		return out as unknown as LCMessage;
-	});
+    return out as unknown as LCMessage;
+  });
 }
 
 function computeToolCallsFromMessages(messages: LCMessage[]): LocalToolCall[] {
-	// Axios camelCase interceptor converts snake_case keys from the API:
-	//   tool_call_id → toolCallId, tool_calls → toolCalls
-	// Handle both formats for robustness.
-	const getToolCallId = (msg: LCMessage): string | undefined =>
-		(msg.tool_call_id ?? msg.toolCallId) as string | undefined;
-	const getToolCalls = (msg: LCMessage): LCMessage["tool_calls"] | undefined =>
-		msg.tool_calls ?? (msg.toolCalls as LCMessage["tool_calls"]);
+  // Axios camelCase interceptor converts snake_case keys from the API:
+  //   tool_call_id → toolCallId, tool_calls → toolCalls
+  // Handle both formats for robustness.
+  const getToolCallId = (msg: LCMessage): string | undefined =>
+    (msg.tool_call_id ?? msg.toolCallId) as string | undefined;
+  const getToolCalls = (msg: LCMessage): LCMessage["tool_calls"] | undefined =>
+    msg.tool_calls ?? (msg.toolCalls as LCMessage["tool_calls"]);
 
-	const toolResults = new Map<string, LCMessage>();
-	for (const msg of messages) {
-		if (msg.type === "tool") {
-			const tcId = getToolCallId(msg);
-			if (tcId) toolResults.set(tcId, msg);
-		}
-	}
+  const toolResults = new Map<string, LCMessage>();
+  for (const msg of messages) {
+    if (msg.type === "tool") {
+      const tcId = getToolCallId(msg);
+      if (tcId) toolResults.set(tcId, msg);
+    }
+  }
 
-	const result: LocalToolCall[] = [];
-	for (const msg of messages) {
-		const toolCalls = getToolCalls(msg);
-		if (
-			(msg.type === "ai" || msg.type === "assistant") &&
-			Array.isArray(toolCalls) &&
-			toolCalls.length > 0
-		) {
-			for (let i = 0; i < toolCalls.length; i++) {
-				const tc = toolCalls[i];
-				const tcId = tc.id || `${msg.id}-tc-${i}`;
-				const toolMsg = toolResults.get(tcId);
-				result.push({
-					id: tcId,
-					call: { name: tc.name, args: tc.args, id: tc.id },
-					result: toolMsg,
-					aiMessage: msg,
-					index: i,
-					state: toolMsg
-						? toolMsg.status === "error"
-							? "error"
-							: "completed"
-						: "pending",
-				});
-			}
-		}
-	}
-	return result;
+  const result: LocalToolCall[] = [];
+  for (const msg of messages) {
+    const toolCalls = getToolCalls(msg);
+    if (
+      (msg.type === "ai" || msg.type === "assistant") &&
+      Array.isArray(toolCalls) &&
+      toolCalls.length > 0
+    ) {
+      for (let i = 0; i < toolCalls.length; i++) {
+        const tc = toolCalls[i];
+        const tcId = tc.id || `${msg.id}-tc-${i}`;
+        const toolMsg = toolResults.get(tcId);
+        result.push({
+          id: tcId,
+          call: { name: tc.name, args: tc.args, id: tc.id },
+          result: toolMsg,
+          aiMessage: msg,
+          index: i,
+          state: toolMsg
+            ? toolMsg.status === "error"
+              ? "error"
+              : "completed"
+            : "pending",
+        });
+      }
+    }
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -315,77 +322,75 @@ function computeToolCallsFromMessages(messages: LCMessage[]): LocalToolCall[] {
 // ---------------------------------------------------------------------------
 
 type ToolRenderState =
-	| "output-available"
-	| "output-error"
-	| "approval-requested"
-	| "input-available";
+  | "output-available"
+  | "output-error"
+  | "approval-requested"
+  | "input-available";
 
 function getToolRenderState(
-	tc: LocalToolCall,
-	isInterrupted: boolean,
-	hitlToolNames?: Set<string> | null,
+  tc: LocalToolCall,
+  isInterrupted: boolean,
+  hitlToolNames?: Set<string> | null,
 ): ToolRenderState {
-	if (tc.state === "completed") return "output-available";
-	if (tc.state === "error") return "output-error";
-	// pending
-	if (isInterrupted && (!hitlToolNames || hitlToolNames.has(tc.call.name))) {
-		return "approval-requested";
-	}
-	return "input-available";
+  if (tc.state === "completed") return "output-available";
+  if (tc.state === "error") return "output-error";
+  // pending
+  if (isInterrupted && (!hitlToolNames || hitlToolNames.has(tc.call.name))) {
+    return "approval-requested";
+  }
+  return "input-available";
 }
 
 // Extracts the set of tool names that require human approval from an HITL
 // interrupt payload. Tolerates both snake_case (live SSE) and camelCase
 // (rehydrated via the axios interceptor) shapes.
 function extractHitlToolNames(value: unknown): Set<string> | null {
-	if (!value || typeof value !== "object") return null;
-	const v = value as Record<string, unknown>;
-	const arr = (v.action_requests ?? v.actionRequests) as
-		| Array<{ name?: string }>
-		| undefined;
-	if (!Array.isArray(arr)) return null;
-	const names = arr
-		.map((r) => (r && typeof r.name === "string" ? r.name : null))
-		.filter((n): n is string => n != null);
-	return new Set(names);
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  const arr = (v.action_requests ?? v.actionRequests) as
+    Array<{ name?: string }> | undefined;
+  if (!Array.isArray(arr)) return null;
+  const names = arr
+    .map((r) => (r && typeof r.name === "string" ? r.name : null))
+    .filter((n): n is string => n != null);
+  return new Set(names);
 }
 
 function getMcpAppInfoFromToolCall(tc: LocalToolCall): McpAppToolInfo | null {
-	const artifact = tc.result?.artifact;
-	if (!artifact || typeof artifact !== "object") return null;
-	const a = artifact as Record<string, unknown>;
-	// Handle both camelCase (Axios/history) and snake_case (stream)
-	const resourceUri = (a.mcpAppResourceUri ?? a.mcp_app_resource_uri) as
-		| string
-		| undefined;
-	const serverId = (a.mcpServerId ?? a.mcp_server_id) as string | undefined;
-	if (!resourceUri || !serverId) return null;
-	return { resourceUri, serverId };
+  const artifact = tc.result?.artifact;
+  if (!artifact || typeof artifact !== "object") return null;
+  const a = artifact as Record<string, unknown>;
+  // Handle both camelCase (Axios/history) and snake_case (stream)
+  const resourceUri = (a.mcpAppResourceUri ?? a.mcp_app_resource_uri) as
+    string | undefined;
+  const serverId = (a.mcpServerId ?? a.mcp_server_id) as string | undefined;
+  if (!resourceUri || !serverId) return null;
+  return { resourceUri, serverId };
 }
 
 function getStructuredContentFromToolCall(
-	tc: LocalToolCall,
+  tc: LocalToolCall,
 ): Record<string, unknown> | undefined {
-	const artifact = tc.result?.artifact;
-	if (!artifact || typeof artifact !== "object") return undefined;
-	const a = artifact as Record<string, unknown>;
-	// Handle both camelCase (Axios/history) and snake_case (stream/langchain-mcp-adapters)
-	const sc = a.structuredContent ?? a.structured_content;
-	if (sc && typeof sc === "object") return sc as Record<string, unknown>;
-	return undefined;
+  const artifact = tc.result?.artifact;
+  if (!artifact || typeof artifact !== "object") return undefined;
+  const a = artifact as Record<string, unknown>;
+  // Handle both camelCase (Axios/history) and snake_case (stream/langchain-mcp-adapters)
+  const sc = a.structuredContent ?? a.structured_content;
+  if (sc && typeof sc === "object") return sc as Record<string, unknown>;
+  return undefined;
 }
 
 function getToolOutputContent(tc: LocalToolCall): unknown {
-	if (!tc.result) return undefined;
-	const content = tc.result.content;
-	if (typeof content === "string") {
-		try {
-			return JSON.parse(content);
-		} catch {
-			return content;
-		}
-	}
-	return content;
+  if (!tc.result) return undefined;
+  const content = tc.result.content;
+  if (typeof content === "string") {
+    try {
+      return JSON.parse(content);
+    } catch {
+      return content;
+    }
+  }
+  return content;
 }
 
 // ---------------------------------------------------------------------------
@@ -393,756 +398,762 @@ function getToolOutputContent(tc: LocalToolCall): unknown {
 // ---------------------------------------------------------------------------
 
 const ChatPage = () => {
-	const params = useParams();
-	const agentId = params.id as string;
-	const threadId = params.threadId as string;
-	const hasInitialized = useRef(false);
-	const [threadModel, setThreadModel] = useState<string | undefined>(undefined);
-	const [agentArchived, setAgentArchived] = useState(false);
-	const [viewerRole, setViewerRole] = useState<"admin" | null>(null);
-	const [initialValues, setInitialValues] = useState<Record<
-		string,
-		unknown
-	> | null>(null);
-	const [rehydratedInterrupt, setRehydratedInterrupt] = useState(false);
-	const [rehydratedInterruptValue, setRehydratedInterruptValue] =
-		useState<unknown>(null);
-	// Subagent internal conversations restored from subgraph checkpoints on
-	// refresh, keyed by tool_call_id. The SDK's custom transport doesn't expose a
-	// way to inject these into the reconstructed subagents, so we hold them here
-	// and pass them to SubAgentCard as a fallback.
-	const [subagentMessages, setSubagentMessages] = useState<
-		Record<string, unknown[]>
-	>({});
+  const params = useParams();
+  const agentId = params.id as string;
+  const threadId = params.threadId as string;
+  const hasInitialized = useRef(false);
+  const [threadModel, setThreadModel] = useState<string | undefined>(undefined);
+  const [agentArchived, setAgentArchived] = useState(false);
+  const [viewerRole, setViewerRole] = useState<"admin" | null>(null);
+  const [initialValues, setInitialValues] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const [rehydratedInterrupt, setRehydratedInterrupt] = useState(false);
+  const [rehydratedInterruptValue, setRehydratedInterruptValue] =
+    useState<unknown>(null);
+  // Subagent internal conversations restored from subgraph checkpoints on
+  // refresh, keyed by tool_call_id. The SDK's custom transport doesn't expose a
+  // way to inject these into the reconstructed subagents, so we hold them here
+  // and pass them to SubAgentCard as a fallback.
+  const [subagentMessages, setSubagentMessages] = useState<
+    Record<string, unknown[]>
+  >({});
 
-	const { mcpServers } = useMcpServersStore();
-	const {
-		ready: agentReady,
-		status: agentStatus,
-		disconnectedMcpServers,
-		refetch: refetchReady,
-	} = useAgentReadiness(agentArchived ? undefined : agentId);
+  const { mcpServers } = useMcpServersStore();
+  const {
+    ready: agentReady,
+    status: agentStatus,
+    disconnectedMcpServers,
+    refetch: refetchReady,
+  } = useAgentReadiness(agentArchived ? undefined : agentId);
 
-	const { customFetch, cancel, fetchActiveRunId } = useDurableRun(threadId);
+  const { customFetch, cancel, fetchActiveRunId } = useDurableRun(threadId);
 
-	const transport = useMemo(
-		() =>
-			new FetchStreamTransport({
-				apiUrl: `${API_BASE_URL}/threads/${threadId}/runs/stream`,
-				fetch: customFetch,
-			}),
-		[threadId, customFetch],
-	);
+  const transport = useMemo(
+    () =>
+      new FetchStreamTransport({
+        apiUrl: `${API_BASE_URL}/threads/${threadId}/runs/stream`,
+        fetch: customFetch,
+      }),
+    [threadId, customFetch],
+  );
 
-	const thread = useStream<Record<string, unknown>>({
-		transport,
-		threadId,
-		initialValues: initialValues ?? { messages: [] },
-		messagesKey: "messages",
-		filterSubagentMessages: true,
-		onFinish: () => {
-			const audio = new Audio("/success.mp3");
-			audio.play().catch(() => {});
-		},
-	} as Parameters<typeof useStream<Record<string, unknown>>>[0]);
+  const thread = useStream<Record<string, unknown>>({
+    transport,
+    threadId,
+    initialValues: initialValues ?? { messages: [] },
+    messagesKey: "messages",
+    filterSubagentMessages: true,
+    onFinish: () => {
+      const audio = new Audio("/success.mp3");
+      audio.play().catch(() => {});
+    },
+  } as Parameters<typeof useStream<Record<string, unknown>>>[0]);
 
-	const { isLoading, error, interrupt, submit: rawSubmit, stop } = thread;
+  const { isLoading, error, interrupt, submit: rawSubmit, stop } = thread;
 
-	// Once anything is dispatched, the live stream owns interrupt state — drop
-	// the rehydrated fallback so it can't shadow a fresh post-resume answer.
-	const submit = useCallback<typeof rawSubmit>(
-		(input, opts) => {
-			setRehydratedInterrupt(false);
-			setRehydratedInterruptValue(null);
-			return rawSubmit(input, opts);
-		},
-		[rawSubmit],
-	);
+  // Once anything is dispatched, the live stream owns interrupt state — drop
+  // the rehydrated fallback so it can't shadow a fresh post-resume answer.
+  const submit = useCallback<typeof rawSubmit>(
+    (input, opts) => {
+      setRehydratedInterrupt(false);
+      setRehydratedInterruptValue(null);
+      return rawSubmit(input, opts);
+    },
+    [rawSubmit],
+  );
 
-	// Stop both server-side (the run outlives this request) and locally.
-	const handleStop = useCallback(() => {
-		void cancel();
-		stop();
-	}, [cancel, stop]);
+  // Stop both server-side (the run outlives this request) and locally.
+  const handleStop = useCallback(() => {
+    void cancel();
+    stop();
+  }, [cancel, stop]);
 
-	// The custom transport path exposes subagent methods at runtime but
-	// BaseStream types do not include them. Cast to access the API.
-	const subagentApi = thread as unknown as SubagentApi;
+  // The custom transport path exposes subagent methods at runtime but
+  // BaseStream types do not include them. Cast to access the API.
+  const subagentApi = thread as unknown as SubagentApi;
 
-	// Supervisor todos from stream values
-	const streamValues = thread.values as Record<string, unknown>;
-	const supervisorTodos = (streamValues?.todos ?? []) as Todo[];
+  // Supervisor todos from stream values
+  const streamValues = thread.values as Record<string, unknown>;
+  const supervisorTodos = (streamValues?.todos ?? []) as Todo[];
 
-	// Messages: use stream messages when available, else initial.
-	// Throttle to ~16Hz so streamed chunks don't trigger per-token re-renders
-	// of the whole conversation (and per-token markdown re-parses).
-	const streamMessagesRaw = thread.messages as LCMessage[];
-	const streamMessages = useThrottledValue(streamMessagesRaw, 60);
-	const initMessages = (initialValues?.messages ?? []) as LCMessage[];
-	const messages =
-		streamMessages.length > 0 || isLoading ? streamMessages : initMessages;
+  // Messages: use stream messages when available, else initial.
+  // Throttle to ~16Hz so streamed chunks don't trigger per-token re-renders
+  // of the whole conversation (and per-token markdown re-parses).
+  const streamMessagesRaw = thread.messages as LCMessage[];
+  const streamMessages = useThrottledValue(streamMessagesRaw, 60);
+  const initMessages = (initialValues?.messages ?? []) as LCMessage[];
+  const messages =
+    streamMessages.length > 0 || isLoading ? streamMessages : initMessages;
 
-	const isInterrupted = interrupt != null || rehydratedInterrupt;
+  const isInterrupted = interrupt != null || rehydratedInterrupt;
 
-	// The HITL middleware only "hangs" tool calls whose name is in interrupt_on.
-	// Other parallel tool calls in the same AI message auto-execute on resume.
-	// Scope approval UI and decisions to the hanging subset so the decision count
-	// matches the backend's hanging count.
-	const hitlToolNames = useMemo(() => {
-		const liveValue = (interrupt as { value?: unknown } | null | undefined)
-			?.value;
-		return (
-			extractHitlToolNames(liveValue) ??
-			extractHitlToolNames(rehydratedInterruptValue)
-		);
-	}, [interrupt, rehydratedInterruptValue]);
+  // The HITL middleware only "hangs" tool calls whose name is in interrupt_on.
+  // Other parallel tool calls in the same AI message auto-execute on resume.
+  // Scope approval UI and decisions to the hanging subset so the decision count
+  // matches the backend's hanging count.
+  const hitlToolNames = useMemo(() => {
+    const liveValue = (interrupt as { value?: unknown } | null | undefined)
+      ?.value;
+    return (
+      extractHitlToolNames(liveValue) ??
+      extractHitlToolNames(rehydratedInterruptValue)
+    );
+  }, [interrupt, rehydratedInterruptValue]);
 
-	// Tool calls: use stream tool calls when streaming, else compute from messages
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const streamToolCallsRaw = ((thread as any).toolCalls ??
-		[]) as LocalToolCall[];
-	const streamToolCalls = useThrottledValue(streamToolCallsRaw, 60);
-	const localToolCalls = useMemo(
-		() => computeToolCallsFromMessages(messages),
-		[messages],
-	);
-	const toolCalls =
-		streamToolCalls.length > 0 || isLoading ? streamToolCalls : localToolCalls;
+  // Tool calls: use stream tool calls when streaming, else compute from messages
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const streamToolCallsRaw = ((thread as any).toolCalls ??
+    []) as LocalToolCall[];
+  const streamToolCalls = useThrottledValue(streamToolCallsRaw, 60);
+  const localToolCalls = useMemo(
+    () => computeToolCallsFromMessages(messages),
+    [messages],
+  );
+  const toolCalls =
+    streamToolCalls.length > 0 || isLoading ? streamToolCalls : localToolCalls;
 
-	// Index tool calls by AI message id once per render, so the inner map can
-	// look them up in O(1) instead of filtering the full list per message.
-	const toolCallsByMessageId = useMemo(() => {
-		const map = new Map<string, LocalToolCall[]>();
-		for (const tc of toolCalls) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const id = (tc.aiMessage as any)?.id as string | undefined;
-			if (!id || !tc.call.name) continue;
-			const existing = map.get(id);
-			if (existing) existing.push(tc);
-			else map.set(id, [tc]);
-		}
-		return map;
-	}, [toolCalls]);
+  // Index tool calls by AI message id once per render, so the inner map can
+  // look them up in O(1) instead of filtering the full list per message.
+  const toolCallsByMessageId = useMemo(() => {
+    const map = new Map<string, LocalToolCall[]>();
+    for (const tc of toolCalls) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const id = (tc.aiMessage as any)?.id as string | undefined;
+      if (!id || !tc.call.name) continue;
+      const existing = map.get(id);
+      if (existing) existing.push(tc);
+      else map.set(id, [tc]);
+    }
+    return map;
+  }, [toolCalls]);
 
-	const getToolCallsForMessage = useCallback(
-		(message: LCMessage) => {
-			if (!message.id) return [];
-			return toolCallsByMessageId.get(message.id) ?? [];
-		},
-		[toolCallsByMessageId],
-	);
+  const getToolCallsForMessage = useCallback(
+    (message: LCMessage) => {
+      if (!message.id) return [];
+      return toolCallsByMessageId.get(message.id) ?? [];
+    },
+    [toolCallsByMessageId],
+  );
 
-	// Loading state detection
-	const lastMsg = messages.length > 0 ? messages[messages.length - 1] : null;
-	const isAwaitingResponse =
-		isLoading &&
-		lastMsg != null &&
-		(lastMsg.type === "human" || lastMsg.type === "user");
+  // Loading state detection
+  const lastMsg = messages.length > 0 ? messages[messages.length - 1] : null;
+  const isAwaitingResponse =
+    isLoading &&
+    lastMsg != null &&
+    (lastMsg.type === "human" || lastMsg.type === "user");
 
-	const assistantIsStreaming =
-		isLoading &&
-		lastMsg != null &&
-		(lastMsg.type === "ai" || lastMsg.type === "assistant");
+  const assistantIsStreaming =
+    isLoading &&
+    lastMsg != null &&
+    (lastMsg.type === "ai" || lastMsg.type === "assistant");
 
-	const consumePendingMessage = usePendingMessageStore(
-		(state) => state.consumePendingMessage,
-	);
-	const knownServerNames = [...mcpServers.map((server) => server.name)].sort(
-		(a, b) => b.length - a.length,
-	);
-	const { setCurrentChat, clearCurrentChat } = useChatHeaderStore();
+  const consumePendingMessage = usePendingMessageStore(
+    (state) => state.consumePendingMessage,
+  );
+  const knownServerNames = [...mcpServers.map((server) => server.name)].sort(
+    (a, b) => b.length - a.length,
+  );
+  const { setCurrentChat, clearCurrentChat } = useChatHeaderStore();
 
-	// ---- Handlers ----
+  // ---- Handlers ----
 
-	const handleSubmit = (message: PromptInputMessage) => {
-		if (!message) return;
+  const handleSubmit = (message: PromptInputMessage) => {
+    if (!message) return;
 
-		const hasText = "text" in message && message.text?.trim();
-		const hasFiles =
-			"files" in message && message.files && message.files.length > 0;
+    const hasText = "text" in message && message.text?.trim();
+    const hasFiles =
+      "files" in message && message.files && message.files.length > 0;
 
-		if (!hasText && !hasFiles) return;
+    if (!hasText && !hasFiles) return;
 
-		// Build LangChain content blocks
-		const contentParts: Array<Record<string, unknown>> = [];
-		if (hasText) contentParts.push({ type: "text", text: message.text });
-		for (const file of message.files ?? []) {
-			const fileAny = file as Record<string, unknown>;
-			const fileUrl = (fileAny.url as string) || "";
-			const mediaType = (fileAny.mediaType as string) || "";
+    // Build LangChain content blocks
+    const contentParts: Array<Record<string, unknown>> = [];
+    if (hasText) contentParts.push({ type: "text", text: message.text });
+    for (const file of message.files ?? []) {
+      const fileAny = file as Record<string, unknown>;
+      const fileUrl = (fileAny.url as string) || "";
+      const mediaType = (fileAny.mediaType as string) || "";
 
-			if (mediaType.startsWith("image/")) {
-				// Images: standard LangChain image_url block
-				contentParts.push({
-					type: "image_url",
-					image_url: { url: fileUrl, detail: "auto" },
-				});
-			} else {
-				// Non-image files (PDF, etc.): standard LangChain file block
-				// LangChain adapters convert this to provider-native format
-				const base64Match = fileUrl.match(/^data:[^;]*;base64,(.*)$/);
-				const base64Data = base64Match ? base64Match[1] : fileUrl;
-				const filename = (fileAny.filename as string) || "file";
-				contentParts.push({
-					type: "file",
-					mime_type: mediaType || "application/octet-stream",
-					base64: base64Data,
-					filename,
-				});
-			}
-		}
+      if (mediaType.startsWith("image/")) {
+        // Images: standard LangChain image_url block
+        contentParts.push({
+          type: "image_url",
+          image_url: { url: fileUrl, detail: "auto" },
+        });
+      } else {
+        // Non-image files (PDF, etc.): standard LangChain file block
+        // LangChain adapters convert this to provider-native format
+        const base64Match = fileUrl.match(/^data:[^;]*;base64,(.*)$/);
+        const base64Data = base64Match ? base64Match[1] : fileUrl;
+        const filename = (fileAny.filename as string) || "file";
+        contentParts.push({
+          type: "file",
+          mime_type: mediaType || "application/octet-stream",
+          base64: base64Data,
+          filename,
+        });
+      }
+    }
 
-		const content =
-			contentParts.length === 1 && contentParts[0].type === "text"
-				? (contentParts[0].text as string)
-				: contentParts;
+    const content =
+      contentParts.length === 1 && contentParts[0].type === "text"
+        ? (contentParts[0].text as string)
+        : contentParts;
 
-		submit(
-			{ messages: [{ type: "human", content }] },
-			{
-				optimisticValues: {
-					messages: [
-						...messages,
-						{ type: "human", content, id: crypto.randomUUID() },
-					],
-				},
-				streamSubgraphs: true,
-			},
-		);
-	};
+    submit(
+      { messages: [{ type: "human", content }] },
+      {
+        optimisticValues: {
+          messages: [
+            ...messages,
+            { type: "human", content, id: crypto.randomUUID() },
+          ],
+        },
+        streamSubgraphs: true,
+      },
+    );
+  };
 
-	const pendingToolCalls = useMemo(
-		() =>
-			toolCalls.filter(
-				(tc) =>
-					getToolRenderState(tc, isInterrupted, hitlToolNames) ===
-					"approval-requested",
-			),
-		[toolCalls, isInterrupted, hitlToolNames],
-	);
+  const pendingToolCalls = useMemo(
+    () =>
+      toolCalls.filter(
+        (tc) =>
+          getToolRenderState(tc, isInterrupted, hitlToolNames) ===
+          "approval-requested",
+      ),
+    [toolCalls, isInterrupted, hitlToolNames],
+  );
 
-	const { decisions, recordDecision } = useHitlApprovals({
-		isInterrupted,
-		pendingToolCalls,
-		submit: (input, opts) => {
-			void submit(input, opts);
-		},
-		messages,
-	});
+  const { decisions, recordDecision } = useHitlApprovals({
+    isInterrupted,
+    pendingToolCalls,
+    submit: (input, opts) => {
+      void submit(input, opts);
+    },
+    messages,
+  });
 
-	const handleRegenerate = () => {
-		// Find the last human message and resubmit with regenerate trigger
-		const lastHuman = [...messages]
-			.reverse()
-			.find((m) => m.type === "human" || m.type === "user");
-		if (!lastHuman) return;
+  const handleRegenerate = () => {
+    // Find the last human message and resubmit with regenerate trigger
+    const lastHuman = [...messages]
+      .reverse()
+      .find((m) => m.type === "human" || m.type === "user");
+    if (!lastHuman) return;
 
-		submit(
-			{ messages: [{ type: "human", content: lastHuman.content }] },
-			{
-				config: {
-					configurable: { trigger: "regenerate-message" },
-				},
-				optimisticValues: { messages },
-				streamSubgraphs: true,
-			},
-		);
-	};
+    submit(
+      { messages: [{ type: "human", content: lastHuman.content }] },
+      {
+        config: {
+          configurable: { trigger: "regenerate-message" },
+        },
+        optimisticValues: { messages },
+        streamSubgraphs: true,
+      },
+    );
+  };
 
-	// ---- Fetch subagent internal messages after reconstruction ----
+  // ---- Fetch subagent internal messages after reconstruction ----
 
-	const hasFetchedSubagentHistory = useRef(false);
+  const hasFetchedSubagentHistory = useRef(false);
 
-	useEffect(() => {
-		if (hasFetchedSubagentHistory.current) return;
-		if (isLoading) return;
-		if (!subagentApi.subagents || subagentApi.subagents.size === 0) return;
+  useEffect(() => {
+    if (hasFetchedSubagentHistory.current) return;
+    if (isLoading) return;
+    if (!subagentApi.subagents || subagentApi.subagents.size === 0) return;
 
-		// Find subagents that were reconstructed but have no internal messages
-		const toFetch = [...subagentApi.subagents.entries()].filter(
-			([, s]) =>
-				s.messages.length === 0 &&
-				(s.status === "complete" || s.status === "error"),
-		);
-		if (toFetch.length === 0) return;
+    // Find subagents that were reconstructed but have no internal messages
+    const toFetch = [...subagentApi.subagents.entries()].filter(
+      ([, s]) =>
+        s.messages.length === 0 &&
+        (s.status === "complete" || s.status === "error"),
+    );
+    if (toFetch.length === 0) return;
 
-		hasFetchedSubagentHistory.current = true;
+    hasFetchedSubagentHistory.current = true;
 
-		Promise.all(
-			toFetch.map(async ([toolCallId]) => {
-				try {
-					const res = await api.get(
-						`/threads/${threadId}/subagents/${toolCallId}/state`,
-					);
-					const msgs = res.data?.messages;
-					if (!Array.isArray(msgs) || msgs.length === 0) return;
-					setSubagentMessages((prev) => ({ ...prev, [toolCallId]: msgs }));
-				} catch {
-					// Subgraph checkpoint may not exist — ignore
-				}
-			}),
-		);
-	}, [subagentApi, thread, isLoading, threadId]);
+    Promise.all(
+      toFetch.map(async ([toolCallId]) => {
+        try {
+          const res = await api.get(
+            `/threads/${threadId}/subagents/${toolCallId}/state`,
+          );
+          const msgs = res.data?.messages;
+          if (!Array.isArray(msgs) || msgs.length === 0) return;
+          setSubagentMessages((prev) => ({ ...prev, [toolCallId]: msgs }));
+        } catch {
+          // Subgraph checkpoint may not exist — ignore
+        }
+      }),
+    );
+  }, [subagentApi, thread, isLoading, threadId]);
 
-	// ---- Initialization ----
+  // ---- Initialization ----
 
-	useEffect(() => {
-		return () => {
-			clearCurrentChat();
-		};
-	}, [clearCurrentChat]);
+  useEffect(() => {
+    return () => {
+      clearCurrentChat();
+    };
+  }, [clearCurrentChat]);
 
-	useEffect(() => {
-		if (hasInitialized.current) return;
-		hasInitialized.current = true;
+  useEffect(() => {
+    if (hasInitialized.current) return;
+    hasInitialized.current = true;
 
-		const initializeChat = async () => {
-			const response = await api.get(`/threads/${threadId}`);
-			const data = response.data;
+    const initializeChat = async () => {
+      const response = await api.get(`/threads/${threadId}`);
+      const data = response.data;
 
-			setThreadModel(data.thread.modelId);
-			const isTriggerThread = data.thread.source === "trigger";
-			setCurrentChat({
-				agentName: data.thread.agentName ?? null,
-				agentEmoji: data.thread.agentEmoji ?? null,
-				agentColor: data.thread.agentColor ?? null,
-				modelId: data.thread.modelId ?? null,
-				// Trigger firings are titled by their trigger; the header shows
-				// "<trigger name> / <firing time>" instead of the agent.
-				triggerName: isTriggerThread
-					? (data.thread.firstMessageContent ?? null)
-					: null,
-				triggerRunAt: isTriggerThread
-					? (data.thread.createdAt ?? null)
-					: null,
-			});
+      setThreadModel(data.thread.modelId);
+      const isTriggerThread = data.thread.source === "trigger";
+      setCurrentChat({
+        agentName: data.thread.agentName ?? null,
+        agentEmoji: data.thread.agentEmoji ?? null,
+        agentColor: data.thread.agentColor ?? null,
+        modelId: data.thread.modelId ?? null,
+        // Trigger firings are titled by their trigger; the header shows
+        // "<trigger name> / <firing time>" instead of the agent, linking
+        // to the trigger's detail page.
+        triggerId: isTriggerThread ? (data.thread.triggerId ?? null) : null,
+        triggerName: isTriggerThread
+          ? (data.thread.firstMessageContent ?? null)
+          : null,
+        triggerRunAt: isTriggerThread ? (data.thread.createdAt ?? null) : null,
+      });
 
-			if (data.thread.agentArchived) {
-				setAgentArchived(true);
-			}
+      if (data.thread.agentArchived) {
+        setAgentArchived(true);
+      }
 
-			if (data.viewerRole === "admin") {
-				setViewerRole("admin");
-			}
+      if (data.viewerRole === "admin") {
+        setViewerRole("admin");
+      }
 
-			if (data.interrupted) {
-				setRehydratedInterrupt(true);
-				if (data.interruptValue !== undefined) {
-					setRehydratedInterruptValue(data.interruptValue);
-				}
-			}
+      if (data.interrupted) {
+        setRehydratedInterrupt(true);
+        if (data.interruptValue !== undefined) {
+          setRehydratedInterruptValue(data.interruptValue);
+        }
+      }
 
-			// If a run is still in flight for this thread, reattach to its live
-			// stream rather than rendering the (incomplete) checkpoint. The
-			// values replay rebuilds the full conversation, so start from empty
-			// to avoid a mid-flight rebuild flicker.
-			const activeRunId = await fetchActiveRunId();
-			if (activeRunId) {
-				setInitialValues({ messages: [] });
-				// Use the `submit` wrapper (not rawSubmit) so any rehydrated HITL
-				// state is cleared before the live replayed run owns it.
-				setTimeout(() => {
-					submit(
-						{
-							[REATTACH_RUN_FIELD]: activeRunId,
-						} as Parameters<typeof submit>[0],
-						{ streamSubgraphs: true } as Parameters<typeof submit>[1],
-					);
-				}, 0);
-				return;
-			}
+      // If a run is still in flight for this thread, reattach to its live
+      // stream rather than rendering the (incomplete) checkpoint. The
+      // values replay rebuilds the full conversation, so start from empty
+      // to avoid a mid-flight rebuild flicker.
+      const activeRunId = await fetchActiveRunId();
+      if (activeRunId) {
+        setInitialValues({ messages: [] });
+        // Use the `submit` wrapper (not rawSubmit) so any rehydrated HITL
+        // state is cleared before the live replayed run owns it.
+        setTimeout(() => {
+          submit(
+            {
+              [REATTACH_RUN_FIELD]: activeRunId,
+            } as Parameters<typeof submit>[0],
+            { streamSubgraphs: true } as Parameters<typeof submit>[1],
+          );
+        }, 0);
+        return;
+      }
 
-			const values = data.values || { messages: [] };
-			// Restore snake_case message keys so the SDK can reconstruct subagents.
-			const normalizedValues = {
-				...values,
-				messages: toSdkMessages((values.messages ?? []) as LCMessage[]),
-			};
+      const values = data.values || { messages: [] };
+      // Restore snake_case message keys so the SDK can reconstruct subagents.
+      const normalizedValues = {
+        ...values,
+        messages: toSdkMessages((values.messages ?? []) as LCMessage[]),
+      };
 
-			const pendingMessage = consumePendingMessage(threadId);
-			if (pendingMessage) {
-				// Set initial values first so submit has proper history base
-				setInitialValues(normalizedValues);
-				// Defer submit to next tick so initialValues takes effect
-				setTimeout(() => {
-					handleSubmit(pendingMessage);
-				}, 0);
-			} else {
-				setInitialValues(normalizedValues);
-			}
-		};
+      const pendingMessage = consumePendingMessage(threadId);
+      if (pendingMessage) {
+        // Set initial values first so submit has proper history base
+        setInitialValues(normalizedValues);
+        // Defer submit to next tick so initialValues takes effect
+        setTimeout(() => {
+          handleSubmit(pendingMessage);
+        }, 0);
+      } else {
+        setInitialValues(normalizedValues);
+      }
+    };
 
-		initializeChat();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [threadId]);
+    initializeChat();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [threadId]);
 
-	// ---- Render ----
+  // ---- Render ----
 
-	return (
-		<div className="h-full flex flex-col w-full overflow-hidden">
-			<div className="h-full relative flex flex-1 flex-col min-h-0 w-full">
-				<Conversation>
-					<ConversationContent className="max-w-4xl mx-auto w-full lg:px-10 sm:px-6 px-2">
-						{supervisorTodos.length > 0 && (
-							<TodoList
-								todos={supervisorTodos}
-								className="mb-4 rounded-lg border border-border/50 bg-muted/30 p-4"
-							/>
-						)}
-						{messages.map((message, messageIndex) => {
-							// Skip tool messages — they're rendered via toolCalls pairing
-							if (message.type === "tool") return null;
+  return (
+    <div className="h-full flex flex-col w-full overflow-hidden">
+      <div className="h-full relative flex flex-1 flex-col min-h-0 w-full">
+        <Conversation>
+          <ConversationContent className="max-w-4xl mx-auto w-full lg:px-10 sm:px-6 px-2">
+            {supervisorTodos.length > 0 && (
+              <TodoList
+                todos={supervisorTodos}
+                className="mb-4 rounded-lg border border-border/50 bg-muted/30 p-4"
+              />
+            )}
+            {messages.map((message, messageIndex) => {
+              // Skip tool messages — they're rendered via toolCalls pairing
+              if (message.type === "tool") return null;
 
-							// ---- Human message ----
-							if (message.type === "human" || message.type === "user") {
-								const text = getTextContent(message);
-								const attachments = getFileAttachments(message);
+              // ---- Human message ----
+              if (message.type === "human" || message.type === "user") {
+                const text = getTextContent(message);
+                const attachments = getFileAttachments(message);
 
-								return (
-									<Fragment key={message.id ?? messageIndex}>
-										{attachments.length > 0 && (
-											<div className="flex justify-end">
-												<Attachments variant="inline">
-													{attachments.map((attachment) => {
-														const mediaCategory = getMediaCategory(attachment);
-														const label = getAttachmentLabel(attachment);
-														return (
-															<AttachmentHoverCard key={attachment.id}>
-																<AttachmentHoverCardTrigger asChild>
-																	<Attachment data={attachment}>
-																		<div className="relative size-5 shrink-0">
-																			<div className="absolute inset-0 transition-opacity group-hover:opacity-0">
-																				<AttachmentPreview />
-																			</div>
-																		</div>
-																		<AttachmentInfo />
-																	</Attachment>
-																</AttachmentHoverCardTrigger>
-																<AttachmentHoverCardContent>
-																	<div className="space-y-3">
-																		{mediaCategory === "image" &&
-																			"url" in attachment &&
-																			attachment.url && (
-																				<div className="flex items-center justify-center overflow-hidden rounded-md border">
-																					<Image
-																						alt={label}
-																						className="object-contain"
-																						height={200}
-																						src={attachment.url as string}
-																						width={200}
-																					/>
-																				</div>
-																			)}
-																		<div className="space-y-1 px-0.5">
-																			<h4 className="font-semibold text-sm leading-none">
-																				{label}
-																			</h4>
-																		</div>
-																	</div>
-																</AttachmentHoverCardContent>
-															</AttachmentHoverCard>
-														);
-													})}
-												</Attachments>
-											</div>
-										)}
-										{text && (
-											<Message from="user">
-												<MessageContent>
-													<MessageResponse>{text}</MessageResponse>
-												</MessageContent>
-											</Message>
-										)}
-									</Fragment>
-								);
-							}
+                return (
+                  <Fragment key={message.id ?? messageIndex}>
+                    {attachments.length > 0 && (
+                      <div className="flex justify-end">
+                        <Attachments variant="inline">
+                          {attachments.map((attachment) => {
+                            const mediaCategory = getMediaCategory(attachment);
+                            const label = getAttachmentLabel(attachment);
+                            return (
+                              <AttachmentHoverCard key={attachment.id}>
+                                <AttachmentHoverCardTrigger asChild>
+                                  <Attachment data={attachment}>
+                                    <div className="relative size-5 shrink-0">
+                                      <div className="absolute inset-0 transition-opacity group-hover:opacity-0">
+                                        <AttachmentPreview />
+                                      </div>
+                                    </div>
+                                    <AttachmentInfo />
+                                  </Attachment>
+                                </AttachmentHoverCardTrigger>
+                                <AttachmentHoverCardContent>
+                                  <div className="space-y-3">
+                                    {mediaCategory === "image" &&
+                                      "url" in attachment &&
+                                      attachment.url && (
+                                        <div className="flex items-center justify-center overflow-hidden rounded-md border">
+                                          <Image
+                                            alt={label}
+                                            className="object-contain"
+                                            height={200}
+                                            src={attachment.url as string}
+                                            width={200}
+                                          />
+                                        </div>
+                                      )}
+                                    <div className="space-y-1 px-0.5">
+                                      <h4 className="font-semibold text-sm leading-none">
+                                        {label}
+                                      </h4>
+                                    </div>
+                                  </div>
+                                </AttachmentHoverCardContent>
+                              </AttachmentHoverCard>
+                            );
+                          })}
+                        </Attachments>
+                      </div>
+                    )}
+                    {text && (
+                      <Message from="user">
+                        <MessageContent>
+                          <MessageResponse>{text}</MessageResponse>
+                        </MessageContent>
+                      </Message>
+                    )}
+                  </Fragment>
+                );
+              }
 
-							// ---- AI message ----
-							if (message.type === "ai" || message.type === "assistant") {
-								const text = getTextContent(message);
-								const reasoning = getReasoningContent(message);
-								const msgToolCalls = getToolCallsForMessage(message);
-								const isLastMessage =
-									messageIndex === messages.length - 1 ||
-									// Last AI message before a potential loading indicator
-									(messageIndex === messages.length - 2 &&
-										messages[messages.length - 1]?.type === "tool");
-								const isLastAiMessage =
-									!isLoading && isLastMessage && text.length > 0;
+              // ---- AI message ----
+              if (message.type === "ai" || message.type === "assistant") {
+                const text = getTextContent(message);
+                const reasoning = getReasoningContent(message);
+                const msgToolCalls = getToolCallsForMessage(message);
+                const isLastMessage =
+                  messageIndex === messages.length - 1 ||
+                  // Last AI message before a potential loading indicator
+                  (messageIndex === messages.length - 2 &&
+                    messages[messages.length - 1]?.type === "tool");
+                const isLastAiMessage =
+                  !isLoading && isLastMessage && text.length > 0;
 
-								return (
-									<Fragment key={message.id ?? messageIndex}>
-										{/* Reasoning / thinking */}
-										{reasoning && (
-											<Reasoning
-												className="w-full"
-												isStreaming={assistantIsStreaming && isLastMessage}
-											>
-												<ReasoningTrigger />
-												<ReasoningContent>{reasoning}</ReasoningContent>
-											</Reasoning>
-										)}
+                return (
+                  <Fragment key={message.id ?? messageIndex}>
+                    {/* Reasoning / thinking */}
+                    {reasoning && (
+                      <Reasoning
+                        className="w-full"
+                        isStreaming={assistantIsStreaming && isLastMessage}
+                      >
+                        <ReasoningTrigger />
+                        <ReasoningContent>{reasoning}</ReasoningContent>
+                      </Reasoning>
+                    )}
 
-										{/* Text content */}
-										{text && (
-											<>
-												<Message from="assistant">
-													<MessageContent>
-														<MessageResponse>{text}</MessageResponse>
-													</MessageContent>
-												</Message>
-												{isLastAiMessage && (
-													<MessageActions>
-														<MessageAction
-															onClick={handleRegenerate}
-															label="Retry"
-														>
-															<RefreshCcwIcon className="size-3" />
-														</MessageAction>
-														<MessageAction
-															onClick={() => {
-																void navigator.clipboard.writeText(text);
-															}}
-															label="Copy"
-														>
-															<CopyIcon className="size-3" />
-														</MessageAction>
-													</MessageActions>
-												)}
-											</>
-										)}
+                    {/* Text content */}
+                    {text && (
+                      <>
+                        <Message from="assistant">
+                          <MessageContent>
+                            <MessageResponse>{text}</MessageResponse>
+                          </MessageContent>
+                        </Message>
+                        {isLastAiMessage && (
+                          <MessageActions>
+                            <MessageAction
+                              onClick={handleRegenerate}
+                              label="Retry"
+                            >
+                              <RefreshCcwIcon className="size-3" />
+                            </MessageAction>
+                            <MessageAction
+                              onClick={() => {
+                                void navigator.clipboard.writeText(text);
+                              }}
+                              label="Copy"
+                            >
+                              <CopyIcon className="size-3" />
+                            </MessageAction>
+                          </MessageActions>
+                        )}
+                      </>
+                    )}
 
-										{/* Tool calls */}
-										{msgToolCalls.map((tc) => {
-											const toolState = getToolRenderState(
-												tc,
-												isInterrupted,
-												hitlToolNames,
-											);
-											const { serverName, toolName } = getToolMetadata(
-												tc.call.name,
-												knownServerNames,
-											);
-											const output = getToolOutputContent(tc);
+                    {/* Tool calls */}
+                    {msgToolCalls.map((tc) => {
+                      const toolState = getToolRenderState(
+                        tc,
+                        isInterrupted,
+                        hitlToolNames,
+                      );
+                      const { serverName, toolName } = getToolMetadata(
+                        tc.call.name,
+                        knownServerNames,
+                      );
+                      const output = getToolOutputContent(tc);
 
-											const decided = decisions[tc.id];
+                      const decided = decisions[tc.id];
 
-											return (
-												<Fragment key={tc.id}>
-													<Tool
-														toolState={toolState}
-														lockOpen={
-															toolState === "approval-requested" && !decided
-														}
-													>
-														<ToolHeader
-															title={toolName}
-															type={`tool-${tc.call.name}`}
-															state={toolState}
-															mcpServerName={serverName}
-															mcpServerIcon={
-																mcpServers.find(
-																	(server) => server.name === serverName,
-																)?.iconUrl
-															}
-														/>
-														<ToolContent>
-															<ToolContentInner>
-																{tc.call.args !== undefined && (
-																	<ToolInput input={tc.call.args} />
-																)}
-																{(output !== undefined ||
-																	tc.state === "error" ||
-																	tc.state === "pending") && (
-																	<ToolOutput
-																		output={output as React.ReactNode}
-																		errorText={
-																			tc.state === "error" && tc.result
-																				? extractToolErrorText(tc.result.content)
-																				: undefined
-																		}
-																	/>
-																)}
-															</ToolContentInner>
-															{/* HITL Approval UI */}
-															{toolState === "approval-requested" && (
-																<ToolFooter>
-																	<Button
-																		variant="default"
-																		className={cn(
-																			"cursor-pointer",
-																			decided === "reject" && "opacity-40",
-																		)}
-																		disabled={decided != null}
-																		onClick={() => { recordDecision(tc.id, "approve"); }}
-																	>
-																		Approve
-																	</Button>
-																	<Button
-																		variant="ghost"
-																		className={cn(
-																			"cursor-pointer",
-																			decided === "approve" && "opacity-40",
-																		)}
-																		disabled={decided != null}
-																		onClick={() => { recordDecision(tc.id, "reject"); }}
-																	>
-																		Reject
-																	</Button>
-																</ToolFooter>
-															)}
-														</ToolContent>
-													</Tool>
-													{(() => {
-														const appToolInfo = getMcpAppInfoFromToolCall(tc);
-														if (!appToolInfo) return null;
-														return (
-															<McpAppWidget
-																input={tc.call.args}
-																output={getToolOutputContent(tc)}
-																structuredContent={getStructuredContentFromToolCall(
-																	tc,
-																)}
-																errorText={
-																	tc.state === "error" && tc.result
-																		? extractToolErrorText(tc.result.content)
-																		: undefined
-																}
-																toolName={toolName}
-																appToolInfo={appToolInfo}
-															/>
-														);
-													})()}
-												</Fragment>
-											);
-										})}
+                      return (
+                        <Fragment key={tc.id}>
+                          <Tool
+                            toolState={toolState}
+                            lockOpen={
+                              toolState === "approval-requested" && !decided
+                            }
+                          >
+                            <ToolHeader
+                              title={toolName}
+                              type={`tool-${tc.call.name}`}
+                              state={toolState}
+                              mcpServerName={serverName}
+                              mcpServerIcon={
+                                mcpServers.find(
+                                  (server) => server.name === serverName,
+                                )?.iconUrl
+                              }
+                            />
+                            <ToolContent>
+                              <ToolContentInner>
+                                {tc.call.args !== undefined && (
+                                  <ToolInput input={tc.call.args} />
+                                )}
+                                {(output !== undefined ||
+                                  tc.state === "error" ||
+                                  tc.state === "pending") && (
+                                  <ToolOutput
+                                    output={output as React.ReactNode}
+                                    errorText={
+                                      tc.state === "error" && tc.result
+                                        ? extractToolErrorText(
+                                            tc.result.content,
+                                          )
+                                        : undefined
+                                    }
+                                  />
+                                )}
+                              </ToolContentInner>
+                              {/* HITL Approval UI */}
+                              {toolState === "approval-requested" && (
+                                <ToolFooter>
+                                  <Button
+                                    variant="default"
+                                    className={cn(
+                                      "cursor-pointer",
+                                      decided === "reject" && "opacity-40",
+                                    )}
+                                    disabled={decided != null}
+                                    onClick={() => {
+                                      recordDecision(tc.id, "approve");
+                                    }}
+                                  >
+                                    Approve
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    className={cn(
+                                      "cursor-pointer",
+                                      decided === "approve" && "opacity-40",
+                                    )}
+                                    disabled={decided != null}
+                                    onClick={() => {
+                                      recordDecision(tc.id, "reject");
+                                    }}
+                                  >
+                                    Reject
+                                  </Button>
+                                </ToolFooter>
+                              )}
+                            </ToolContent>
+                          </Tool>
+                          {(() => {
+                            const appToolInfo = getMcpAppInfoFromToolCall(tc);
+                            if (!appToolInfo) return null;
+                            return (
+                              <McpAppWidget
+                                input={tc.call.args}
+                                output={getToolOutputContent(tc)}
+                                structuredContent={getStructuredContentFromToolCall(
+                                  tc,
+                                )}
+                                errorText={
+                                  tc.state === "error" && tc.result
+                                    ? extractToolErrorText(tc.result.content)
+                                    : undefined
+                                }
+                                toolName={toolName}
+                                appToolInfo={appToolInfo}
+                              />
+                            );
+                          })()}
+                        </Fragment>
+                      );
+                    })}
 
-										{/* Subagent cards */}
-										{(() => {
-											const turnSubagents = message.id
-												? subagentApi.getSubagentsByMessage(message.id)
-												: [];
-											if (turnSubagents.length === 0) return null;
-											return (
-												<div className="space-y-2 mt-1">
-													<SubAgentProgress subagents={turnSubagents} />
-													{turnSubagents.map((sub) => (
-														<SubAgentCard
-															key={sub.id}
-															subagent={sub}
-															mcpServers={mcpServers}
-															fallbackMessages={subagentMessages[sub.id]}
-														/>
-													))}
-													<SynthesisIndicator
-														subagents={turnSubagents}
-														isCoordinatorStreaming={
-															assistantIsStreaming && isLastMessage
-														}
-													/>
-												</div>
-											);
-										})()}
-									</Fragment>
-								);
-							}
+                    {/* Subagent cards */}
+                    {(() => {
+                      const turnSubagents = message.id
+                        ? subagentApi.getSubagentsByMessage(message.id)
+                        : [];
+                      if (turnSubagents.length === 0) return null;
+                      return (
+                        <div className="space-y-2 mt-1">
+                          <SubAgentProgress subagents={turnSubagents} />
+                          {turnSubagents.map((sub) => (
+                            <SubAgentCard
+                              key={sub.id}
+                              subagent={sub}
+                              mcpServers={mcpServers}
+                              fallbackMessages={subagentMessages[sub.id]}
+                            />
+                          ))}
+                          <SynthesisIndicator
+                            subagents={turnSubagents}
+                            isCoordinatorStreaming={
+                              assistantIsStreaming && isLastMessage
+                            }
+                          />
+                        </div>
+                      );
+                    })()}
+                  </Fragment>
+                );
+              }
 
-							return null;
-						})}
+              return null;
+            })}
 
-						{/* Loading indicator */}
-						{isAwaitingResponse && (
-							<div>
-								<Message from="assistant">
-									<div className="w-full flex flex-col gap-2">
-										<MessageContent>
-											<ThinkingLoader className="px-0" />
-										</MessageContent>
-									</div>
-								</Message>
-							</div>
-						)}
+            {/* Loading indicator */}
+            {isAwaitingResponse && (
+              <div>
+                <Message from="assistant">
+                  <div className="w-full flex flex-col gap-2">
+                    <MessageContent>
+                      <ThinkingLoader className="px-0" />
+                    </MessageContent>
+                  </div>
+                </Message>
+              </div>
+            )}
 
-						{/* Streaming indicator when AI has started but text is still coming */}
-						{assistantIsStreaming &&
-							lastMsg !== null &&
-							getTextContent(lastMsg).length === 0 &&
-							!getToolCallsForMessage(lastMsg).length && (
-								<div>
-									<Message from="assistant">
-										<div className="w-full flex flex-col gap-2">
-											<MessageContent>
-												<ThinkingLoader className="px-0" />
-											</MessageContent>
-										</div>
-									</Message>
-								</div>
-							)}
+            {/* Streaming indicator when AI has started but text is still coming */}
+            {assistantIsStreaming &&
+              lastMsg !== null &&
+              getTextContent(lastMsg).length === 0 &&
+              !getToolCallsForMessage(lastMsg).length && (
+                <div>
+                  <Message from="assistant">
+                    <div className="w-full flex flex-col gap-2">
+                      <MessageContent>
+                        <ThinkingLoader className="px-0" />
+                      </MessageContent>
+                    </div>
+                  </Message>
+                </div>
+              )}
 
-						{error != null && (
-							<Error>
-								<ErrorContent>An error occurred.</ErrorContent>
-								<ErrorDetails>
-									<div>
-										{error instanceof globalThis.Error
-											? error.message
-											: String(error)}
-									</div>
-								</ErrorDetails>
-							</Error>
-						)}
-					</ConversationContent>
-					<ConversationScrollButton />
-				</Conversation>
-				<div className="pointer-events-none absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-background to-transparent z-10" />
-			</div>
-			<div className="w-full shrink-0 bg-background">
-				{viewerRole === "admin" ? (
-					<div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-6">
-						<div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
-							<ShieldCheck className="size-5 shrink-0 text-muted-foreground" />
-							<p className="text-sm text-muted-foreground">
-								Viewing as admin — this thread belongs to another user and is
-								read-only.
-							</p>
-						</div>
-					</div>
-				) : agentArchived ? (
-					<div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-6">
-						<div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
-							<ArchiveIcon className="size-5 shrink-0 text-muted-foreground" />
-							<p className="text-sm text-muted-foreground">
-								The agent linked to this conversation has been archived. This
-								thread is preserved as read-only so you can still review your
-								past messages.
-							</p>
-						</div>
-					</div>
-				) : agentStatus === "not_configured" ? (
-					<div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-4">
-						<div className="w-full flex items-center justify-center border border-red-200 bg-red-50 rounded-lg px-4 py-8">
-							<p className="text-md text-center text-red-700">
-								Agent is not configured yet. Contact agent owner to configure it
-								first.
-							</p>
-						</div>
-					</div>
-				) : (
-					<ChatPromptInput
-						onSubmit={handleSubmit}
-						status={isLoading ? "streaming" : "ready"}
-						className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-4"
-						stop={handleStop}
-						selectedModel={threadModel}
-						readOnlyModel={true}
-						agentReady={agentReady}
-						disconnectedServers={disconnectedMcpServers}
-						onAllConnected={refetchReady}
-					/>
-				)}
-			</div>
-		</div>
-	);
+            {error != null && (
+              <Error>
+                <ErrorContent>An error occurred.</ErrorContent>
+                <ErrorDetails>
+                  <div>
+                    {error instanceof globalThis.Error
+                      ? error.message
+                      : String(error)}
+                  </div>
+                </ErrorDetails>
+              </Error>
+            )}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-background to-transparent z-10" />
+      </div>
+      <div className="w-full shrink-0 bg-background">
+        {viewerRole === "admin" ? (
+          <div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-6">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
+              <ShieldCheck className="size-5 shrink-0 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                Viewing as admin — this thread belongs to another user and is
+                read-only.
+              </p>
+            </div>
+          </div>
+        ) : agentArchived ? (
+          <div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-6">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
+              <ArchiveIcon className="size-5 shrink-0 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                The agent linked to this conversation has been archived. This
+                thread is preserved as read-only so you can still review your
+                past messages.
+              </p>
+            </div>
+          </div>
+        ) : agentStatus === "not_configured" ? (
+          <div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-4">
+            <div className="w-full flex items-center justify-center border border-red-200 bg-red-50 rounded-lg px-4 py-8">
+              <p className="text-md text-center text-red-700">
+                Agent is not configured yet. Contact agent owner to configure it
+                first.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <ChatPromptInput
+            onSubmit={handleSubmit}
+            status={isLoading ? "streaming" : "ready"}
+            className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-4"
+            stop={handleStop}
+            selectedModel={threadModel}
+            readOnlyModel={true}
+            agentReady={agentReady}
+            disconnectedServers={disconnectedMcpServers}
+            onAllConnected={refetchReady}
+          />
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default ChatPage;

--- a/web/src/components/layout/chat-header.tsx
+++ b/web/src/components/layout/chat-header.tsx
@@ -1,47 +1,67 @@
 "use client";
 
 import { AlarmClock } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useChatHeaderStore } from "@/stores/chat-header-store";
 import { formatRunAt } from "@/lib/triggers/schedule";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 
 export function ChatHeader() {
-	const { agentName, agentEmoji, agentColor, triggerName, triggerRunAt } =
-		useChatHeaderStore();
+  const router = useRouter();
+  const {
+    agentName,
+    agentEmoji,
+    agentColor,
+    triggerId,
+    triggerName,
+    triggerRunAt,
+  } = useChatHeaderStore();
 
-	// Trigger-fired thread: trigger name + firing time behind an alarm clock.
-	if (triggerName) {
-		return (
-			<div className="flex h-14 shrink-0 items-center justify-center gap-2 px-5 font-[family-name:var(--font-dm-sans)] text-[14px]">
-				<div className="flex items-center justify-center shrink-0 size-7 rounded-full bg-[#EDF4F0] dark:bg-emerald-950/40">
-					<AlarmClock className="size-3.5 text-[#3D8B63] dark:text-emerald-400" />
-				</div>
-				<span className="font-semibold text-[#1E2D28] dark:text-foreground">
-					{triggerName}
-				</span>
-				{triggerRunAt && (
-					<>
-						<span className="text-[#C4D0CA] dark:text-white/20">/</span>
-						<span className="font-medium text-[#4A5B53] dark:text-white/70">
-							{formatRunAt(
-								triggerRunAt,
-								Intl.DateTimeFormat().resolvedOptions().timeZone,
-							)}
-						</span>
-					</>
-				)}
-			</div>
-		);
-	}
+  // Trigger-fired thread: trigger name + firing time behind an alarm clock.
+  if (triggerName) {
+    return (
+      <div className="flex h-14 shrink-0 items-center justify-center gap-2 px-5 font-[family-name:var(--font-dm-sans)] text-[14px]">
+        <div className="flex items-center justify-center shrink-0 size-7 rounded-full bg-[#EDF4F0] dark:bg-emerald-950/40">
+          <AlarmClock className="size-3.5 text-[#3D8B63] dark:text-emerald-400" />
+        </div>
+        {triggerId ? (
+          <button
+            type="button"
+            onClick={() => {
+              router.push(`/triggers/${triggerId}`);
+            }}
+            className="cursor-pointer font-semibold text-[#1E2D28] dark:text-foreground rounded-sm transition-colors hover:text-[#3D8B63] dark:hover:text-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3D8B63]/40"
+          >
+            {triggerName}
+          </button>
+        ) : (
+          <span className="font-semibold text-[#1E2D28] dark:text-foreground">
+            {triggerName}
+          </span>
+        )}
+        {triggerRunAt && (
+          <>
+            <span className="text-[#C4D0CA] dark:text-white/20">/</span>
+            <span className="font-medium text-[#4A5B53] dark:text-white/70">
+              {formatRunAt(
+                triggerRunAt,
+                Intl.DateTimeFormat().resolvedOptions().timeZone,
+              )}
+            </span>
+          </>
+        )}
+      </div>
+    );
+  }
 
-	if (!agentName) return null;
+  if (!agentName) return null;
 
-	return (
-		<div className="flex h-14 shrink-0 items-center justify-center gap-2 px-5">
-			<AgentAvatar color={agentColor} emoji={agentEmoji} size="xs" />
-			<span className="font-[family-name:var(--font-dm-sans)] font-semibold text-[14px] text-[#1E2D28] dark:text-foreground">
-				{agentName}
-			</span>
-		</div>
-	);
+  return (
+    <div className="flex h-14 shrink-0 items-center justify-center gap-2 px-5">
+      <AgentAvatar color={agentColor} emoji={agentEmoji} size="xs" />
+      <span className="font-[family-name:var(--font-dm-sans)] font-semibold text-[14px] text-[#1E2D28] dark:text-foreground">
+        {agentName}
+      </span>
+    </div>
+  );
 }

--- a/web/src/stores/chat-header-store.ts
+++ b/web/src/stores/chat-header-store.ts
@@ -1,42 +1,52 @@
 import { create } from "zustand";
 
 interface ChatHeaderState {
-	agentName: string | null;
-	agentEmoji: string | null;
-	agentColor: string | null;
-	modelId: string | null;
-	/** Set for trigger-fired threads: the trigger's name and firing time. */
-	triggerName: string | null;
-	triggerRunAt: string | null;
-	setCurrentChat: (data: {
-		agentName: string | null;
-		agentEmoji: string | null;
-		agentColor?: string | null;
-		modelId: string | null;
-		triggerName?: string | null;
-		triggerRunAt?: string | null;
-	}) => void;
-	clearCurrentChat: () => void;
+  agentName: string | null;
+  agentEmoji: string | null;
+  agentColor: string | null;
+  modelId: string | null;
+  /** Set for trigger-fired threads: the trigger's id, name and firing time. */
+  triggerId: string | null;
+  triggerName: string | null;
+  triggerRunAt: string | null;
+  setCurrentChat: (data: {
+    agentName: string | null;
+    agentEmoji: string | null;
+    agentColor?: string | null;
+    modelId: string | null;
+    triggerId?: string | null;
+    triggerName?: string | null;
+    triggerRunAt?: string | null;
+  }) => void;
+  clearCurrentChat: () => void;
 }
 
 export const useChatHeaderStore = create<ChatHeaderState>((set) => ({
-	agentName: null,
-	agentEmoji: null,
-	agentColor: null,
-	modelId: null,
-	triggerName: null,
-	triggerRunAt: null,
-	setCurrentChat: (data) => {
-		set({ agentColor: null, triggerName: null, triggerRunAt: null, ...data });
-	},
-	clearCurrentChat: () => {
-		set({
-			agentName: null,
-			agentEmoji: null,
-			agentColor: null,
-			modelId: null,
-			triggerName: null,
-			triggerRunAt: null,
-		});
-	},
+  agentName: null,
+  agentEmoji: null,
+  agentColor: null,
+  modelId: null,
+  triggerId: null,
+  triggerName: null,
+  triggerRunAt: null,
+  setCurrentChat: (data) => {
+    set({
+      agentColor: null,
+      triggerId: null,
+      triggerName: null,
+      triggerRunAt: null,
+      ...data,
+    });
+  },
+  clearCurrentChat: () => {
+    set({
+      agentName: null,
+      agentEmoji: null,
+      agentColor: null,
+      modelId: null,
+      triggerId: null,
+      triggerName: null,
+      triggerRunAt: null,
+    });
+  },
 }));


### PR DESCRIPTION
## Résumé

Dans la vue conversation, quand le thread est issu d'un trigger, le nom du trigger affiché dans l'en-tête est désormais **cliquable** et amène l'utilisateur vers le réveil correspondant (`/triggers/{id}`).

## Changements

- **`chat-header-store.ts`** — ajout du champ `triggerId` au store (initial state, `setCurrentChat`, `clearCurrentChat`).
- **`chat/[threadId]/page.tsx`** — propagation de `thread.triggerId` vers le store pour les threads `source=trigger`.
- **`chat-header.tsx`** — le nom du trigger devient un `<button>` (`cursor-pointer`, hover en accent émeraude, focus-ring) qui `router.push(\`/triggers/${triggerId}\`)`. Fallback en `<span>` non-cliquable si aucun `triggerId` (anciens threads sans référence).

## Test

- `tsc` : aucune nouvelle erreur.
- Prettier appliqué.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the trigger name in the chat header clickable for trigger‑fired threads to navigate to `/triggers/{id}`. Adds `triggerId` to the chat header store and wires it from the thread; falls back to plain text if missing.

- **New Features**
  - `chat-header.tsx`: render trigger name as a button that `router.push`es to `/triggers/{id}` with hover/focus styles; fallback to non-clickable text without `triggerId`.
  - `chat/[threadId]/page.tsx`: include `triggerId` in `setCurrentChat` when `source === "trigger"`.
  - `chat-header-store.ts`: add `triggerId` to state and reset in `setCurrentChat`/`clearCurrentChat`.

<sup>Written for commit a753f347a750b454a5b6f5204ae36d5f21c4aa07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

