### PR TITLE
fix(mcp): request client_secret_post at dynamic client registration

### DIFF
--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -32,6 +32,12 @@ def build_oauth_client_metadata() -> OAuthClientMetadata:
     Scopes are intentionally omitted: they are discovered per-server from the
     Protected Resource Metadata (RFC 9728 ``scopes_supported``) during
     authorization, so there is nothing server-specific to configure here.
+
+    ``token_endpoint_auth_method`` is requested explicitly: when omitted,
+    RFC 7591 lets the server default to ``client_secret_basic``, and the SDK's
+    basic-auth token request keeps ``client_id`` in the form body alongside the
+    Basic header — strict servers (e.g. Notion) reject that as multiple
+    authentication methods.
     """
     return OAuthClientMetadata(
         client_name="auxilia",
@@ -40,7 +46,7 @@ def build_oauth_client_metadata() -> OAuthClientMetadata:
         ],
         grant_types=["authorization_code", "refresh_token"],
         response_types=["code"],
-        token_endpoint_auth_method=None,
+        token_endpoint_auth_method="client_secret_post",
     )
 
 

--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -1,6 +1,6 @@
 import logging
 import secrets
-from urllib.parse import urlencode, urljoin
+from urllib.parse import parse_qsl, urlencode, urljoin
 
 import httpx
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, PKCEParameters
@@ -24,6 +24,30 @@ from app.settings import app_settings
 
 
 logger = logging.getLogger(__name__)
+
+
+def strip_client_id_for_basic_auth(request: httpx.Request) -> httpx.Request:
+    """Rebuild a token request without ``client_id`` in the form body when it
+    also carries a Basic ``Authorization`` header.
+
+    RFC 6749 §2.3 allows only one client-authentication method per request,
+    but the SDK's ``_exchange_token_authorization_code`` and ``_refresh_token``
+    always put ``client_id`` in the body, even when ``prepare_token_auth`` has
+    selected ``client_secret_basic``. Strict servers (e.g. Notion) reject the
+    combination with "Client must not use multiple authentication methods".
+    Stripping it here keeps registrations stored as ``client_secret_basic``
+    working without re-registration.
+    """
+    if not request.headers.get("Authorization", "").startswith("Basic "):
+        return request
+    data = dict(parse_qsl(request.content.decode()))
+    if "client_id" not in data:
+        return request
+    del data["client_id"]
+    headers = {
+        k: v for k, v in request.headers.items() if k.lower() != "content-length"
+    }
+    return httpx.Request(request.method, request.url, data=data, headers=headers)
 
 
 def build_oauth_client_metadata() -> OAuthClientMetadata:
@@ -112,6 +136,16 @@ class WebOAuthClientProvider(OAuthClientProvider):
                 **self.context.client_metadata.model_dump(),
             )
         )
+
+    async def _exchange_token_authorization_code(
+        self, *args, **kwargs
+    ) -> httpx.Request:
+        request = await super()._exchange_token_authorization_code(*args, **kwargs)
+        return strip_client_id_for_basic_auth(request)
+
+    async def _refresh_token(self) -> httpx.Request:
+        request = await super()._refresh_token()
+        return strip_client_id_for_basic_auth(request)
 
     async def initiate_authorization(self) -> None:
         """Start the OAuth flow explicitly, without calling a business tool to

--- a/backend/tests/mcp/client/test_auth.py
+++ b/backend/tests/mcp/client/test_auth.py
@@ -16,6 +16,7 @@ import pytest
 from mcp.shared.auth import (
     OAuthClientInformationFull,
     OAuthMetadata,
+    OAuthToken,
     ProtectedResourceMetadata,
 )
 
@@ -198,3 +199,67 @@ async def test_dynamic_client_registration_when_no_static_creds(monkeypatch):
     assert query["client_id"] == ["dcr-client-id"]
     # Notion advertises no scopes -> none requested.
     assert "scope" not in query
+
+
+# ---------------------------------------------------------------------------
+# Token requests for client_secret_basic registrations
+#
+# RFC 6749 §2.3 allows a single client-authentication method per request, but
+# the SDK keeps client_id in the form body alongside the Basic Authorization
+# header; strict servers (e.g. Notion) reject that as multiple authentication
+# methods. The provider strips it so registrations stored as
+# client_secret_basic keep working without re-registration.
+# ---------------------------------------------------------------------------
+
+
+def _provider_with_client_info(auth_method: str) -> WebOAuthClientProvider:
+    provider = _make_provider()
+    provider.context.oauth_metadata = _asm()
+    provider.context.client_info = OAuthClientInformationFull(
+        client_id="client-123",
+        client_secret="secret-xyz",
+        redirect_uris=["https://app.example/cb"],
+        token_endpoint_auth_method=auth_method,
+    )
+    return provider
+
+
+async def test_exchange_request_for_basic_omits_client_id_in_body():
+    provider = _provider_with_client_info("client_secret_basic")
+
+    request = await provider._exchange_token_authorization_code(
+        auth_code="code-abc", code_verifier="verifier"
+    )
+
+    assert request.headers["Authorization"].startswith("Basic ")
+    body = parse_qs(request.content.decode())
+    assert "client_id" not in body
+    assert "client_secret" not in body
+    assert body["code"] == ["code-abc"]
+    assert body["grant_type"] == ["authorization_code"]
+
+
+async def test_exchange_request_for_post_keeps_credentials_in_body():
+    provider = _provider_with_client_info("client_secret_post")
+
+    request = await provider._exchange_token_authorization_code(
+        auth_code="code-abc", code_verifier="verifier"
+    )
+
+    assert "Authorization" not in request.headers
+    body = parse_qs(request.content.decode())
+    assert body["client_id"] == ["client-123"]
+    assert body["client_secret"] == ["secret-xyz"]
+
+
+async def test_refresh_request_for_basic_omits_client_id_in_body():
+    provider = _provider_with_client_info("client_secret_basic")
+    provider.context.current_tokens = OAuthToken(access_token="at", refresh_token="rt")
+
+    request = await provider._refresh_token()
+
+    assert request.headers["Authorization"].startswith("Basic ")
+    body = parse_qs(request.content.decode())
+    assert "client_id" not in body
+    assert body["refresh_token"] == ["rt"]
+    assert body["grant_type"] == ["refresh_token"]

