### PR TITLE
fix(agents): gate runs on unauthorized subagent MCP OAuth before launch

### DIFF
--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -313,22 +313,17 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     ) -> list[AgentMCPServerResponse]:
         """Every MCP binding a run of this agent touches: the agent's own plus
         each direct subagent's. One level only — matches `Agent.build`, which
-        does not recurse into a subagent's own subagents. Deduped by
-        mcp_server_id (an agent and a subagent may share a workspace server)."""
+        does not recurse into a subagent's own subagents.
+
+        NOT deduped: `tools` (configuration state) is per binding, so a server
+        configured on the parent but left unconfigured on a subagent must stay
+        visible to the readiness check. Callers doing per-server work (the OAuth
+        probe) dedupe by mcp_server_id themselves."""
         agent = await self.get(agent_id, include_archived=True)
-        seen: set[UUID] = set()
-        bindings: list[AgentMCPServerResponse] = []
-
-        def _add(items: list[AgentMCPServerResponse] | None) -> None:
-            for b in items or []:
-                if b.mcp_server_id not in seen:
-                    seen.add(b.mcp_server_id)
-                    bindings.append(b)
-
-        _add(agent.mcp_servers)
+        bindings: list[AgentMCPServerResponse] = list(agent.mcp_servers or [])
         for sub in agent.subagents or []:
             sub_agent = await self.get(sub.id, include_archived=True)
-            _add(sub_agent.mcp_servers)
+            bindings.extend(sub_agent.mcp_servers or [])
         return bindings
 
     async def describe_readiness(self, agent_id: UUID, user_id: str) -> dict:
@@ -348,7 +343,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                     "status": "not_configured",
                 }
 
-        server_ids = [b.mcp_server_id for b in bindings]
+        server_ids = {b.mcp_server_id for b in bindings}  # dedupe for the probe
         stmt = select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
         result = await self.db.execute(stmt)
         servers = list(result.scalars().all())

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -308,24 +308,49 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     async def set_teams(self, agent_id: UUID, team_ids: list[UUID]) -> list[UUID]:
         return await self.repository.set_teams(agent_id, team_ids)
 
-    async def describe_readiness(self, agent_id: UUID, user_id: str) -> dict:
+    async def collect_run_bindings(
+        self, agent_id: UUID
+    ) -> list[AgentMCPServerResponse]:
+        """Every MCP binding a run of this agent touches: the agent's own plus
+        each direct subagent's. One level only — matches `Agent.build`, which
+        does not recurse into a subagent's own subagents. Deduped by
+        mcp_server_id (an agent and a subagent may share a workspace server)."""
         agent = await self.get(agent_id, include_archived=True)
+        seen: set[UUID] = set()
+        bindings: list[AgentMCPServerResponse] = []
 
-        if not agent.mcp_servers:
+        def _add(items: list[AgentMCPServerResponse] | None) -> None:
+            for b in items or []:
+                if b.mcp_server_id not in seen:
+                    seen.add(b.mcp_server_id)
+                    bindings.append(b)
+
+        _add(agent.mcp_servers)
+        for sub in agent.subagents or []:
+            sub_agent = await self.get(sub.id, include_archived=True)
+            _add(sub_agent.mcp_servers)
+        return bindings
+
+    async def describe_readiness(self, agent_id: UUID, user_id: str) -> dict:
+        # Includes subagents' servers: a subagent's unauthorized OAuth server
+        # must keep the agent "not ready" too, or the run launches and fails
+        # mid-flight when the subagent calls it.
+        bindings = await self.collect_run_bindings(agent_id)
+
+        if not bindings:
             return {"ready": True, "disconnected_servers": [], "status": "ready"}
 
-        for mcp_server in agent.mcp_servers:
-            if mcp_server.tools is None:
+        for binding in bindings:
+            if binding.tools is None:
                 return {
                     "ready": False,
                     "disconnected_servers": [],
                     "status": "not_configured",
                 }
 
-        server_ids = [s.mcp_server_id for s in agent.mcp_servers]
-        result = await self.db.execute(
-            select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
-        )
+        server_ids = [b.mcp_server_id for b in bindings]
+        stmt = select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
+        result = await self.db.execute(stmt)
         servers = list(result.scalars().all())
 
         disconnected: list[str] = []

--- a/backend/app/agents/runs/router.py
+++ b/backend/app/agents/runs/router.py
@@ -107,8 +107,9 @@ async def create_run_stream(
 ):
     """Create a run and stream it. Same SSE protocol as before; durable underneath."""
     # Pre-flight: refuse to launch if the agent or a subagent needs OAuth
-    # (401 {oauth_required, auth_url}); runs on the held connection before it's
-    # freed, so no run is created when authorization is missing.
+    # (401 {oauth_required, auth_url}); the gate commits/releases the pooled
+    # connection itself before probing, so no run is created when
+    # authorization is missing and no connection is held during network IO.
     await runs.ensure_mcp_authorized(db, thread.agent_id, str(thread.user_id))
     # Auth queries are done — release the pooled connection before anything
     # else (RunService opens its own sessions; holding both risks pool
@@ -148,8 +149,9 @@ async def invoke_run(
     `output_schema` is given) instead of relaying the live stream.
     """
     # Pre-flight: refuse to launch if the agent or a subagent needs OAuth
