### PR TITLE
feat(triggers): add "Run now" action to trigger card menu

### DIFF
--- a/web/src/app/(protected)/triggers/components/trigger-card.tsx
+++ b/web/src/app/(protected)/triggers/components/trigger-card.tsx
@@ -6,6 +6,7 @@ import { Trigger } from "@/types/triggers";
 import { describeSchedule, parseCronExpression } from "@/lib/triggers/schedule";
 import { useAgentsStore } from "@/stores/agents-store";
 import { useTriggersStore } from "@/stores/triggers-store";
+import { useRunTrigger } from "@/hooks/use-run-trigger";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 import { SageDropdownMenu } from "@/components/ui/sage-dropdown-menu";
 
@@ -17,11 +18,19 @@ interface TriggerCardProps {
 export default function TriggerCard({ trigger, onDelete }: TriggerCardProps) {
 	const router = useRouter();
 	const updateTrigger = useTriggersStore((state) => state.updateTrigger);
+	const runTrigger = useRunTrigger();
 	const agent = useAgentsStore((state) =>
 		state.agents.find((a) => a.id === trigger.agentId),
 	);
 
 	const frequency = describeSchedule(parseCronExpression(trigger.cronExpression));
+
+	const handleRunNow = () => {
+		runTrigger(trigger).catch((error: unknown) => {
+			console.error("Error running trigger:", error);
+			alert("Failed to run the trigger. Please try again.");
+		});
+	};
 
 	const handleToggleActive = () => {
 		updateTrigger(trigger.id, { isActive: !trigger.isActive }).catch(
@@ -65,6 +74,11 @@ export default function TriggerCard({ trigger, onDelete }: TriggerCardProps) {
 							</button>
 						}
 						items={[
+							{
+								label: "Run now",
+								icon: <Play />,
+								onClick: handleRunNow,
+							},
 							{
 								label: trigger.isActive ? "Pause" : "Resume",
 								icon: trigger.isActive ? <Pause /> : <Play />,


### PR DESCRIPTION
## Summary

Adds a **Run now** action as the first item in the trigger card's `...` dropdown menu on the Triggers list page.

- Reuses the existing `useRunTrigger` hook (same behavior as the detail page's "Run now" button)
- Uses the same `Play` icon as the detail page action
- Fires the trigger in the background — no navigation; the new thread appears in the sidebar with its loading indicator

## Testing

- [ ] Open the Triggers page, click `...` on a card, select **Run now** → thread appears running in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Run now action to the trigger card menu on the Triggers page so you can run a trigger without leaving the list. It runs in the background via `useRunTrigger`, shows the new thread loading in the sidebar, and alerts on failure.

<sup>Written for commit f5b5969f00b49f993fea8a4f01bdf580742efff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

