### PR TITLE
fix(triggers): show running state in trigger run history

### DIFF
--- a/web/src/app/(protected)/triggers/components/run-history-card.tsx
+++ b/web/src/app/(protected)/triggers/components/run-history-card.tsx
@@ -4,12 +4,34 @@ import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
 import { formatRunAt } from "@/lib/triggers/schedule";
+import { TriggerThread } from "@/types/triggers";
 import { useTriggerRunsStore } from "@/stores/trigger-runs-store";
 import { useActiveRunThreadIdSet } from "@/hooks/use-active-runs";
 
 interface RunHistoryCardProps {
 	triggerId: string;
 	timezone: string;
+}
+
+/** Trigger runs execute as the trigger's *owner*, so the viewer's
+ * `/runs/active` poll can't see firings of someone else's trigger (e.g. an
+ * admin watching it). While the card is open, refresh the history itself —
+ * new firings and outcomes then surface regardless of who owns the run. */
+const HISTORY_POLL_MS = 15_000;
+
+/** A firing whose run outcome is missing is in flight — every firing
+ * enqueues a run, and terminal transitions always stamp the thread. Bound
+ * it in time so the rare orphan (enqueue crashed after the thread was
+ * committed) doesn't spin forever; the reaper finalizes real runs long
+ * before this. */
+const MISSING_OUTCOME_RUNNING_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function isInFlight(run: TriggerThread): boolean {
+	return (
+		!run.lastRunStatus &&
+		Date.now() - new Date(run.createdAt).getTime() <
+			MISSING_OUTCOME_RUNNING_WINDOW_MS
+	);
 }
 
 /** Past firings (last 30 days); each row opens the thread it created. */
@@ -25,6 +47,15 @@ export default function RunHistoryCard({
 		fetchRuns(triggerId).catch(() => {
 			// logged by the store; the card keeps whatever it has
 		});
+		const timer = setInterval(() => {
+			if (document.visibilityState === "hidden") return;
+			fetchRuns(triggerId).catch(() => {
+				// logged by the store; the card keeps whatever it has
+			});
+		}, HISTORY_POLL_MS);
+		return () => {
+			clearInterval(timer);
+		};
 	}, [triggerId, fetchRuns]);
 
 	// A scheduled firing while the card is open surfaces as an active thread