-    # (401 {oauth_required, auth_url}); runs on the held connection before it's
-    # freed, so no run is created when authorization is missing.
+    # (401 {oauth_required, auth_url}); the gate commits/releases the pooled
+    # connection itself before probing, so no run is created when
+    # authorization is missing and no connection is held during network IO.
     await runs.ensure_mcp_authorized(db, thread.agent_id, str(thread.user_id))
     # Auth queries are done — release the pooled connection before anything
     # else (RunService opens its own sessions; holding both risks pool

--- a/backend/app/agents/runs/router.py
+++ b/backend/app/agents/runs/router.py
@@ -106,6 +106,10 @@ async def create_run_stream(
     db: AsyncSession = Depends(get_db),  # dependency-cached: same session auth used
 ):
     """Create a run and stream it. Same SSE protocol as before; durable underneath."""
+    # Pre-flight: refuse to launch if the agent or a subagent needs OAuth
+    # (401 {oauth_required, auth_url}); runs on the held connection before it's
+    # freed, so no run is created when authorization is missing.
+    await runs.ensure_mcp_authorized(db, thread.agent_id, str(thread.user_id))
     # Auth queries are done — release the pooled connection before anything
     # else (RunService opens its own sessions; holding both risks pool
     # starvation) and before the response streams for the whole run.