--- a/backend/tests/mcp/servers/test_service.py
+++ b/backend/tests/mcp/servers/test_service.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
+import pytest
 from mcp.shared.auth import OAuthClientInformationFull
 
+from app.exceptions import AlreadyExistsError, DomainValidationError
 from app.mcp.servers import service as service_module
-from app.mcp.servers.service import _build_oauth_provider
+from app.mcp.servers.models import MCPAuthType
+from app.mcp.servers.schemas import MCPServerCreate
+from app.mcp.servers.service import MCPServerService, _build_oauth_provider
 
 
 def _repo_with_credentials(**overrides):
@@ -62,6 +67,12 @@ async def test_build_oauth_provider_without_credentials_defers_to_dcr():
 
     assert provider._client_id is None
     assert provider._client_secret is None
+    # Requested explicitly at registration: omitting it lets servers default
+    # to client_secret_basic, whose SDK token request Notion rejects.
+    assert (
+        provider.context.client_metadata.token_endpoint_auth_method
+        == "client_secret_post"
+    )
 
 
 async def test_persist_client_info_writes_when_credentials_present(monkeypatch):
@@ -89,20 +100,12 @@ async def test_persist_client_info_noop_without_credentials():
     await provider.persist_client_info()
 
     storage.set_client_info.assert_not_awaited()
-from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
-
-import pytest
-
-from app.exceptions import AlreadyExistsError, DomainValidationError
-from app.mcp.servers.models import MCPAuthType
-from app.mcp.servers.schemas import MCPServerCreate
-from app.mcp.servers.service import MCPServerService
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_db():
@@ -141,6 +144,7 @@ def make_mcp_server(**kwargs):
 # ---------------------------------------------------------------------------
 # create
 # ---------------------------------------------------------------------------
+
 
 async def test_create_raises_already_exists_when_url_taken(service, mock_repo):
     mock_repo.get_by_url.return_value = make_mcp_server()


### PR DESCRIPTION
## Problem

Connecting Notion via OAuth started failing at the token exchange:

```
OAuthTokenError: Token exchange failed (400): {"error":"invalid_request","error_description":"Client must not use multiple authentication methods"}
```

Root cause chain:

1. `build_oauth_client_metadata()` set `token_endpoint_auth_method=None`, and the SDK's registration request serializes with `exclude_none=True` — so the field is **omitted** from the DCR payload.
2. Per RFC 7591, an omitted `token_endpoint_auth_method` lets the server pick the default: Notion registers the client as `client_secret_basic` and issues a secret.
3. The MCP SDK's basic-auth token request is malformed per strict RFC 6749 §2.3: `prepare_token_auth` adds the Basic `Authorization` header but the exchange and refresh bodies unconditionally keep `client_id` in the form body (still unfixed on SDK `main`).
4. Notion's token endpoint recently started rejecting that combination as two client-authentication methods. Reproduced independently with curl: Basic + `client_id` in body → 400; either method alone → passes client auth. A registration from June 26 with the identical request shape had completed successfully, so the change is server-side enforcement, not anything in this repo.

## Fix (two layers)

**1. New registrations request `client_secret_post` explicitly** in the client-wide DCR metadata — the standard RFC 7591 way for a client to declare how it authenticates (MCP Inspector does the same with `"none"`), and the SDK's own default before it grew basic-auth support. The SDK's `client_secret_post` path builds a clean request that Notion accepts. Servers with static credentials are unaffected: `_build_oauth_provider` already overrides the method from stored credentials.

**2. Existing `client_secret_basic` registrations keep working** — `WebOAuthClientProvider` now overrides `_exchange_token_authorization_code` and `_refresh_token` to strip `client_id` from the form body whenever the Basic `Authorization` header is present, making the request RFC 6749 §2.3-compliant. Already-persisted registrations (Notion, Sentry, …) work as-is, at exchange and refresh, with no reset or re-registration. This was chosen over migrating stored registrations to `client_secret_post`, which could break servers that honor basic but not post.

Also consolidates `test_service.py`'s accidental mid-file import block to the top (pre-existing E402/F811 that blocked the pre-commit hook once the file was touched).

## Testing

- Pinned the new DCR default in `test_build_oauth_provider_without_credentials_defers_to_dcr`
- New tests: basic-auth exchange/refresh requests omit body `client_id`; `client_secret_post` requests keep credentials in the body with no Basic header
- `uv run pytest tests/mcp/` — 31 passed
- Verified end-to-end: fresh Notion connect registers as `client_secret_post` and the token exchange succeeds; curl probe confirms Notion accepts Basic without body `client_id` (the shape existing registrations now send)

🤖 Generated with [Claude Code](https://claude.com/claude-code)