### PR TITLE
fix(mcp): pass MCP server id as str to OAuth token storage

### DIFF
--- a/backend/app/mcp/client/factory.py
+++ b/backend/app/mcp/client/factory.py
@@ -33,7 +33,7 @@ class MCPClientConfigFactory:
                     server_url=config.url,
                     client_metadata=build_oauth_client_metadata(),
                     storage=self._token_storage_factory.get_storage(
-                        self._user_id, config.id
+                        self._user_id, str(config.id)
                     ),
                 ),
             }

--- a/backend/app/mcp/client/storage.py
+++ b/backend/app/mcp/client/storage.py
@@ -20,6 +20,7 @@ class StoredToken(BaseModel):
 
 class OAuthStateData(BaseModel):
     """Data stored against an OAuth state parameter."""
+
     user_id: str
     mcp_server_id: str
     verifier: str
@@ -39,8 +40,8 @@ class RedisTokenStorage(TokenStorage):
         prefix: str = "mcp",
         redis: Redis | None = None,
     ):
-        self.user_id = user_id
-        self.mcp_server_id = mcp_server_id
+        self.user_id = str(user_id)
+        self.mcp_server_id = str(mcp_server_id)
         self.redis: Redis = redis or Redis(
             host=host, port=port, db=db, decode_responses=True
         )
@@ -75,19 +76,21 @@ class RedisTokenStorage(TokenStorage):
         if not stored:
             logger.debug(
                 "No stored token for user %s and MCP server %s",
-                self.user_id, self.mcp_server_id,
+                self.user_id,
+                self.mcp_server_id,
             )
             return None
 
         if stored.expires_at is not None:
             logger.debug(
                 "Stored token for user %s and MCP server %s expires at %s",
-                self.user_id, self.mcp_server_id, stored.expires_at,
+                self.user_id,
+                self.mcp_server_id,
+                stored.expires_at,
             )
             if stored.token_payload.expires_in is not None:
                 remaining = stored.expires_at - datetime.now(UTC)
-                stored.token_payload.expires_in = max(
-                    0, int(remaining.total_seconds()))
+                stored.token_payload.expires_in = max(0, int(remaining.total_seconds()))
 
         return stored.token_payload
 
@@ -99,15 +102,13 @@ class RedisTokenStorage(TokenStorage):
             existing = await self.get_stored_token()
             if existing and existing.token_payload.refresh_token:
                 tokens = tokens.model_copy(
-                    update={
-                        "refresh_token": existing.token_payload.refresh_token}
+                    update={"refresh_token": existing.token_payload.refresh_token}
                 )
 
         expires_at: datetime | None = None
 
         if tokens.expires_in is not None:
-            expires_at = datetime.now(UTC) + \
-                timedelta(seconds=tokens.expires_in)
+            expires_at = datetime.now(UTC) + timedelta(seconds=tokens.expires_in)
 
         stored_token = StoredToken(token_payload=tokens, expires_at=expires_at)
 
@@ -191,7 +192,9 @@ class TokenStorageFactory:
             return None
         return OAuthStateData.model_validate_json(raw)
 
-    async def get_storage_from_state(self, state: str) -> tuple[RedisTokenStorage, OAuthStateData] | None:
+    async def get_storage_from_state(
+        self, state: str
+    ) -> tuple[RedisTokenStorage, OAuthStateData] | None:
         """
         Recover storage instance from OAuth state parameter.
 
@@ -202,8 +205,7 @@ class TokenStorageFactory:
         if not state_data:
             return None
 
-        storage = self.get_storage(
-            state_data.user_id, state_data.mcp_server_id)
+        storage = self.get_storage(state_data.user_id, state_data.mcp_server_id)
         return storage, state_data
 
     async def clear_server_data(self, mcp_server_id: str) -> int:


### PR DESCRIPTION
## Problem

Production logs showed repeated crashes during MCP OAuth authorization:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for OAuthStateData
  File "/app/app/mcp/client/storage.py", line 145, in set_verifier
```

The truncated field error is `mcp_server_id: Input should be a valid string [input_type=UUID]`.

## Root cause

`MCPClientConfigFactory.build()` passed the raw `UUID` `config.id` to `TokenStorageFactory.get_storage()` — the only one of five call sites not wrapping it in `str()`. The UUID sat on `RedisTokenStorage` harmlessly for token reads/writes, but the moment the mcp SDK needed a **fresh authorization code grant** (token expired beyond refresh), `set_verifier` built `OAuthStateData(mcp_server_id=<UUID>)` and Pydantic v2 rejected it — it does not coerce `UUID` → `str`.

Because the crash happens **before** the OAuth state is stored, re-authorization from an agent run could never complete, so the error repeated on every run until now.

## Fix

- `factory.py`: pass `str(config.id)`, matching the other call sites.
- `storage.py`: `RedisTokenStorage.__init__` coerces both `user_id` and `mcp_server_id` with `str()` so no future call site can regress this.

## Verification

Reproduced the exact production traceback with a script driving the real path (`MCPClientConfigFactory.build()` on an oauth2 server → `storage.set_verifier()`, the call the SDK makes in `_perform_authorization_code_grant`). After the fix the same script completes, including the Redis state write. `tests/mcp/` (27 tests) and ruff pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes during MCP OAuth re-authorization by ensuring MCP server IDs are always stored as strings. This lets `OAuthStateData` validate correctly and stops the re-auth crash loop when tokens expire.

- **Bug Fixes**
  - Pass `str(config.id)` from `MCPClientConfigFactory.build()` to `TokenStorageFactory.get_storage()`.
  - Coerce `user_id` and `mcp_server_id` to `str` in `RedisTokenStorage.__init__` to prevent future regressions.
  - Result: `OAuthStateData` validates, fresh auth code grants succeed, and re-auth no longer crashes.

<sup>Written for commit 03623a45d80a6bc89c0a86b6dabb10250f7748e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