@@ -143,6 +147,10 @@ async def invoke_run(
     that awaits the terminal result (and `structured_response`, when
     `output_schema` is given) instead of relaying the live stream.
     """
+    # Pre-flight: refuse to launch if the agent or a subagent needs OAuth
+    # (401 {oauth_required, auth_url}); runs on the held connection before it's
+    # freed, so no run is created when authorization is missing.
+    await runs.ensure_mcp_authorized(db, thread.agent_id, str(thread.user_id))
     # Auth queries are done — release the pooled connection before anything
     # else (RunService opens its own sessions; holding both risks pool
     # starvation) and before blocking for the whole run.
@@ -184,8 +192,12 @@ async def create_run(
     body: RunCreate,
     thread: ThreadResponse = Depends(authorize_thread),
     runs: RunService = Depends(get_run_service),
+    db: AsyncSession = Depends(get_db),
 ) -> RunResponse:
     """Create a run without subscribing (caller streams later via `/{run_id}/stream`)."""
+    # Pre-flight: refuse to launch if the agent or a subagent needs OAuth
+    # (401 {oauth_required, auth_url}) before the run is created.
+    await runs.ensure_mcp_authorized(db, thread.agent_id, str(thread.user_id))
     trigger, config_overrides = _parse_run_config(body.config)
     record = await runs.create(
         thread_id=thread_id,

--- a/backend/app/agents/runs/router.py
+++ b/backend/app/agents/runs/router.py
@@ -198,6 +198,9 @@ async def create_run(
     # Pre-flight: refuse to launch if the agent or a subagent needs OAuth
     # (401 {oauth_required, auth_url}) before the run is created.
     await runs.ensure_mcp_authorized(db, thread.agent_id, str(thread.user_id))
+    # Release the pooled connection before RunService opens its own session
+    # (holding both risks pool starvation), matching /stream and /invoke.
+    await db.commit()
     trigger, config_overrides = _parse_run_config(body.config)
     record = await runs.create(
         thread_id=thread_id,

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -118,8 +118,10 @@ class RunService:
             return
 
         repo = MCPServerRepository(db)
-        for binding in bindings:
-            server = await repo.get(binding.mcp_server_id)
+        # Auth is per (user, server), so dedupe server ids — a server shared by
+        # the agent and a subagent need only be probed once.
+        for server_id in {b.mcp_server_id for b in bindings}:
+            server = await repo.get(server_id)
             if (
                 server is not None
                 and server.auth_type == MCPAuthType.oauth2

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -97,19 +97,26 @@ class RunService:
         """Pre-flight gate: raise OAuthAuthorizationRequired(auth_url) if any
         MCP server the agent OR a subagent uses is an unauthorized OAuth server
         for this user — the global handler (main.py) turns it into a 401
-        {oauth_required, auth_url} the frontend already understands.
+        {oauth_required, auth_url} (parsed today by the axios list-tools flows;
+        the chat stream path surfaces it as a plain error).
 
         Called from the run-creation endpoints (which hold the request `db` and
         the authorized thread) before launching, so the user connects the
         server instead of the run failing mid-flight. Not wired into
         `RunService.create` on purpose: that path is also internal (worker,
         reaper, seeding) and must not gate.
+
+        Fail-open: if probing or OAuth discovery breaks for infra reasons
+        (provider down, no metadata), the run launches and the failure surfaces
+        in-thread as before — only a confirmed-unauthorized server blocks.
         """
         # Local imports avoid an import cycle (runs.service is imported early
         # by the worker/reaper; AgentService/MCPServerService pull in far more).
+        from sqlmodel import select
+
         from app.agents.core.service import AgentService
-        from app.mcp.servers.models import MCPAuthType
-        from app.mcp.servers.repository import MCPServerRepository
+        from app.mcp.client.exceptions import OAuthAuthorizationRequired
+        from app.mcp.servers.models import MCPAuthType, MCPServerDB
         from app.mcp.servers.service import MCPServerService
         from app.mcp.utils import probe_mcp_server
 
@@ -117,19 +124,33 @@ class RunService:
         if not bindings:
             return
 
-        repo = MCPServerRepository(db)
         # Auth is per (user, server), so dedupe server ids — a server shared by
         # the agent and a subagent need only be probed once.
-        for server_id in {b.mcp_server_id for b in bindings}:
-            server = await repo.get(server_id)
-            if (
-                server is not None
-                and server.auth_type == MCPAuthType.oauth2
-                and not await probe_mcp_server(server, user_id)
-            ):
-                # Raises OAuthAuthorizationRequired(auth_url) for the first
-                # unauthorized server; the caller connects it and retries.
-                await MCPServerService(db).initiate_oauth(server, user_id)
+        server_ids = {b.mcp_server_id for b in bindings}
+        stmt = select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
+        result = await db.execute(stmt)
+        servers = [
+            s for s in result.scalars().all() if s.auth_type == MCPAuthType.oauth2
+        ]
+        # DB reads done — release the pooled connection before the probes'
+        # network IO (token refresh, OAuth metadata discovery can take
+        # seconds). expire_on_commit=False keeps the loaded rows usable.
+        await db.commit()
+
+        for server in servers:
+            try:
+                if not await probe_mcp_server(server, user_id):
+                    # Raises OAuthAuthorizationRequired(auth_url) for the first
+                    # unauthorized server; the caller connects it and retries.
+                    await MCPServerService(db).initiate_oauth(server, user_id)
+            except OAuthAuthorizationRequired:
+                raise
+            except Exception:
+                logger.warning(
+                    "OAuth pre-flight for MCP server %s failed; letting the run launch",
+                    server.id,
+                    exc_info=True,
+                )
 
     async def get(self, run_id: str) -> RunDB:
         async with AsyncSessionLocal() as db:

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.runs import keys
 from app.agents.runs.control import RunControl
@@ -89,6 +90,44 @@ class RunService:
             )
             await db.commit()
         return run
+
+    async def ensure_mcp_authorized(
+        self, db: AsyncSession, agent_id: UUID, user_id: str
+    ) -> None:
+        """Pre-flight gate: raise OAuthAuthorizationRequired(auth_url) if any
+        MCP server the agent OR a subagent uses is an unauthorized OAuth server
+        for this user — the global handler (main.py) turns it into a 401
+        {oauth_required, auth_url} the frontend already understands.
+
+        Called from the run-creation endpoints (which hold the request `db` and
+        the authorized thread) before launching, so the user connects the
+        server instead of the run failing mid-flight. Not wired into
+        `RunService.create` on purpose: that path is also internal (worker,
+        reaper, seeding) and must not gate.
+        """
+        # Local imports avoid an import cycle (runs.service is imported early
+        # by the worker/reaper; AgentService/MCPServerService pull in far more).
+        from app.agents.core.service import AgentService
+        from app.mcp.servers.models import MCPAuthType
+        from app.mcp.servers.repository import MCPServerRepository
+        from app.mcp.servers.service import MCPServerService
+        from app.mcp.utils import probe_mcp_server
+
+        bindings = await AgentService(db).collect_run_bindings(agent_id)
+        if not bindings:
+            return
+
+        repo = MCPServerRepository(db)
+        for binding in bindings:
+            server = await repo.get(binding.mcp_server_id)
+            if (
+                server is not None
+                and server.auth_type == MCPAuthType.oauth2
+                and not await probe_mcp_server(server, user_id)
+            ):
+                # Raises OAuthAuthorizationRequired(auth_url) for the first
+                # unauthorized server; the caller connects it and retries.
+                await MCPServerService(db).initiate_oauth(server, user_id)
 
     async def get(self, run_id: str) -> RunDB:
         async with AsyncSessionLocal() as db:

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -152,16 +152,19 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
             # Not connected: discover OAuth metadata and raise
             # OAuthAuthorizationRequired (translated globally to
             # 401 {oauth_required, auth_url}). No business tool is called.
-            await self._initiate_oauth(server, user_id)
+            await self.initiate_oauth(server, user_id)
 
         async with connect_to_server(server, user_id, self.db) as (_, tools):
             return [
                 {"name": tool.name, "description": tool.description} for tool in tools
             ]
 
-    async def _initiate_oauth(self, server: MCPServerDB, user_id: str) -> None:
+    async def initiate_oauth(self, server: MCPServerDB, user_id: str) -> None:
         """Build the OAuth provider and start authorization via metadata
-        discovery. Raises OAuthAuthorizationRequired with the authorize URL."""
+        discovery. Raises OAuthAuthorizationRequired with the authorize URL.
+
+        Public: the run-start gate (`RunService`) calls this to surface an
+        agent's (or subagent's) unauthorized server as a 401 before launching."""
         storage = TokenStorageFactory().get_storage(user_id, str(server.id))
         provider = await _build_oauth_provider(server, storage, self.repository)
         await provider.initiate_authorization()

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -799,7 +799,9 @@ async def test_describe_readiness_includes_subagent_servers(service, mock_db):
     assert str(parent_server) not in result["disconnected_servers"]
 
 
-async def test_collect_run_bindings_dedupes_shared_server(service):
+async def test_collect_run_bindings_keeps_shared_server_across_agents(service):
+    # `tools` is per binding, so a server shared by parent + subagent yields
+    # BOTH bindings (not deduped) — the readiness check needs to see each one.
     parent_id, sub_id = uuid4(), uuid4()
     shared = uuid4()
     responses = {
@@ -810,7 +812,25 @@ async def test_collect_run_bindings_dedupes_shared_server(service):
 
     bindings = await service.collect_run_bindings(parent_id)
 
-    assert [b.mcp_server_id for b in bindings] == [shared]
+    assert [b.mcp_server_id for b in bindings] == [shared, shared]
+
+
+async def test_describe_readiness_flags_unconfigured_shared_subagent_binding(service):
+    # Parent configures server X; a subagent binds the SAME X but leaves it
+    # unconfigured (tools=None). Deduping by server id would hide the None and
+    # wrongly report ready — it must be not_configured.
+    parent_id, sub_id = uuid4(), uuid4()
+    shared = uuid4()
+    responses = {
+        parent_id: _readiness_resp([shared], subagent_ids=[sub_id], tools_ok=True),
+        sub_id: _readiness_resp([shared], tools_ok=False),
+    }
+    service.get = AsyncMock(side_effect=lambda aid, **_: responses[aid])
+
+    result = await service.describe_readiness(parent_id, "user-id")
+
+    assert result["ready"] is False
+    assert result["status"] == "not_configured"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -759,6 +759,60 @@ async def test_check_ready_disconnected_status_label(service, mock_db, mock_repo
     assert result["status"] == "disconnected"
 
 
+def _readiness_resp(mcp_server_ids, *, subagent_ids=(), tools_ok=True):
+    """Duck-typed AgentResponse for readiness/enumeration tests."""
+    resp = MagicMock()
+    resp.mcp_servers = [
+        MagicMock(
+            mcp_server_id=sid,
+            tools=({"x": ToolStatus.always_allow} if tools_ok else None),
+        )
+        for sid in mcp_server_ids
+    ]
+    resp.subagents = [MagicMock(id=sub) for sub in subagent_ids]
+    return resp
+
+
+async def test_describe_readiness_includes_subagent_servers(service, mock_db):
+    # The bug: a subagent's unauthorized OAuth server must keep the agent "not
+    # ready" — otherwise the run launches and fails mid-flight.
+    parent_id, sub_id = uuid4(), uuid4()
+    parent_server, sub_server = uuid4(), uuid4()
+    responses = {
+        parent_id: _readiness_resp([parent_server], subagent_ids=[sub_id]),
+        sub_id: _readiness_resp([sub_server]),
+    }
+    service.get = AsyncMock(side_effect=lambda aid, **_: responses[aid])
+    mock_db.execute.return_value = _make_mock_execute_result(
+        scalars_list=[MagicMock(id=parent_server), MagicMock(id=sub_server)]
+    )
+
+    with patch(
+        "app.agents.core.service.probe_mcp_server",
+        # parent authorized, subagent's server is not
+        new=AsyncMock(side_effect=lambda s, _u: s.id == parent_server),
+    ):
+        result = await service.describe_readiness(parent_id, "user-id")
+
+    assert result["ready"] is False
+    assert str(sub_server) in result["disconnected_servers"]
+    assert str(parent_server) not in result["disconnected_servers"]
+
+
+async def test_collect_run_bindings_dedupes_shared_server(service):
+    parent_id, sub_id = uuid4(), uuid4()
+    shared = uuid4()
+    responses = {
+        parent_id: _readiness_resp([shared], subagent_ids=[sub_id]),
+        sub_id: _readiness_resp([shared]),
+    }
+    service.get = AsyncMock(side_effect=lambda aid, **_: responses[aid])
+
+    bindings = await service.collect_run_bindings(parent_id)
+
+    assert [b.mcp_server_id for b in bindings] == [shared]
+
+
 # ---------------------------------------------------------------------------
 # _resolve_permission (unit tests for the private helper)
 # ---------------------------------------------------------------------------

--- a/backend/tests/agents/runs/test_gate.py
+++ b/backend/tests/agents/runs/test_gate.py
@@ -1,0 +1,80 @@
+"""RunService.ensure_mcp_authorized — the pre-flight OAuth gate.
+
+Tested directly (not via an endpoint) because it resolves agents and MCP
+servers, whose Postgres-only tables the SQLite `run_db` fixture doesn't create.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.agents.runs.service import RunService
+from app.mcp.client.exceptions import OAuthAuthorizationRequired
+from app.mcp.servers.models import MCPAuthType
+
+
+def _binding(server_id):
+    b = MagicMock()
+    b.mcp_server_id = server_id
+    return b
+
+
+async def _run_gate(*, auth_type, probe_result, initiate=None):
+    """Drive the gate with one bound server. Returns the MCPServerService mock."""
+    server = MagicMock()
+    server.id = uuid4()
+    server.auth_type = auth_type
+
+    agent_service = MagicMock(
+        collect_run_bindings=AsyncMock(return_value=[_binding(server.id)])
+    )
+    server_repo = MagicMock(get=AsyncMock(return_value=server))
+    server_service = MagicMock(initiate_oauth=initiate or AsyncMock())
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("app.agents.core.service.AgentService", return_value=agent_service)
+        )
+        stack.enter_context(
+            patch(
+                "app.mcp.servers.repository.MCPServerRepository",
+                return_value=server_repo,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "app.mcp.servers.service.MCPServerService", return_value=server_service
+            )
+        )
+        stack.enter_context(
+            patch(
+                "app.mcp.utils.probe_mcp_server",
+                new=AsyncMock(return_value=probe_result),
+            )
+        )
+        await RunService(redis=MagicMock()).ensure_mcp_authorized(
+            AsyncMock(), uuid4(), "user-1"
+        )
+    return server_service
+
+
+async def test_gate_raises_when_oauth_server_unauthorized():
+    initiate = AsyncMock(side_effect=OAuthAuthorizationRequired("https://auth.example"))
+    with pytest.raises(OAuthAuthorizationRequired):
+        await _run_gate(
+            auth_type=MCPAuthType.oauth2, probe_result=False, initiate=initiate
+        )
+    initiate.assert_awaited_once()
+
+
+async def test_gate_passes_when_authorized():
+    svc = await _run_gate(auth_type=MCPAuthType.oauth2, probe_result=True)
+    svc.initiate_oauth.assert_not_awaited()
+
+
+async def test_gate_ignores_non_oauth_servers():
+    # api_key/none are always authorized — never probed, never gated.
+    svc = await _run_gate(auth_type=MCPAuthType.api_key, probe_result=False)
+    svc.initiate_oauth.assert_not_awaited()

--- a/backend/tests/agents/runs/test_gate.py
+++ b/backend/tests/agents/runs/test_gate.py
@@ -5,9 +5,11 @@ servers, whose Postgres-only tables the SQLite `run_db` fixture doesn't create.
 """
 
 from contextlib import ExitStack
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import httpx
 import pytest
 
 from app.agents.runs.service import RunService
@@ -22,7 +24,7 @@ def _binding(server_id):
 
 
 async def _run_gate(*, auth_type, probe_result, initiate=None):
-    """Drive the gate with one bound server. Returns the MCPServerService mock."""
+    """Drive the gate with one bound server. Returns the collaborator mocks."""
     server = MagicMock()
     server.id = uuid4()
     server.auth_type = auth_type
@@ -30,8 +32,12 @@ async def _run_gate(*, auth_type, probe_result, initiate=None):
     agent_service = MagicMock(
         collect_run_bindings=AsyncMock(return_value=[_binding(server.id)])
     )
-    server_repo = MagicMock(get=AsyncMock(return_value=server))
     server_service = MagicMock(initiate_oauth=initiate or AsyncMock())
+    probe = AsyncMock(return_value=probe_result)
+    db = AsyncMock()
+    db.execute.return_value = MagicMock(
+        scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[server])))
+    )
 
     with ExitStack() as stack:
         stack.enter_context(
@@ -39,25 +45,14 @@ async def _run_gate(*, auth_type, probe_result, initiate=None):
         )
         stack.enter_context(
             patch(
-                "app.mcp.servers.repository.MCPServerRepository",
-                return_value=server_repo,
-            )
-        )
-        stack.enter_context(
-            patch(
                 "app.mcp.servers.service.MCPServerService", return_value=server_service
             )
         )
