### PR TITLE
fix(db): Better handling connection

### DIFF
--- a/backend/app/agents/runs/router.py
+++ b/backend/app/agents/runs/router.py
@@ -8,6 +8,7 @@ by replaying its event log from a cursor.
 
 from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.runs.schemas import RunCreate, RunResponse
 from app.agents.runs.service import RunService
@@ -15,6 +16,7 @@ from app.agents.runs.state import RunStatus
 from app.agents.runtime import read_run_result
 from app.agents.structured_output import validate_structured_response
 from app.auth.dependencies import get_current_user
+from app.database import get_db
 from app.exceptions import (
     DomainError,
     NotFoundError,
@@ -101,6 +103,7 @@ async def create_run_stream(
     config: dict | None = Body(None, embed=True),
     thread: ThreadResponse = Depends(authorize_thread),
     runs: RunService = Depends(get_run_service),
+    db: AsyncSession = Depends(get_db),  # dependency-cached: same session auth used
 ):
     """Create a run and stream it. Same SSE protocol as before; durable underneath."""
     trigger, config_overrides = _parse_run_config(config)
@@ -112,6 +115,9 @@ async def create_run_stream(
         trigger=trigger,
         config_overrides=config_overrides,
     )
+    # Release the pooled connection before the response streams for the whole
+    # run — auth queries are done; RunService uses its own short-lived sessions.
+    await db.commit()
     return StreamingResponse(
         runs.stream(record.id),
         media_type="text/event-stream",
@@ -128,6 +134,7 @@ async def invoke_run(
     output_schema: dict | None = Body(None, embed=True),
     thread: ThreadResponse = Depends(authorize_thread),
     runs: RunService = Depends(get_run_service),
+    db: AsyncSession = Depends(get_db),  # dependency-cached: same session auth used
 ) -> dict:
     """Create a run and block until it finishes, returning the final answer.
 
@@ -145,6 +152,9 @@ async def invoke_run(
         config_overrides=config_overrides,
         output_schema=output_schema,
     )
+    # Release the pooled connection before blocking for the whole run — auth
+    # queries are done; RunService uses its own short-lived sessions.
+    await db.commit()
     record = await runs.wait_for_terminal(record.id)
     # Only a clean success yields a result. cancelled/interrupted/error/timeout
     # would otherwise return stale or partial checkpoint data as if it succeeded.
@@ -225,6 +235,7 @@ async def stream_run(
     last_event_id: str = Query("0"),
     _: ThreadResponse = Depends(authorize_thread),
     runs: RunService = Depends(get_run_service),
+    db: AsyncSession = Depends(get_db),  # dependency-cached: same session auth used
 ):
     """Reattach to a run, replaying its event log from `last_event_id`.
 
@@ -234,6 +245,9 @@ async def stream_run(
     """
     record = await runs.get(run_id)
     _ensure_run_on_thread(record, thread_id)
+    # Release the pooled connection before the response streams for the whole
+    # run — auth queries are done; RunService uses its own short-lived sessions.
+    await db.commit()
     return StreamingResponse(
         runs.stream(run_id, last_event_id),
         media_type="text/event-stream",

--- a/backend/app/agents/runs/router.py
+++ b/backend/app/agents/runs/router.py
@@ -106,6 +106,10 @@ async def create_run_stream(
     db: AsyncSession = Depends(get_db),  # dependency-cached: same session auth used
 ):
     """Create a run and stream it. Same SSE protocol as before; durable underneath."""
+    # Auth queries are done — release the pooled connection before anything
+    # else (RunService opens its own sessions; holding both risks pool
+    # starvation) and before the response streams for the whole run.
+    await db.commit()
     trigger, config_overrides = _parse_run_config(config)
     record = await runs.create(
         thread_id=thread_id,
@@ -115,9 +119,6 @@ async def create_run_stream(
         trigger=trigger,
         config_overrides=config_overrides,
     )
-    # Release the pooled connection before the response streams for the whole
-    # run — auth queries are done; RunService uses its own short-lived sessions.
-    await db.commit()
     return StreamingResponse(
         runs.stream(record.id),
         media_type="text/event-stream",
@@ -142,6 +143,10 @@ async def invoke_run(
     that awaits the terminal result (and `structured_response`, when
     `output_schema` is given) instead of relaying the live stream.
     """
+    # Auth queries are done — release the pooled connection before anything
+    # else (RunService opens its own sessions; holding both risks pool
+    # starvation) and before blocking for the whole run.
+    await db.commit()
     trigger, config_overrides = _parse_run_config(config)
     record = await runs.create(
         thread_id=thread_id,
@@ -152,9 +157,6 @@ async def invoke_run(
         config_overrides=config_overrides,
         output_schema=output_schema,
     )
-    # Release the pooled connection before blocking for the whole run — auth
-    # queries are done; RunService uses its own short-lived sessions.
-    await db.commit()
     record = await runs.wait_for_terminal(record.id)
     # Only a clean success yields a result. cancelled/interrupted/error/timeout
     # would otherwise return stale or partial checkpoint data as if it succeeded.
@@ -243,11 +245,12 @@ async def stream_run(
     stream id it saw to resume after a reconnect. Works on a finished run too —
     the log (including the `end` sentinel) is replayed in full.
     """
+    # Auth queries are done — release the pooled connection before anything
+    # else (RunService opens its own sessions; holding both risks pool
+    # starvation) and before the response streams for the whole run.
+    await db.commit()
     record = await runs.get(run_id)
     _ensure_run_on_thread(record, thread_id)
-    # Release the pooled connection before the response streams for the whole
-    # run — auth queries are done; RunService uses its own short-lived sessions.
-    await db.commit()
     return StreamingResponse(
         runs.stream(run_id, last_event_id),
         media_type="text/event-stream",


### PR DESCRIPTION
Root cause: 3 long-lived endpoints (/runs/invoke, /runs/stream, /runs/{id}/stream) pinned their request-scoped DB connection for the entire agent run (up to 14.7 min observed). Default pool = 15 connections. Morning burst of 153 concurrent /invoke calls (PAT client) exhausted pool → every other request starved 30s → 273 QueuePool timeouts, 218 route 500s, 09:40–10:15.

Fix (backend/app/agents/runs/router.py): await db.commit() before the blocking part in each handler — connection back to pool in ms, run consumers use their own short-lived sessions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release the request-scoped DB session before long-lived run endpoints block or stream to prevent pool exhaustion and 500s under load. Improves stability during high concurrency.

- **Bug Fixes**
  - Inject `AsyncSession` via `get_db` and call `await db.commit()` right after auth and before blocking/streaming so the pooled connection returns immediately.
  - Applied to `/runs/invoke`, `/runs/stream`, and `/runs/{id}/stream`; run work uses `RunService` short-lived sessions, preventing QueuePool timeouts.

<sup>Written for commit 12e0597278d4710c76fda5a2b51ccf2060127697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

