### PR TITLE
fix(observability): make Langfuse timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ SLACK_BOT_TOKEN=
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
 LANGFUSE_BASE_URL=https://cloud.langfuse.com
+LANGFUSE_TIMEOUT=15
 
 # OpenSandbox (optional - enables code execution for agents)
 OPEN_SANDBOX_DOMAIN=

--- a/backend/app/integrations/langfuse/callback.py
+++ b/backend/app/integrations/langfuse/callback.py
@@ -4,12 +4,21 @@ from langfuse.langchain import CallbackHandler
 from app.integrations.langfuse.settings import langfuse_settings
 
 
-if langfuse_settings.langfuse_base_url and langfuse_settings.langfuse_public_key and langfuse_settings.langfuse_secret_key:
-    langfuse = Langfuse(
+def _build_langfuse() -> tuple[Langfuse | None, CallbackHandler | None]:
+    if not (
+        langfuse_settings.langfuse_base_url
+        and langfuse_settings.langfuse_public_key
+        and langfuse_settings.langfuse_secret_key
+    ):
+        return None, None
+
+    client = Langfuse(
         public_key=langfuse_settings.langfuse_public_key,
         secret_key=langfuse_settings.langfuse_secret_key,
-        host=langfuse_settings.langfuse_base_url
+        host=langfuse_settings.langfuse_base_url,
+        timeout=langfuse_settings.langfuse_timeout,
     )
-    langfuse_callback_handler = CallbackHandler()
-else:
-    langfuse_callback_handler = None
+    return client, CallbackHandler()
+
+
+langfuse, langfuse_callback_handler = _build_langfuse()

--- a/backend/app/integrations/langfuse/settings.py
+++ b/backend/app/integrations/langfuse/settings.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, PositiveInt
 from pydantic_settings import BaseSettings
 
 
@@ -12,10 +12,11 @@ class LangfuseSettings(BaseSettings):
     langfuse_public_key: str | None = None
     langfuse_secret_key: str | None = None
     langfuse_base_url: str | None = None
+    langfuse_timeout: PositiveInt = 15
 
     model_config: ConfigDict = ConfigDict(
         env_file=ROOT_ENV,
-        extra="ignore"
+        extra="ignore",
     )
 
 

--- a/backend/tests/integrations/langfuse/test_callback.py
+++ b/backend/tests/integrations/langfuse/test_callback.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.integrations.langfuse import callback
+from app.integrations.langfuse.settings import LangfuseSettings
+
+
+def test_langfuse_timeout_defaults_to_fifteen_seconds(monkeypatch):
+    monkeypatch.delenv("LANGFUSE_TIMEOUT", raising=False)
+
+    settings = LangfuseSettings(_env_file=None)
+
+    assert settings.langfuse_timeout == 15
+
+
+def test_langfuse_timeout_can_be_configured_from_environment(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_TIMEOUT", "21")
+
+    settings = LangfuseSettings(_env_file=None)
+
+    assert settings.langfuse_timeout == 21
+
+
+@pytest.mark.parametrize("timeout", [0, -1])
+def test_langfuse_timeout_must_be_positive(timeout):
+    with pytest.raises(ValidationError):
+        LangfuseSettings(langfuse_timeout=timeout, _env_file=None)
+
+
+def test_langfuse_client_receives_configured_timeout(monkeypatch):
+    langfuse_constructor = MagicMock()
+    callback_constructor = MagicMock()
+    monkeypatch.setattr(callback, "Langfuse", langfuse_constructor)
+    monkeypatch.setattr(callback, "CallbackHandler", callback_constructor)
+    monkeypatch.setattr(callback.langfuse_settings, "langfuse_public_key", "pk-test")
+    monkeypatch.setattr(callback.langfuse_settings, "langfuse_secret_key", "sk-test")
+    monkeypatch.setattr(
+        callback.langfuse_settings, "langfuse_base_url", "https://langfuse.test"
+    )
+    monkeypatch.setattr(callback.langfuse_settings, "langfuse_timeout", 21)
+
+    client, handler = callback._build_langfuse()
+
+    langfuse_constructor.assert_called_once_with(
+        public_key="pk-test",
+        secret_key="sk-test",
+        host="https://langfuse.test",
+        timeout=21,
+    )
+    callback_constructor.assert_called_once_with()
+    assert client is langfuse_constructor.return_value
+    assert handler is callback_constructor.return_value

--- a/docs/content/deploy/environment-variables.mdx
+++ b/docs/content/deploy/environment-variables.mdx
@@ -74,8 +74,9 @@ If `OPEN_SANDBOX_DOMAIN` is missing, the sandbox toggle on agents is silently di
 | `LANGFUSE_PUBLIC_KEY`   | Langfuse project public key                                |
 | `LANGFUSE_SECRET_KEY`   | Langfuse project secret key                                |
 | `LANGFUSE_BASE_URL`     | `https://cloud.langfuse.com` or your self-hosted URL       |
+| `LANGFUSE_TIMEOUT`      | API request timeout in seconds (positive integer; default `15`) |
 
-All three are required to enable Langfuse; missing any of them disables the integration silently. Details: [Observability (Langfuse)](/docs/deploy/langfuse).
+The public key, secret key, and base URL are required to enable Langfuse; missing any of them disables the integration silently. The timeout is optional. Details: [Observability (Langfuse)](/docs/deploy/langfuse).
 
 ## Slack (optional)
 

--- a/docs/content/deploy/langfuse.mdx
+++ b/docs/content/deploy/langfuse.mdx
@@ -11,15 +11,16 @@
 
 ## Enable it
 
-Set these three environment variables on the backend:
+Set the three required environment variables on the backend. You can also tune the optional request timeout:
 
 ```env
 LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_BASE_URL=https://cloud.langfuse.com  # or your self-hosted URL
+LANGFUSE_TIMEOUT=15                           # request timeout in seconds
 ```
 
-On startup, the backend instantiates a shared `Langfuse` client and attaches a `CallbackHandler` to every LangGraph invocation. If any of the three variables is missing, the integration is silently disabled.
+On startup, the backend instantiates a shared `Langfuse` client and attaches a `CallbackHandler` to every LangGraph invocation. If any of the three credential/URL variables is missing, the integration is silently disabled. `LANGFUSE_TIMEOUT` is optional, defaults to 15 seconds, and must be a positive integer.
 
 See `app/integrations/langfuse/callback.py` for the wiring.
 

--- a/docs/content/get-started.mdx
+++ b/docs/content/get-started.mdx
@@ -73,6 +73,7 @@ OPEN_SANDBOX_DEFAULT_IMAGE=    # e.g. keurcien/opensandbox-sandbox-image:latest
 LANGFUSE_PUBLIC_KEY=pk-...
 LANGFUSE_SECRET_KEY=sk-...
 LANGFUSE_BASE_URL=https://cloud.langfuse.com
+LANGFUSE_TIMEOUT=15
 
 # Slack integration (see /docs/deploy/slack)
 SLACK_SIGNING_SECRET=


### PR DESCRIPTION
## Pourquoi

Le SDK Langfuse utilise par défaut un timeout d'environ 5 secondes. Une instance Langfuse auto-hébergée sur Cloud Run peut dépasser ce délai lors d'un démarrage à froid, ce qui produit des erreurs d'export OpenTelemetry alors que l'exécution de l'agent elle-même n'a pas échoué.

## Changements

- ajoute LANGFUSE_TIMEOUT comme entier positif configurable ;
- utilise 15 secondes par défaut ;
- transmet cette valeur au client Langfuse ;
- documente la variable dans les exemples et le guide de déploiement.

Cette PR est indépendante du correctif structured output.

## Tests

- 8 tests ciblés passent ;
- Ruff passe sur les fichiers Python modifiés.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Langfuse API timeout configurable to reduce false OpenTelemetry export errors during cold starts. Adds `LANGFUSE_TIMEOUT` with a 15s default and validation.

- New Features
  - Add `langfuse_timeout` (positive integer) to settings and pass it to the `Langfuse` client.
  - Create a helper to build the `Langfuse` client and `CallbackHandler`, keeping the integration disabled if required vars are missing.
  - Document `LANGFUSE_TIMEOUT` in `.env.example` and deployment docs; add tests for default, validation, and wiring.

- Migration
  - Optional: set `LANGFUSE_TIMEOUT` for self-hosted `Langfuse` (e.g., Cloud Run) if cold starts can exceed 15s.

<sup>Written for commit ab74efde399f2c5e5dda4a5df02d4a8d0b973249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