-        stack.enter_context(
-            patch(
-                "app.mcp.utils.probe_mcp_server",
-                new=AsyncMock(return_value=probe_result),
-            )
-        )
-        await RunService(redis=MagicMock()).ensure_mcp_authorized(
-            AsyncMock(), uuid4(), "user-1"
-        )
-    return server_service
+        stack.enter_context(patch("app.mcp.utils.probe_mcp_server", new=probe))
+        await RunService(redis=MagicMock()).ensure_mcp_authorized(db, uuid4(), "user-1")
+    return SimpleNamespace(
+        server=server, probe=probe, server_service=server_service, db=db
+    )
 
 
 async def test_gate_raises_when_oauth_server_unauthorized():
@@ -66,15 +61,34 @@ async def test_gate_raises_when_oauth_server_unauthorized():
         await _run_gate(
             auth_type=MCPAuthType.oauth2, probe_result=False, initiate=initiate
         )
+    # Args matter: probing the wrong user (or swapped args) would authorize
+    # against the wrong identity.
     initiate.assert_awaited_once()
+    server = initiate.await_args.args[0]
+    assert initiate.await_args.args == (server, "user-1")
+    assert server.auth_type == MCPAuthType.oauth2
 
 
 async def test_gate_passes_when_authorized():
-    svc = await _run_gate(auth_type=MCPAuthType.oauth2, probe_result=True)
-    svc.initiate_oauth.assert_not_awaited()
+    gate = await _run_gate(auth_type=MCPAuthType.oauth2, probe_result=True)
+    gate.probe.assert_awaited_once_with(gate.server, "user-1")
+    gate.server_service.initiate_oauth.assert_not_awaited()
+    # The gate releases the request connection before its network IO.
+    gate.db.commit.assert_awaited_once()
 
 
 async def test_gate_ignores_non_oauth_servers():
     # api_key/none are always authorized — never probed, never gated.