@@ -71,7 +102,7 @@ export default function RunHistoryCard({
 					<span className="flex-1 min-w-0 truncate font-[family-name:var(--font-dm-sans)] text-[14px] font-medium text-[#1E2D28] dark:text-white group-hover:text-[#3D8B63] dark:group-hover:text-emerald-400 transition-colors">
 						{formatRunAt(run.createdAt, timezone)}
 					</span>
-					{activeRunThreadIds.has(run.id) ? (
+					{activeRunThreadIds.has(run.id) || isInFlight(run) ? (
 						<span className="flex shrink-0 items-center gap-1">
 							<Loader2
 								aria-hidden="true"

--- a/web/src/app/(protected)/triggers/components/run-history-card.tsx
+++ b/web/src/app/(protected)/triggers/components/run-history-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
 import { formatRunAt } from "@/lib/triggers/schedule";
@@ -26,6 +26,29 @@ export default function RunHistoryCard({
 			// logged by the store; the card keeps whatever it has
 		});
 	}, [triggerId, fetchRuns]);
+
+	// A scheduled firing while the card is open surfaces as an active thread
+	// id the fetched history doesn't have yet — refetch so its row appears.
+	// Active ids that belong to other threads (e.g. a chat run) can never
+	// show up in this trigger's history, so remember the ids already looked
+	// up and refetch at most once per unknown id.
+	const checkedThreadIdsRef = useRef(new Set<string>());
+	useEffect(() => {
+		if (runs === undefined) return;
+		const known = new Set(runs.map((run) => run.id));
+		let hasUnknown = false;
+		for (const threadId of activeRunThreadIds) {
+			if (known.has(threadId) || checkedThreadIdsRef.current.has(threadId)) {
+				continue;
+			}
+			checkedThreadIdsRef.current.add(threadId);
+			hasUnknown = true;
+		}
+		if (!hasUnknown) return;
+		fetchRuns(triggerId).catch(() => {
+			// logged by the store; the card keeps whatever it has
+		});
+	}, [runs, activeRunThreadIds, triggerId, fetchRuns]);
 
 	return (
 		<div className="flex flex-col rounded-[14px] border border-[#e1ebe6] dark:border-white/10 bg-white dark:bg-card px-4.5 py-1.5 shadow-[0_1px_3px_rgba(33,36,31,0.04)]">

--- a/web/src/app/(protected)/triggers/components/run-history-card.tsx
+++ b/web/src/app/(protected)/triggers/components/run-history-card.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect } from "react";
 import Link from "next/link";
+import { Loader2 } from "lucide-react";
 import { formatRunAt } from "@/lib/triggers/schedule";
 import { useTriggerRunsStore } from "@/stores/trigger-runs-store";
+import { useActiveRunThreadIdSet } from "@/hooks/use-active-runs";
 
 interface RunHistoryCardProps {
 	triggerId: string;
@@ -17,6 +19,7 @@ export default function RunHistoryCard({
 }: RunHistoryCardProps) {
 	const runs = useTriggerRunsStore((state) => state.runsByTrigger[triggerId]);
 	const fetchRuns = useTriggerRunsStore((state) => state.fetchRuns);
+	const activeRunThreadIds = useActiveRunThreadIdSet();
 
 	useEffect(() => {
 		fetchRuns(triggerId).catch(() => {
@@ -45,30 +48,42 @@ export default function RunHistoryCard({
 					<span className="flex-1 min-w-0 truncate font-[family-name:var(--font-dm-sans)] text-[14px] font-medium text-[#1E2D28] dark:text-white group-hover:text-[#3D8B63] dark:group-hover:text-emerald-400 transition-colors">
 						{formatRunAt(run.createdAt, timezone)}
 					</span>
-					{(run.lastRunStatus === "error" ||
-						run.lastRunStatus === "timeout") && (
+					{activeRunThreadIds.has(run.id) ? (
 						<span className="flex shrink-0 items-center gap-1">
-							<svg
-								width="13"
-								height="13"
-								viewBox="0 0 24 24"
-								xmlns="http://www.w3.org/2000/svg"
-								className="shrink-0"
+							<Loader2
 								aria-hidden="true"
-							>
-								<path
-									d="M18 6L6 18M6 6l12 12"
-									fill="none"
-									stroke="#CE5B45"
-									strokeWidth="3"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								/>
-							</svg>
-							<span className="font-[family-name:var(--font-dm-sans)] text-[12.5px]/4 font-semibold text-[#CE5B45]">
-								Failed
+								className="size-[13px] shrink-0 animate-spin text-[#4CA882]"
+							/>
+							<span className="font-[family-name:var(--font-dm-sans)] text-[12.5px]/4 font-semibold text-[#4CA882]">
+								Running
 							</span>
 						</span>
+					) : (
+						(run.lastRunStatus === "error" ||
+							run.lastRunStatus === "timeout") && (
+							<span className="flex shrink-0 items-center gap-1">
+								<svg
+									width="13"
+									height="13"
+									viewBox="0 0 24 24"
+									xmlns="http://www.w3.org/2000/svg"
+									className="shrink-0"
+									aria-hidden="true"
+								>
+									<path
+										d="M18 6L6 18M6 6l12 12"
+										fill="none"
+										stroke="#CE5B45"
+										strokeWidth="3"
+										strokeLinecap="round"
+										strokeLinejoin="round"
+									/>
+								</svg>
+								<span className="font-[family-name:var(--font-dm-sans)] text-[12.5px]/4 font-semibold text-[#CE5B45]">
+									Failed
+								</span>
+							</span>
+						)
 					)}
 					<span className="shrink-0 font-[family-name:var(--font-dm-sans)] text-[12.5px] font-semibold text-[#4CA882] opacity-0 group-hover:opacity-100 transition-opacity">
 						Open

--- a/web/src/hooks/use-active-runs.ts
+++ b/web/src/hooks/use-active-runs.ts
@@ -178,6 +178,22 @@ export function useActiveRunThreadIds(threads: Thread[]): Set<string> {
 		};
 	}, [hasActiveRuns, latestTriggerThreadAt, pollEpoch]);
 
+	return useActiveRunThreadIdSet();
+}
+
+/**
+ * Read-only view of the in-flight thread ids — client-side marks merged
+ * with the last poll. Polling itself is owned by `useActiveRunThreadIds`
+ * (mounted once, in the sidebar); consumers like the trigger run history
+ * just observe the shared store.
+ */
+export function useActiveRunThreadIdSet(): Set<string> {
+	const confirmedThreadIds = useActiveRunsStore(
+		(state) => state.confirmedThreadIds,
+	);
+	const optimisticMarkedAt = useActiveRunsStore(
+		(state) => state.optimisticMarkedAt,
+	);
 	// Pure union — expired optimistic marks are pruned by the store on
 	// every poll, not at render time.
 	return useMemo(() => {


### PR DESCRIPTION
## Summary

When a trigger is run manually, the sidebar thread shows a loading spinner, but the run history on the trigger page gave no indication the run was in flight.

- Extract the in-flight thread-id set (optimistic client marks ∪ `GET /runs/active` poll) from `useActiveRunThreadIds` into a new read-only hook `useActiveRunThreadIdSet`. It only observes the shared `useActiveRunsStore` — polling remains owned by the sidebar's `useActiveRunThreadIds`, so mounting the card doesn't start a second poll loop.
- `RunHistoryCard` rows whose thread is in that set show a spinning `Loader2` + **Running** label (same sage green as the sidebar spinner), taking precedence over the **Failed** marker. When the poll stamps the terminal outcome, the id leaves the active set and `setRunStatus` updates `lastRunStatus`, so the row transitions to Failed/plain without a refetch.

Covers both manual runs (instant, via the optimistic mark from `useRunTrigger`) and scheduled firings that land while the page is open (picked up by the poll).

## Test plan

- [ ] Open a trigger page, click **Run now** → the new history row appears immediately with a Running spinner
- [ ] Wait for the run to finish → spinner clears (or shows **Failed** on error/timeout) without reloading
- [ ] Sidebar loading dot behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show “Running” in trigger run history and surface new firings in real time, including when viewing someone else’s trigger. Polls the trigger’s history (15s, visible tab only) and uses the shared active-runs store for immediate updates.

- **Bug Fixes**
  - Added read-only `useActiveRunThreadIdSet` that unions optimistic marks with confirmed IDs; sidebar keeps ownership of `/runs/active` polling.
  - `RunHistoryCard` shows a spinning “Running” when the thread id is active or the firing has no outcome yet (bounded to 24h), taking precedence over “Failed”.
  - When the active set contains an unknown thread id, refetch this trigger’s runs once so the row appears.

<sup>Written for commit badb084ccc6863c1e185e36b9749e8e6c713649f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

