### PR TITLE
feat: proper dark mode styling for code blocks

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15306,7 +15306,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2,7 +2,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@source "../node_modules/streamdown/dist/*.js";
+@source "../../node_modules/streamdown/dist/*.js";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
<img width="865" height="574" alt="Screenshot 2026-07-13 at 11 04 50" src="https://github.com/user-attachments/assets/9fb3ca6e-fa4e-4ba3-b750-ddaa70127eec" />

There was no dark mode styling for code blocks, now there is one.
This was only an issue for the code blocks, not the tools blocks. 

<img width="834" height="620" alt="Screenshot 2026-07-13 at 11 16 48" src="https://github.com/user-attachments/assets/d5942645-683e-4c9b-8f73-9bd0f972438c" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing dark mode styling for code blocks by correcting the Tailwind content source for `streamdown`. Code blocks now render properly in dark mode; tools blocks were unaffected.

- Bug Fixes
  - Updated `@source` in `globals.css` to `../../node_modules/streamdown/dist/*.js` so Tailwind includes `streamdown` components and generates dark styles for code blocks.

<sup>Written for commit 5cfac81df3b1d7a3bf609dfed0d334c1db1a906e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