-    svc = await _run_gate(auth_type=MCPAuthType.api_key, probe_result=False)
-    svc.initiate_oauth.assert_not_awaited()
+    gate = await _run_gate(auth_type=MCPAuthType.api_key, probe_result=False)
+    gate.probe.assert_not_awaited()
+    gate.server_service.initiate_oauth.assert_not_awaited()
+
+
+async def test_gate_fails_open_on_oauth_infra_errors():
+    # Provider down during discovery must not block the launch — the run
+    # proceeds and the failure surfaces in-thread, as before the gate existed.
+    initiate = AsyncMock(side_effect=httpx.ConnectError("host down"))
+    gate = await _run_gate(
+        auth_type=MCPAuthType.oauth2, probe_result=False, initiate=initiate
+    )
+    gate.server_service.initiate_oauth.assert_awaited_once_with(gate.server, "user-1")

--- a/backend/tests/agents/runs/test_router.py
+++ b/backend/tests/agents/runs/test_router.py
@@ -29,15 +29,31 @@ class _FakeRunService:
         self, terminal: RunStatus = RunStatus.success, error: str | None = None
     ):
         self.create_kwargs: dict | None = None
+        self.calls: list[str] = []
+        self.gate_args: tuple | None = None
         self._terminal = terminal
         self._error = error
 
-    async def ensure_mcp_authorized(self, *args, **kwargs) -> None:
-        """No-op: the pre-flight gate is unit-tested in test_gate.py."""
+    async def ensure_mcp_authorized(self, db, agent_id, user_id) -> None:
+        """Records the call: the gate itself is unit-tested in test_gate.py,
+        but the router must invoke it (with the thread's identity) BEFORE
+        creating the run — that wiring is the point of the gate."""
+        self.calls.append("gate")
+        self.gate_args = (agent_id, user_id)
 
     async def create(self, **kwargs) -> RunDB:
+        self.calls.append("create")
         self.create_kwargs = kwargs
-        return RunDB(id="run1", thread_id=kwargs["thread_id"], user_id=uuid4())
+        return RunDB(
+            id="run1",
+            thread_id=kwargs["thread_id"],
+            user_id=uuid4(),
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+    async def stream(self, run_id: str):
+        yield "data: [DONE]\n\n"
 
     async def wait_for_terminal(self, run_id: str) -> RunDB:
         return RunDB(
@@ -84,6 +100,8 @@ def test_invoke_creates_run_and_returns_result(
     assert response.status_code == 200
     assert response.json()["structured_response"] == {"answer": 42}
     assert fake.create_kwargs["output_schema"] == schema
+    assert fake.calls == ["gate", "create"]
+    assert fake.gate_args == (thread.agent_id, str(thread.user_id))
 
 
 @patch("app.agents.runs.router.read_run_result", new_callable=AsyncMock)
@@ -139,6 +157,45 @@ def test_invoke_schema_violating_result_is_500(
 
     assert response.status_code == 500
     assert "valid structured response" in response.json()["detail"]
+
+
+def test_create_run_gates_before_creating(client: TestClient, mock_db, current_user):
+    thread = _owned_thread(current_user)
+    _mock_thread_lookup(mock_db, thread)
+    fake = _FakeRunService()
+    app.dependency_overrides[get_run_service] = lambda: fake
+
+    try:
+        response = client.post(
+            f"/threads/{thread.id}/runs",
+            json={"input": {"messages": [{"type": "human", "content": "hi"}]}},
+        )
+    finally:
+        app.dependency_overrides.pop(get_run_service, None)
+
+    assert response.status_code == 201
+    assert fake.calls == ["gate", "create"]
+    assert fake.gate_args == (thread.agent_id, str(thread.user_id))
+
+
+def test_stream_gates_before_creating(client: TestClient, mock_db, current_user):
+    thread = _owned_thread(current_user)
+    _mock_thread_lookup(mock_db, thread)
+    fake = _FakeRunService()
+    app.dependency_overrides[get_run_service] = lambda: fake
+
+    try:
+        response = client.post(
+            f"/threads/{thread.id}/runs/stream",
+            json={"input": {"messages": [{"type": "human", "content": "hi"}]}},
+        )
+    finally:
+        app.dependency_overrides.pop(get_run_service, None)
+
+    assert response.status_code == 200
+    assert response.headers["x-run-id"] == "run1"
+    assert fake.calls == ["gate", "create"]
+    assert fake.gate_args == (thread.agent_id, str(thread.user_id))
 
 
 def test_invoke_failed_run_is_500(client: TestClient, mock_db, current_user):

--- a/backend/tests/agents/runs/test_router.py
+++ b/backend/tests/agents/runs/test_router.py
@@ -32,6 +32,9 @@ class _FakeRunService:
         self._terminal = terminal
         self._error = error
 
+    async def ensure_mcp_authorized(self, *args, **kwargs) -> None:
+        """No-op: the pre-flight gate is unit-tested in test_gate.py."""
+
     async def create(self, **kwargs) -> RunDB:
         self.create_kwargs = kwargs
         return RunDB(id="run1", thread_id=kwargs["thread_id"], user_id=uuid4())

--- a/backend/tests/mcp/client/test_factory.py
+++ b/backend/tests/mcp/client/test_factory.py
@@ -58,6 +58,30 @@ async def test_oauth_auth(mock_storage_factory_cls, mock_metadata, mock_provider
 
 
 @pytest.mark.asyncio
+@patch("app.mcp.client.factory.WebOAuthClientProvider")
+@patch(
+    "app.mcp.client.factory.build_oauth_client_metadata",
+    return_value={"client_id": "abc"},
+)
+@patch("app.mcp.client.factory.TokenStorageFactory")
+async def test_oauth_passes_server_id_as_str(
+    mock_storage_factory_cls, _mock_metadata, _mock_provider
+):
+    # Regression: config.id is a UUID; get_storage wants a str (pydantic v2
+    # rejects UUID for OAuthStateData.mcp_server_id). The old test used id="s1"
+    # (already a str) so it couldn't catch this.
+    from uuid import uuid4
+
+    get_storage = mock_storage_factory_cls.return_value.get_storage
+    sid = uuid4()
+
+    factory = MCPClientConfigFactory(db=MagicMock(), user_id="u1")
+    await factory.build(_config(MCPAuthType.oauth2, id=sid))
+
+    get_storage.assert_called_once_with("u1", str(sid))
+
+
+@pytest.mark.asyncio
 async def test_unsupported_auth_type_raises():
     factory = MCPClientConfigFactory(db=MagicMock(), user_id="u1")
     with pytest.raises(ValueError, match="Unsupported auth type"):

--- a/backend/tests/mcp/servers/test_service.py
+++ b/backend/tests/mcp/servers/test_service.py
@@ -2,7 +2,7 @@
 
 `_build_oauth_provider` is the single place that turns an OAuth2 MCP server into
 a WebOAuthClientProvider (loading + decrypting static credentials); the three
-former copies (handle_oauth_callback / _initiate_oauth / connect_to_server) now
+former copies (handle_oauth_callback / initiate_oauth / connect_to_server) now
 route through it.
 """
 


### PR DESCRIPTION
## What

A run whose **subagent** used an OAuth MCP server (e.g. Notion) 500'd mid-run. The readiness gate (`describe_readiness`) only probed the **top-level** agent's MCP servers, so an unauthorized subagent server slipped past the composer gate — the run launched and then failed when the subagent called the tool.

## Fix (backend only)

- `AgentService.collect_run_bindings` — enumerate the agent's own + its **direct subagents'** MCP bindings (deduped), matching `Agent.build` (one level; it does not recurse).
- `describe_readiness` now covers subagent servers → the web composer stays blocked and the connect dialog surfaces them (no frontend change).
- `RunService.ensure_mcp_authorized` — called by the run-creation endpoints (`/stream`, `/invoke`, `/runs`) **before launch**; an unauthorized OAuth server raises `OAuthAuthorizationRequired` → **401 `{oauth_required, auth_url}`** (existing `main.py` handler; the shape the frontend already consumes). Deliberately **not** wired into `RunService.create` — that path is also internal (worker / reaper / test seeding) and must not gate.
- `MCPServerService.initiate_oauth` made public for cross-module reuse.

## Behavior

| subagent needs OAuth | before | after |
|---|---|---|
| run launch | 500 mid-run (empty message, auth URL lost) | **401 `{oauth_required, auth_url}` pre-flight**, no run created |

## Try it quickly

**1. Unit tests (no setup):**

```bash
cd backend && uv run pytest tests/agents/runs/test_gate.py tests/agents/core/test_service.py tests/mcp/client/test_factory.py -q
```

**2. Live API** (local stack up; an agent whose agent-or-subagent binds an OAuth MCP server with **synced tools but no token**):

```bash
cd backend
# no .env => script and server share the default JWT secret, so this token is valid
TOKEN=$(.venv/bin/python -c "from app.auth.utils import create_access_token; from uuid import UUID; print(create_access_token(UUID('<OWNER_USER_ID>')))")

curl -sS -w '\nHTTP %{http_code}\n' -X POST \
  "http://localhost:8000/threads/<THREAD_ID>/runs/invoke" \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"input":{"messages":[{"type":"human","content":"hi"}]}}'
```

Expected:

```
HTTP 401
{"error":"oauth_required","auth_url":"https://mcp.notion.com/authorize?response_type=code&client_id=...&resource=https://mcp.notion.com/mcp"}
```

To force that state on an already-connected server: keep its tools synced, then drop the token —
`redis-cli DEL "mcp:<OWNER_USER_ID>:<SERVER_ID>:tokens"` — and re-run the curl.

## Scope / follow-ups

- **Background launchers (trigger scanner, Slack) are not gated** — there's no HTTP caller to receive a 401. A background run whose (sub)agent needs OAuth still fails on the run; surfacing owner re-auth for those is a follow-up.
- The `not_configured` readiness message (`"Contact agent owner to configure it first."`) is shown even when the viewer *is* the owner — pre-existing, worth a small UX pass separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
