### PR TITLE
fix(agents): use provider-native json_schema for structured output on…

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -131,15 +131,25 @@ Un run peut fournir un `output_schema` (JSON Schema) pour obtenir une réponse v
 
 **Le schéma n'est pas appliqué pendant la boucle ReAct.** Contraindre le décodage à chaque appel casse la boucle en pratique : le modèle arrête d'appeler les outils et remplit directement le schéma avec des valeurs inventées. Le middleware laisse donc la boucle tourner sans contrainte, puis applique le schéma sur **un seul dernier tour de formatage**, une fois la réponse finale atteinte.
 
-Sur ce tour de formatage, langchain résout le schéma en **`ToolStrategy`** : un appel d'outil forcé (`tool_choice` = `"required"` ou une fonction nommée). Cela fonctionne pour tous nos fournisseurs **sauf Meta**.
+Sur ce tour de formatage, langchain résout le schéma par défaut en **`ToolStrategy`** : un appel d'outil forcé (`tool_choice` = `"required"` ou une fonction nommée). Cela fonctionne pour la plupart de nos fournisseurs, mais deux APIs rejettent l'appel forcé. La stratégie de formatage est donc choisie par fournisseur via `PROVIDER_FORMAT_MODES` (`app/agents/structured_output.py`) — un fournisseur absent utilise l'appel d'outil forcé par défaut.
+
+| Mode | Fournisseur | Comment |
+| --- | --- | --- |
+| `FORMAT_TOOL` (défaut) | OpenAI, Anthropic, Google, Xiaomi, OpenRouter… | Appel d'outil forcé (`ToolStrategy`). Le fournisseur garantit le schéma. |
+| `FORMAT_PROVIDER_NATIVE` | Meta | `ProviderStrategy` → `response_format: {type: "json_schema"}`. |
+| `FORMAT_JSON_OBJECT` | DeepSeek | `response_format: {type: "json_object"}` + validation locale. |
 
 ### Le cas Meta
 
-L'API de Meta (`muse-spark-1.1`) n'accepte que `tool_choice="auto"` et rejette l'appel forcé avec une erreur 400. Pour les fournisseurs listés dans `AUTO_ONLY_TOOL_CHOICE_PROVIDERS` (`app/model_providers/catalog.py`), on formate donc via la **stratégie native** (`ProviderStrategy` → `response_format: {type: "json_schema"}`), qui ne force aucun `tool_choice`. Ajouter un fournisseur « auto-only » se résume à une ligne dans ce frozenset.
+L'API de Meta (`muse-spark-1.1`) n'accepte que `tool_choice="auto"` et rejette l'appel forcé avec une erreur 400. On formate donc via la **stratégie native** (`ProviderStrategy` → `response_format: {type: "json_schema"}`), qui ne force aucun `tool_choice`.
 
-### Pourquoi ne pas utiliser la voie native partout ?
+### Le cas DeepSeek (mode raisonnement)
 
-Parce que `ToolStrategy` (le défaut de langchain) fonctionne déjà chez tous les autres fournisseurs. On ne remplace la stratégie que là où l'appel forcé échoue réellement (Meta), afin de garder un impact minimal et de ne pas risquer de régression sur les fournisseurs qui marchent aujourd'hui.
+DeepSeek avec le raisonnement activé (`thinking.type = "enabled"`) rejette **à la fois** l'appel forcé (`Thinking mode does not support this tool_choice`) **et** le `json_schema` (`This response_format type is unavailable now`). Seul le mode `json_object` (legacy) fonctionne : il ne garantit que « c'est du JSON », pas la forme. Le middleware embarque donc le schéma dans le prompt, lie `response_format: {type: "json_object"}`, puis **parse et valide le JSON lui-même** (`validate_structured_response`, avec la même boucle de retry). C'est la seule voie où l'enforcement du schéma vient de nous et non du fournisseur.
+
+### Pourquoi ne pas utiliser une voie unique partout ?
+
+Parce que `ToolStrategy` (le défaut de langchain) fonctionne déjà chez la plupart des fournisseurs. On ne dévie de la stratégie que là où l'appel forcé échoue réellement (Meta, DeepSeek en raisonnement), afin de garder un impact minimal et de ne pas risquer de régression sur les fournisseurs qui marchent aujourd'hui. Ajouter un fournisseur se résume à une ligne dans `PROVIDER_FORMAT_MODES`.
 
 ## Configuration
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -125,6 +125,22 @@ python example_callback_handler.py <state-from-oauth-start>
 - `GET /agents/` - List all agents
 - `GET /agents/{agent_id}` - Get agent details
 
+## Sorties structurées (structured output)
+
+Un run peut fournir un `output_schema` (JSON Schema) pour obtenir une réponse validée dans `structured_response`. Le schéma est géré par `DeferredStructuredOutputMiddleware` (`app/agents/structured_output.py`).
+
+**Le schéma n'est pas appliqué pendant la boucle ReAct.** Contraindre le décodage à chaque appel casse la boucle en pratique : le modèle arrête d'appeler les outils et remplit directement le schéma avec des valeurs inventées. Le middleware laisse donc la boucle tourner sans contrainte, puis applique le schéma sur **un seul dernier tour de formatage**, une fois la réponse finale atteinte.
+
+Sur ce tour de formatage, langchain résout le schéma en **`ToolStrategy`** : un appel d'outil forcé (`tool_choice` = `"required"` ou une fonction nommée). Cela fonctionne pour tous nos fournisseurs **sauf Meta**.
+
+### Le cas Meta
+
+L'API de Meta (`muse-spark-1.1`) n'accepte que `tool_choice="auto"` et rejette l'appel forcé avec une erreur 400. Pour les fournisseurs listés dans `AUTO_ONLY_TOOL_CHOICE_PROVIDERS` (`app/model_providers/catalog.py`), on formate donc via la **stratégie native** (`ProviderStrategy` → `response_format: {type: "json_schema"}`), qui ne force aucun `tool_choice`. Ajouter un fournisseur « auto-only » se résume à une ligne dans ce frozenset.
+
+### Pourquoi ne pas utiliser la voie native partout ?
+
+Parce que `ToolStrategy` (le défaut de langchain) fonctionne déjà chez tous les autres fournisseurs. On ne remplace la stratégie que là où l'appel forcé échoue réellement (Meta), afin de garder un impact minimal et de ne pas risquer de régression sur les fournisseurs qui marchent aujourd'hui.
+
 ## Configuration
 
 ### Environment Variables

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -39,7 +39,12 @@ from app.agents.toolset import PreparedToolset, Toolset, sanitize_tool_name
 from app.database import get_checkpointer
 from app.exceptions import DomainValidationError
 from app.integrations.langfuse.callback import langfuse_callback_handler
-from app.model_providers.catalog import LLM_PROVIDERS, MODELS, ChatModelFactory
+from app.model_providers.catalog import (
+    AUTO_ONLY_TOOL_CHOICE_PROVIDERS,
+    LLM_PROVIDERS,
+    MODELS,
+    ChatModelFactory,
+)
 from app.sandbox.settings import sandbox_settings
 from app.threads.models import ThreadDB
 
@@ -78,6 +83,7 @@ def build_runnable(
     subagents=None,
     checkpointer=None,
     output_schema: dict | None = None,
+    provider_native: bool = False,
 ):
     """Build a LangGraph runnable, dispatching on whether a sandbox is needed.
 
@@ -108,7 +114,7 @@ def build_runnable(
             m for m in base_middleware if not isinstance(m, PatchToolCallsMiddleware)
         ]
         if output_schema is not None:
-            middleware.append(DeferredStructuredOutputMiddleware())
+            middleware.append(DeferredStructuredOutputMiddleware(provider_native))
         return create_deep_agent(
             model=model,
             tools=[*tools, *create_sandbox_tools(lazy_backend)],
@@ -124,7 +130,7 @@ def build_runnable(
     if subagents:
         middleware.append(SubAgentMiddleware(backend=StateBackend, subagents=subagents))
     if output_schema is not None:
-        middleware.append(DeferredStructuredOutputMiddleware())
+        middleware.append(DeferredStructuredOutputMiddleware(provider_native))
     return create_agent(
         model=model,
         tools=tools,
@@ -310,6 +316,9 @@ class Agent:
             if sandbox
             else SystemMessage(self.agent.config.instructions)
         )
+        provider = next(
+            (m.provider for m in MODELS if m.name == self.thread.model_id), None
+        )
         return build_runnable(
             model=self.model,
             tools=self.agent.live.all,
@@ -319,6 +328,7 @@ class Agent:
             subagents=compiled,
             checkpointer=checkpointer,
             output_schema=output_schema,
+            provider_native=provider in AUTO_ONLY_TOOL_CHOICE_PROVIDERS,
         )
 
     def _resolve_input(self, agent_input: dict | None, command: dict | None):

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -31,6 +31,8 @@ from app.agents.stream import (
     encode_synthetic_ai_message_sse,
 )
 from app.agents.structured_output import (
+    FORMAT_TOOL,
+    PROVIDER_FORMAT_MODES,
     DeferredStructuredOutputMiddleware,
     is_structured_output_artifact,
 )
@@ -40,7 +42,6 @@ from app.database import get_checkpointer
 from app.exceptions import DomainValidationError
 from app.integrations.langfuse.callback import langfuse_callback_handler
 from app.model_providers.catalog import (
-    AUTO_ONLY_TOOL_CHOICE_PROVIDERS,
     LLM_PROVIDERS,
     MODELS,
     ChatModelFactory,
@@ -83,7 +84,7 @@ def build_runnable(
     subagents=None,
     checkpointer=None,
     output_schema: dict | None = None,
-    provider_native: bool = False,
+    format_mode: str = FORMAT_TOOL,
 ):
     """Build a LangGraph runnable, dispatching on whether a sandbox is needed.
 
@@ -114,7 +115,7 @@ def build_runnable(
             m for m in base_middleware if not isinstance(m, PatchToolCallsMiddleware)
         ]
         if output_schema is not None:
-            middleware.append(DeferredStructuredOutputMiddleware(provider_native))
+            middleware.append(DeferredStructuredOutputMiddleware(format_mode))
         return create_deep_agent(
             model=model,
             tools=[*tools, *create_sandbox_tools(lazy_backend)],
@@ -130,7 +131,7 @@ def build_runnable(
     if subagents:
         middleware.append(SubAgentMiddleware(backend=StateBackend, subagents=subagents))
     if output_schema is not None:
-        middleware.append(DeferredStructuredOutputMiddleware(provider_native))
+        middleware.append(DeferredStructuredOutputMiddleware(format_mode))
     return create_agent(
         model=model,
         tools=tools,
@@ -328,7 +329,7 @@ class Agent:
             subagents=compiled,
             checkpointer=checkpointer,
             output_schema=output_schema,
-            provider_native=provider in AUTO_ONLY_TOOL_CHOICE_PROVIDERS,
+            format_mode=PROVIDER_FORMAT_MODES.get(provider, FORMAT_TOOL),
         )
 
     def _resolve_input(self, agent_input: dict | None, command: dict | None):

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -39,12 +39,7 @@ from app.agents.toolset import PreparedToolset, Toolset, sanitize_tool_name
 from app.database import get_checkpointer
 from app.exceptions import DomainValidationError
 from app.integrations.langfuse.callback import langfuse_callback_handler
-from app.model_providers.catalog import (
-    AUTO_ONLY_TOOL_CHOICE_PROVIDERS,
-    LLM_PROVIDERS,
-    MODELS,
-    ChatModelFactory,
-)
+from app.model_providers.catalog import LLM_PROVIDERS, MODELS, ChatModelFactory
 from app.sandbox.settings import sandbox_settings
 from app.threads.models import ThreadDB
 
@@ -83,7 +78,6 @@ def build_runnable(
     subagents=None,
     checkpointer=None,
     output_schema: dict | None = None,
-    supports_forced_tool_choice: bool = True,
 ):
     """Build a LangGraph runnable, dispatching on whether a sandbox is needed.
 
@@ -114,9 +108,7 @@ def build_runnable(
             m for m in base_middleware if not isinstance(m, PatchToolCallsMiddleware)
         ]
         if output_schema is not None:
-            middleware.append(
-                DeferredStructuredOutputMiddleware(supports_forced_tool_choice)
-            )
+            middleware.append(DeferredStructuredOutputMiddleware())
         return create_deep_agent(
             model=model,
             tools=[*tools, *create_sandbox_tools(lazy_backend)],
@@ -208,7 +200,6 @@ class Agent:
         middleware: list,
         callbacks: list,
         subagents: list[ResolvedAgent],
-        supports_forced_tool_choice: bool = True,
     ):
         self.thread = thread
         self.agent = agent
@@ -216,7 +207,6 @@ class Agent:
         self.middleware = middleware
         self.callbacks = callbacks
         self.subagents = subagents
-        self.supports_forced_tool_choice = supports_forced_tool_choice
 
     @property
     def metadata(self) -> dict:
@@ -261,9 +251,6 @@ class Agent:
         model = ChatModelFactory().create(
             provider.name, thread.model_id, provider.api_key
         )
-        supports_forced_tool_choice = (
-            provider.name not in AUTO_ONLY_TOOL_CHOICE_PROVIDERS
-        )
 
         # Build middleware stack.
         # PatchToolCallsMiddleware runs first so that any dangling tool_calls
@@ -302,7 +289,6 @@ class Agent:
             middleware=middleware,
             callbacks=callbacks,
             subagents=subagents,
-            supports_forced_tool_choice=supports_forced_tool_choice,
         )
 
     def _build_agent(self, checkpointer, output_schema: dict | None = None):
@@ -333,7 +319,6 @@ class Agent:
             subagents=compiled,
             checkpointer=checkpointer,
             output_schema=output_schema,
-            supports_forced_tool_choice=self.supports_forced_tool_choice,
         )
 
     def _resolve_input(self, agent_input: dict | None, command: dict | None):

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -39,7 +39,12 @@ from app.agents.toolset import PreparedToolset, Toolset, sanitize_tool_name
 from app.database import get_checkpointer
 from app.exceptions import DomainValidationError
 from app.integrations.langfuse.callback import langfuse_callback_handler
-from app.model_providers.catalog import LLM_PROVIDERS, MODELS, ChatModelFactory
+from app.model_providers.catalog import (
+    AUTO_ONLY_TOOL_CHOICE_PROVIDERS,
+    LLM_PROVIDERS,
+    MODELS,
+    ChatModelFactory,
+)
 from app.sandbox.settings import sandbox_settings
 from app.threads.models import ThreadDB
 
@@ -78,6 +83,7 @@ def build_runnable(
     subagents=None,
     checkpointer=None,
     output_schema: dict | None = None,
+    supports_forced_tool_choice: bool = True,
 ):
     """Build a LangGraph runnable, dispatching on whether a sandbox is needed.
 
@@ -108,7 +114,9 @@ def build_runnable(
             m for m in base_middleware if not isinstance(m, PatchToolCallsMiddleware)
         ]
         if output_schema is not None:
-            middleware.append(DeferredStructuredOutputMiddleware())
+            middleware.append(
+                DeferredStructuredOutputMiddleware(supports_forced_tool_choice)
+            )
         return create_deep_agent(
             model=model,
             tools=[*tools, *create_sandbox_tools(lazy_backend)],
@@ -200,6 +208,7 @@ class Agent:
         middleware: list,
         callbacks: list,
         subagents: list[ResolvedAgent],
+        supports_forced_tool_choice: bool = True,
     ):
         self.thread = thread
         self.agent = agent
@@ -207,6 +216,7 @@ class Agent:
         self.middleware = middleware
         self.callbacks = callbacks
         self.subagents = subagents
+        self.supports_forced_tool_choice = supports_forced_tool_choice
 
     @property
     def metadata(self) -> dict:
@@ -251,6 +261,9 @@ class Agent:
         model = ChatModelFactory().create(
             provider.name, thread.model_id, provider.api_key
         )
+        supports_forced_tool_choice = (
+            provider.name not in AUTO_ONLY_TOOL_CHOICE_PROVIDERS
+        )
 
         # Build middleware stack.
         # PatchToolCallsMiddleware runs first so that any dangling tool_calls
@@ -289,6 +302,7 @@ class Agent:
             middleware=middleware,
             callbacks=callbacks,
             subagents=subagents,
+            supports_forced_tool_choice=supports_forced_tool_choice,
         )
 
     def _build_agent(self, checkpointer, output_schema: dict | None = None):
@@ -319,6 +333,7 @@ class Agent:
             subagents=compiled,
             checkpointer=checkpointer,
             output_schema=output_schema,
+            supports_forced_tool_choice=self.supports_forced_tool_choice,
         )
 
     def _resolve_input(self, agent_input: dict | None, command: dict | None):

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -84,14 +84,6 @@ def is_structured_output_artifact(message: Any) -> bool:
     return bool(metadata.get(STRUCTURED_OUTPUT_FLAG))
 
 
-def _schema_of(response_format: Any) -> Any:
-    """The JSON Schema inside a raw-schema dict or a langchain strategy wrapper
-    (``ToolStrategy`` / ``ProviderStrategy`` both expose ``.schema``)."""
-    if isinstance(response_format, dict):
-        return response_format
-    return getattr(response_format, "schema", None)
-
-
 def validate_structured_response(value: Any, response_format: Any) -> str | None:
     """Return why ``value`` is not a valid structured response, or None if it is.
 
@@ -104,7 +96,11 @@ def validate_structured_response(value: Any, response_format: Any) -> str | None
     """
     if value is None:
         return "no structured response was produced"
-    schema = _schema_of(response_format)
+    schema = (
+        response_format
+        if isinstance(response_format, dict)
+        else getattr(response_format, "schema", None)
+    )
     if not isinstance(schema, dict):
         return None
     try:
@@ -134,18 +130,15 @@ def _tag(message: BaseMessage) -> BaseMessage:
     )
 
 
+def _forced_tool_choice_rejected(exc: Exception) -> bool:
+    """True for the 400 that providers allowing only ``tool_choice="auto"``
+    (Meta) raise when langchain forces a tool call for structured output."""
+    message = str(exc).lower()
+    return "tool_choice" in message and "auto" in message
+
+
 class DeferredStructuredOutputMiddleware(AgentMiddleware):
-    """Apply ``response_format`` only on a final formatting turn.
-
-    ``supports_forced_tool_choice`` is False for providers whose API only
-    accepts ``tool_choice="auto"`` (Meta): the formatting turn is routed to the
-    provider-native json_schema strategy (``ProviderStrategy``) instead of the
-    default forced tool call, which those providers reject with a 400.
-    """
-
-    def __init__(self, supports_forced_tool_choice: bool = True) -> None:
-        super().__init__()
-        self.supports_forced_tool_choice = supports_forced_tool_choice
+    """Apply ``response_format`` only on a final formatting turn."""
 
     async def awrap_model_call(
         self,
@@ -170,25 +163,39 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
 
         # Final answer reached: a constrained call formats it. The resolved
         # response_format (strategy + ToolStrategy tool names from agent setup)
-        # is passed through untouched — except for providers that only allow
-        # tool_choice="auto" (Meta): they reject the forced tool call with a 400,
-        # so their turn is routed to the provider-native json_schema strategy.
+        # is passed through untouched. Providers whose API only allows
+        # tool_choice="auto" (Meta) reject that forced tool call with a 400; the
+        # turn is retried with the provider-native json_schema strategy, which
+        # needs no forced tool_choice.
         # Each failed attempt's messages are dropped entirely — they may carry a
         # dangling structured-output tool call that must not reach state — and the
         # rejection is fed back to the next attempt.
-        response_format = request.response_format
-        if not self.supports_forced_tool_choice:
-            response_format = ProviderStrategy(schema=_schema_of(response_format))
         conversation = [*request.messages, *response.result]
         instruction = FORMAT_INSTRUCTION
+        response_format = request.response_format
         error: str | None = None
         for _ in range(MAX_FORMAT_ATTEMPTS):
-            format_response = await handler(
-                request.override(
-                    messages=[*conversation, HumanMessage(instruction)],
-                    response_format=response_format,
+            try:
+                format_response = await handler(
+                    request.override(
+                        messages=[*conversation, HumanMessage(instruction)],
+                        response_format=response_format,
+                    )
                 )
-            )
+            except Exception as exc:  # noqa: BLE001 - narrowed below; re-raised otherwise
+                # ponytail: one fast-fail 400 per format turn on auto-only
+                # providers; add a per-provider capability flag if that cost matters.
+                if _forced_tool_choice_rejected(exc) and not isinstance(
+                    response_format, ProviderStrategy
+                ):
+                    schema = (
+                        response_format
+                        if isinstance(response_format, dict)
+                        else getattr(response_format, "schema", None)
+                    )
+                    response_format = ProviderStrategy(schema=schema)
+                    continue
+                raise
             error = validate_structured_response(
                 format_response.structured_response, response_format
             )

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -50,6 +50,7 @@ from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
 )
+from langchain.agents.structured_output import ProviderStrategy
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
 from app.exceptions import StructuredOutputError
@@ -83,6 +84,14 @@ def is_structured_output_artifact(message: Any) -> bool:
     return bool(metadata.get(STRUCTURED_OUTPUT_FLAG))
 
 
+def _schema_of(response_format: Any) -> Any:
+    """The JSON Schema inside a raw-schema dict or a langchain strategy wrapper
+    (``ToolStrategy`` / ``ProviderStrategy`` both expose ``.schema``)."""
+    if isinstance(response_format, dict):
+        return response_format
+    return getattr(response_format, "schema", None)
+
+
 def validate_structured_response(value: Any, response_format: Any) -> str | None:
     """Return why ``value`` is not a valid structured response, or None if it is.
 
@@ -95,11 +104,7 @@ def validate_structured_response(value: Any, response_format: Any) -> str | None
     """
     if value is None:
         return "no structured response was produced"
-    schema = (
-        response_format
-        if isinstance(response_format, dict)
-        else getattr(response_format, "schema", None)
-    )
+    schema = _schema_of(response_format)
     if not isinstance(schema, dict):
         return None
     try:
@@ -130,7 +135,17 @@ def _tag(message: BaseMessage) -> BaseMessage:
 
 
 class DeferredStructuredOutputMiddleware(AgentMiddleware):
-    """Apply ``response_format`` only on a final formatting turn."""
+    """Apply ``response_format`` only on a final formatting turn.
+
+    ``supports_forced_tool_choice`` is False for providers whose API only
+    accepts ``tool_choice="auto"`` (Meta): the formatting turn is routed to the
+    provider-native json_schema strategy (``ProviderStrategy``) instead of the
+    default forced tool call, which those providers reject with a 400.
+    """
+
+    def __init__(self, supports_forced_tool_choice: bool = True) -> None:
+        super().__init__()
+        self.supports_forced_tool_choice = supports_forced_tool_choice
 
     async def awrap_model_call(
         self,
@@ -153,21 +168,29 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
         if loop_continues:
             return response
 
-        # Final answer reached: a constrained call formats it. The original
-        # response_format object is passed through untouched so the strategy
-        # (and ToolStrategy tool names) resolved at agent setup still apply.
+        # Final answer reached: a constrained call formats it. The resolved
+        # response_format (strategy + ToolStrategy tool names from agent setup)
+        # is passed through untouched — except for providers that only allow
+        # tool_choice="auto" (Meta): they reject the forced tool call with a 400,
+        # so their turn is routed to the provider-native json_schema strategy.
         # Each failed attempt's messages are dropped entirely — they may carry a
         # dangling structured-output tool call that must not reach state — and the
         # rejection is fed back to the next attempt.
+        response_format = request.response_format
+        if not self.supports_forced_tool_choice:
+            response_format = ProviderStrategy(schema=_schema_of(response_format))
         conversation = [*request.messages, *response.result]
         instruction = FORMAT_INSTRUCTION
         error: str | None = None
         for _ in range(MAX_FORMAT_ATTEMPTS):
             format_response = await handler(
-                request.override(messages=[*conversation, HumanMessage(instruction)])
+                request.override(
+                    messages=[*conversation, HumanMessage(instruction)],
+                    response_format=response_format,
+                )
             )
             error = validate_structured_response(
-                format_response.structured_response, request.response_format
+                format_response.structured_response, response_format
             )
             if error is None:
                 return ModelResponse(

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -84,6 +84,14 @@ def is_structured_output_artifact(message: Any) -> bool:
     return bool(metadata.get(STRUCTURED_OUTPUT_FLAG))
 
 
+def _schema_of(response_format: Any) -> Any:
+    """The JSON Schema inside a raw-schema dict or a langchain strategy wrapper
+    (``ToolStrategy`` / ``ProviderStrategy`` both expose ``.schema``)."""
+    if isinstance(response_format, dict):
+        return response_format
+    return getattr(response_format, "schema", None)
+
+
 def validate_structured_response(value: Any, response_format: Any) -> str | None:
     """Return why ``value`` is not a valid structured response, or None if it is.
 
@@ -96,11 +104,7 @@ def validate_structured_response(value: Any, response_format: Any) -> str | None
     """
     if value is None:
         return "no structured response was produced"
-    schema = (
-        response_format
-        if isinstance(response_format, dict)
-        else getattr(response_format, "schema", None)
-    )
+    schema = _schema_of(response_format)
     if not isinstance(schema, dict):
         return None
     try:
@@ -130,15 +134,18 @@ def _tag(message: BaseMessage) -> BaseMessage:
     )
 
 
-def _forced_tool_choice_rejected(exc: Exception) -> bool:
-    """True for the 400 that providers allowing only ``tool_choice="auto"``
-    (Meta) raise when langchain forces a tool call for structured output."""
-    message = str(exc).lower()
-    return "tool_choice" in message and "auto" in message
-
-
 class DeferredStructuredOutputMiddleware(AgentMiddleware):
-    """Apply ``response_format`` only on a final formatting turn."""
+    """Apply ``response_format`` only on a final formatting turn.
+
+    ``provider_native`` is True for providers whose API only accepts
+    ``tool_choice="auto"`` (Meta): the formatting turn then uses the provider-
+    native json_schema strategy (``ProviderStrategy``) instead of the default
+    forced tool call, which those providers reject with a 400.
+    """
+
+    def __init__(self, provider_native: bool = False) -> None:
+        super().__init__()
+        self.provider_native = provider_native
 
     async def awrap_model_call(
         self,
@@ -163,39 +170,25 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
 
         # Final answer reached: a constrained call formats it. The resolved
         # response_format (strategy + ToolStrategy tool names from agent setup)
-        # is passed through untouched. Providers whose API only allows
-        # tool_choice="auto" (Meta) reject that forced tool call with a 400; the
-        # turn is retried with the provider-native json_schema strategy, which
-        # needs no forced tool_choice.
+        # is passed through untouched — except for providers whose API only
+        # allows tool_choice="auto" (Meta), which reject the forced tool call
+        # with a 400: those format via the provider-native json_schema strategy.
         # Each failed attempt's messages are dropped entirely — they may carry a
         # dangling structured-output tool call that must not reach state — and the
         # rejection is fed back to the next attempt.
         conversation = [*request.messages, *response.result]
         instruction = FORMAT_INSTRUCTION
         response_format = request.response_format
+        if self.provider_native:
+            response_format = ProviderStrategy(schema=_schema_of(response_format))
         error: str | None = None
         for _ in range(MAX_FORMAT_ATTEMPTS):
-            try:
-                format_response = await handler(
-                    request.override(
-                        messages=[*conversation, HumanMessage(instruction)],
-                        response_format=response_format,
-                    )
+            format_response = await handler(
+                request.override(
+                    messages=[*conversation, HumanMessage(instruction)],
+                    response_format=response_format,
                 )
-            except Exception as exc:  # noqa: BLE001 - narrowed below; re-raised otherwise
-                # ponytail: one fast-fail 400 per format turn on auto-only
-                # providers; add a per-provider capability flag if that cost matters.
-                if _forced_tool_choice_rejected(exc) and not isinstance(
-                    response_format, ProviderStrategy
-                ):
-                    schema = (
-                        response_format
-                        if isinstance(response_format, dict)
-                        else getattr(response_format, "schema", None)
-                    )
-                    response_format = ProviderStrategy(schema=schema)
-                    continue
-                raise
+            )
             error = validate_structured_response(
                 format_response.structured_response, response_format
             )

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -40,6 +40,7 @@ on the ToolStrategy path — and keep them out of the rendered chat history.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -71,11 +72,51 @@ FORMAT_RETRY_INSTRUCTION = (
     "not invent values."
 )
 
+# json_object mode carries the schema in the prompt (the provider enforces only
+# "valid JSON", not the shape — validate_structured_response does the rest).
+JSON_OBJECT_INSTRUCTION = (
+    "Based on your answer above, respond with a single JSON object matching this "
+    "JSON Schema. Output only the JSON object — no prose, no code fences. Use "
+    "only information from this conversation; do not invent values.\n\n"
+    "JSON Schema:\n{schema}"
+)
+
+JSON_OBJECT_RETRY_INSTRUCTION = (
+    "Based on your answer above, respond with a single JSON object matching the "
+    "JSON Schema below. Your previous attempt was rejected: {error}. Fill in "
+    "every required field, output only the JSON object (no prose, no code "
+    "fences), and use only information from this conversation.\n\n"
+    "JSON Schema:\n{schema}"
+)
+
 # Formatting turns before giving up. Each attempt feeds the prior rejection back,
 # so extra tries cut the tail of transient omissions (e.g. a dropped required key).
 MAX_FORMAT_ATTEMPTS = 3
 
 STRUCTURED_OUTPUT_FLAG = "structured_output"
+
+# Formatting strategy for the final structured-output turn.
+#   FORMAT_TOOL           — langchain default: a forced (named) tool call.
+#   FORMAT_PROVIDER_NATIVE — provider-native json_schema (ProviderStrategy).
+#   FORMAT_JSON_OBJECT     — legacy json_object response_format; the schema rides
+#                            in the prompt and we validate the parsed JSON.
+FORMAT_TOOL = "tool"
+FORMAT_PROVIDER_NATIVE = "provider_native"
+FORMAT_JSON_OBJECT = "json_object"
+
+# Formatting strategy per model provider (see the modes above). Providers not
+# listed use the default forced tool call — the only path that constrains the
+# provider itself. The others exist because some provider APIs reject it:
+#   - Meta's Model API rejects a forced tool_choice with a 400 but accepts the
+#     provider-native json_schema, so it uses FORMAT_PROVIDER_NATIVE.
+#   - DeepSeek's thinking mode rejects BOTH a forced tool_choice ("Thinking mode
+#     does not support this tool_choice") AND json_schema ("This response_format
+#     type is unavailable now"); only the legacy json_object mode works, so it
+#     uses FORMAT_JSON_OBJECT.
+PROVIDER_FORMAT_MODES: dict[str, str] = {
+    "meta": FORMAT_PROVIDER_NATIVE,
+    "deepseek": FORMAT_JSON_OBJECT,
+}
 
 
 def is_structured_output_artifact(message: Any) -> bool:
@@ -114,6 +155,36 @@ def validate_structured_response(value: Any, response_format: Any) -> str | None
     return None
 
 
+def _message_text(message: BaseMessage) -> str:
+    """The text content of a message, flattening the list-of-parts form some
+    providers use so json_object output can be parsed as a single string."""
+    content = getattr(message, "content", "")
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        )
+    return content or ""
+
+
+def _parse_json_object(messages: list[BaseMessage]) -> tuple[Any, str | None]:
+    """Parse the last AIMessage as a JSON object: ``(value, None)`` on success,
+    ``(None, error)`` otherwise. json_object mode returns bare JSON, but a stray
+    ```` ```json ```` fence is stripped defensively before parsing."""
+    ai = next((m for m in reversed(messages) if isinstance(m, AIMessage)), None)
+    if ai is None:
+        return None, "no structured response was produced"
+    text = _message_text(ai).strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if "\n" in text:
+            text = text.split("\n", 1)[1]
+    try:
+        return json.loads(text), None
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, f"response was not valid JSON: {exc}"
+
+
 def _payload_shape(value: Any) -> str:
     """A non-sensitive descriptor of a rejected payload for logs: its keys (a
     dropped required field is the usual culprit) or type — never the values,
@@ -137,15 +208,21 @@ def _tag(message: BaseMessage) -> BaseMessage:
 class DeferredStructuredOutputMiddleware(AgentMiddleware):
     """Apply ``response_format`` only on a final formatting turn.
 
-    ``provider_native`` is True for providers whose API only accepts
-    ``tool_choice="auto"`` (Meta): the formatting turn then uses the provider-
-    native json_schema strategy (``ProviderStrategy``) instead of the default
-    forced tool call, which those providers reject with a 400.
+    ``format_mode`` selects how that final turn constrains the output, for
+    providers whose API rejects the langchain default (a forced tool call):
+
+    - ``FORMAT_TOOL`` (default): forced tool call — the provider enforces the
+      schema.
+    - ``FORMAT_PROVIDER_NATIVE``: provider-native json_schema (``ProviderStrategy``)
+      — for providers that only allow ``tool_choice="auto"`` (Meta).
+    - ``FORMAT_JSON_OBJECT``: legacy json_object mode — for providers that reject
+      both a forced tool call and json_schema (DeepSeek's thinking mode). The
+      schema rides in the prompt and the parsed JSON is validated here.
     """
 
-    def __init__(self, provider_native: bool = False) -> None:
+    def __init__(self, format_mode: str = FORMAT_TOOL) -> None:
         super().__init__()
-        self.provider_native = provider_native
+        self.format_mode = format_mode
 
     async def awrap_model_call(
         self,
@@ -168,18 +245,27 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
         if loop_continues:
             return response
 
-        # Final answer reached: a constrained call formats it. The resolved
-        # response_format (strategy + ToolStrategy tool names from agent setup)
-        # is passed through untouched — except for providers whose API only
-        # allows tool_choice="auto" (Meta), which reject the forced tool call
-        # with a 400: those format via the provider-native json_schema strategy.
-        # Each failed attempt's messages are dropped entirely — they may carry a
-        # dangling structured-output tool call that must not reach state — and the
+        # Final answer reached: a constrained call formats it. Each failed
+        # attempt's messages are dropped entirely — they may carry a dangling
+        # structured-output tool call that must not reach state — and the
         # rejection is fed back to the next attempt.
+        if self.format_mode == FORMAT_JSON_OBJECT:
+            return await self._format_via_json_object(request, handler, response)
+        return await self._format_via_strategy(request, handler, response)
+
+    async def _format_via_strategy(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+        response: ModelResponse,
+    ) -> ModelResponse:
+        """Format via langchain's structured-output machinery: the default forced
+        tool call, or (Meta) the provider-native json_schema strategy. The parsed
+        result flows back on ``structured_response``."""
         conversation = [*request.messages, *response.result]
         instruction = FORMAT_INSTRUCTION
         response_format = request.response_format
-        if self.provider_native:
+        if self.format_mode == FORMAT_PROVIDER_NATIVE:
             response_format = ProviderStrategy(schema=_schema_of(response_format))
         error: str | None = None
         for _ in range(MAX_FORMAT_ATTEMPTS):
@@ -193,12 +279,10 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
                 format_response.structured_response, response_format
             )
             if error is None:
-                return ModelResponse(
-                    result=[
-                        *response.result,
-                        *(_tag(m) for m in format_response.result),
-                    ],
-                    structured_response=format_response.structured_response,
+                return self._combine(
+                    response,
+                    format_response.result,
+                    format_response.structured_response,
                 )
             logger.warning(
                 "structured-output rejected: %s | shape=%s",
@@ -208,4 +292,66 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
             instruction = FORMAT_RETRY_INSTRUCTION.format(error=error)
         raise StructuredOutputError(
             f"Model failed to produce a valid structured response: {error}"
+        )
+
+    async def _format_via_json_object(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+        response: ModelResponse,
+    ) -> ModelResponse:
+        """Format via legacy json_object mode (DeepSeek thinking): bind
+        ``response_format={"type": "json_object"}`` so the provider emits bare
+        JSON, carry the schema in the prompt (json_object enforces only "is
+        JSON", not the shape), then parse and validate here. No forced tool call
+        or json_schema is ever sent, both of which that API rejects."""
+        conversation = [*request.messages, *response.result]
+        schema = _schema_of(request.response_format)
+        schema_text = json.dumps(schema)
+        instruction = JSON_OBJECT_INSTRUCTION.format(schema=schema_text)
+        model_settings = {
+            **request.model_settings,
+            "response_format": {"type": "json_object"},
+        }
+        error: str | None = None
+        for _ in range(MAX_FORMAT_ATTEMPTS):
+            # response_format=None so no strategy is applied (no tool_choice, no
+            # json_schema); tools dropped so the turn only emits the JSON answer.
+            format_response = await handler(
+                request.override(
+                    messages=[*conversation, HumanMessage(instruction)],
+                    response_format=None,
+                    tools=[],
+                    model_settings=model_settings,
+                )
+            )
+            value, error = _parse_json_object(format_response.result)
+            if error is None:
+                error = validate_structured_response(value, request.response_format)
+            if error is None:
+                return self._combine(response, format_response.result, value)
+            logger.warning(
+                "structured-output rejected: %s | shape=%s",
+                error,
+                _payload_shape(value),
+            )
+            instruction = JSON_OBJECT_RETRY_INSTRUCTION.format(
+                error=error, schema=schema_text
+            )
+        raise StructuredOutputError(
+            f"Model failed to produce a valid structured response: {error}"
+        )
+
+    @staticmethod
+    def _combine(
+        response: ModelResponse,
+        format_messages: list[BaseMessage],
+        structured_response: Any,
+    ) -> ModelResponse:
+        """Prose answer + tagged formatting messages in state, parsed object on
+        ``structured_response``. Formatting messages are tagged so read paths can
+        keep them out of the rendered chat history."""
+        return ModelResponse(
+            result=[*response.result, *(_tag(m) for m in format_messages)],
+            structured_response=structured_response,
         )

--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -25,13 +25,6 @@ ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
     {"claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-5"}
 )
 
-# Providers whose API only accepts tool_choice="auto" (no "required" / named
-# function). The structured-output formatting turn routes these to provider-
-# native json_schema (ProviderStrategy) instead of a forced tool call — Meta's
-# Model API rejects forced tool_choice with a 400. Forced-tool-call providers
-# (deepseek etc.) keep the default strategy. See DeferredStructuredOutputMiddleware.
-AUTO_ONLY_TOOL_CHOICE_PROVIDERS: frozenset[str] = frozenset({"meta"})
-
 # OpenRouter catalog: our model id -> (OpenRouter slug, GLM `reasoning_effort`).
 # GLM 5.2 exposes two thinking levels; "max" is its deep-reasoning default, "high"
 # is lighter. Each is surfaced to users as its own model.

--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -25,6 +25,12 @@ ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
     {"claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-5"}
 )
 
+# Providers whose API only accepts tool_choice="auto" (no "required" / named
+# function). Structured output formats via provider-native json_schema
+# (ProviderStrategy) on these instead of a forced tool call — Meta's Model API
+# rejects forced tool_choice with a 400. See DeferredStructuredOutputMiddleware.
+AUTO_ONLY_TOOL_CHOICE_PROVIDERS: frozenset[str] = frozenset({"meta"})
+
 # OpenRouter catalog: our model id -> (OpenRouter slug, GLM `reasoning_effort`).
 # GLM 5.2 exposes two thinking levels; "max" is its deep-reasoning default, "high"
 # is lighter. Each is surfaced to users as its own model.

--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -25,6 +25,13 @@ ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
     {"claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-5"}
 )
 
+# Providers whose API only accepts tool_choice="auto" (no "required" / named
+# function). The structured-output formatting turn routes these to provider-
+# native json_schema (ProviderStrategy) instead of a forced tool call — Meta's
+# Model API rejects forced tool_choice with a 400. Forced-tool-call providers
+# (deepseek etc.) keep the default strategy. See DeferredStructuredOutputMiddleware.
+AUTO_ONLY_TOOL_CHOICE_PROVIDERS: frozenset[str] = frozenset({"meta"})
+
 # OpenRouter catalog: our model id -> (OpenRouter slug, GLM `reasoning_effort`).
 # GLM 5.2 exposes two thinking levels; "max" is its deep-reasoning default, "high"
 # is lighter. Each is surfaced to users as its own model.

--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -25,12 +25,6 @@ ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
     {"claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-5"}
 )
 
-# Providers whose API only accepts tool_choice="auto" (no "required" / named
-# function). Structured output formats via provider-native json_schema
-# (ProviderStrategy) on these instead of a forced tool call — Meta's Model API
-# rejects forced tool_choice with a 400. See DeferredStructuredOutputMiddleware.
-AUTO_ONLY_TOOL_CHOICE_PROVIDERS: frozenset[str] = frozenset({"meta"})
-
 # OpenRouter catalog: our model id -> (OpenRouter slug, GLM `reasoning_effort`).
 # GLM 5.2 exposes two thinking levels; "max" is its deep-reasoning default, "high"
 # is lighter. Each is surfaced to users as its own model.
@@ -104,10 +98,15 @@ class ChatModelFactory:
             case "openai":
                 return ChatOpenAI(model=model_id, api_key=api_key)
             case "deepseek":
+                # Reasoning enabled. max_tokens caps the answer so json_object
+                # structured output isn't truncated mid-string (DeepSeek's JSON
+                # mode guide warns about this); 32768 matches the other
+                # reasoning providers here.
                 return ChatDeepSeek(
                     model=model_id,
                     api_key=api_key,
-                    extra_body={"thinking": {"type": "disabled"}},
+                    max_tokens=32768,
+                    extra_body={"thinking": {"type": "enabled"}},
                 )
             case "anthropic":
                 kwargs: dict = {}

--- a/backend/tests/agents/test_runtime.py
+++ b/backend/tests/agents/test_runtime.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock, patch
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 
 from app.agents.runtime import Agent
-from app.agents.structured_output import DeferredStructuredOutputMiddleware
+from app.agents.structured_output import (
+    FORMAT_JSON_OBJECT,
+    FORMAT_PROVIDER_NATIVE,
+    FORMAT_TOOL,
+    DeferredStructuredOutputMiddleware,
+)
 from app.agents.tool_errors import ToolErrorMiddleware
 from app.model_providers.catalog import Model
 
@@ -44,11 +49,12 @@ def test_build_agent_forwards_output_schema(mock_create_agent):
 
 
 @patch("app.agents.runtime.create_agent")
-def test_build_agent_routes_auto_only_provider_to_provider_native(mock_create_agent):
-    """The formatting middleware is flagged provider_native for providers whose
-    API only allows tool_choice='auto' (Meta), and not for others — this is what
-    keeps Meta off the forced-tool-call path (and must reach the non-sandbox
-    create_agent middleware, not just the sandbox one)."""
+def test_build_agent_routes_provider_to_format_mode(mock_create_agent):
+    """The formatting middleware's format_mode is resolved per provider (and must
+    reach the non-sandbox create_agent middleware, not just the sandbox one):
+    Meta rejects a forced tool call but takes json_schema (provider_native);
+    DeepSeek thinking rejects both, so it uses json_object; everyone else uses
+    the default forced tool call."""
     schema = {
         "title": "answer",
         "type": "object",
@@ -56,11 +62,12 @@ def test_build_agent_routes_auto_only_provider_to_provider_native(mock_create_ag
         "required": ["answer"],
     }
     models = [
-        Model(name="auto-model", provider="meta"),
-        Model(name="forced-model", provider="deepseek"),
+        Model(name="meta-model", provider="meta"),
+        Model(name="deepseek-model", provider="deepseek"),
+        Model(name="openai-model", provider="openai"),
     ]
 
-    def provider_native_for(model_id: str) -> bool:
+    def format_mode_for(model_id: str) -> str:
         agent = _build_agent()
         agent.thread.model_id = model_id
         with patch("app.agents.runtime.MODELS", models):
@@ -69,10 +76,11 @@ def test_build_agent_routes_auto_only_provider_to_provider_native(mock_create_ag
         deferred = next(
             m for m in middleware if isinstance(m, DeferredStructuredOutputMiddleware)
         )
-        return deferred.provider_native
+        return deferred.format_mode
 
-    assert provider_native_for("auto-model") is True
-    assert provider_native_for("forced-model") is False
+    assert format_mode_for("meta-model") == FORMAT_PROVIDER_NATIVE
+    assert format_mode_for("deepseek-model") == FORMAT_JSON_OBJECT
+    assert format_mode_for("openai-model") == FORMAT_TOOL
 
 
 @patch("app.agents.runtime.create_agent")

--- a/backend/tests/agents/test_runtime.py
+++ b/backend/tests/agents/test_runtime.py
@@ -5,6 +5,7 @@ from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from app.agents.runtime import Agent
 from app.agents.structured_output import DeferredStructuredOutputMiddleware
 from app.agents.tool_errors import ToolErrorMiddleware
+from app.model_providers.catalog import Model
 
 
 def _build_agent(*, has_code_interpreter: bool = False, middleware=None) -> Agent:
@@ -40,6 +41,38 @@ def test_build_agent_forwards_output_schema(mock_create_agent):
     # model skips tools and fabricates values to satisfy the constraint.
     middleware = mock_create_agent.call_args.kwargs["middleware"]
     assert any(isinstance(m, DeferredStructuredOutputMiddleware) for m in middleware)
+
+
+@patch("app.agents.runtime.create_agent")
+def test_build_agent_routes_auto_only_provider_to_provider_native(mock_create_agent):
+    """The formatting middleware is flagged provider_native for providers whose
+    API only allows tool_choice='auto' (Meta), and not for others — this is what
+    keeps Meta off the forced-tool-call path (and must reach the non-sandbox
+    create_agent middleware, not just the sandbox one)."""
+    schema = {
+        "title": "answer",
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+    }
+    models = [
+        Model(name="auto-model", provider="meta"),
+        Model(name="forced-model", provider="deepseek"),
+    ]
+
+    def provider_native_for(model_id: str) -> bool:
+        agent = _build_agent()
+        agent.thread.model_id = model_id
+        with patch("app.agents.runtime.MODELS", models):
+            agent._build_agent(checkpointer=None, output_schema=schema)
+        middleware = mock_create_agent.call_args.kwargs["middleware"]
+        deferred = next(
+            m for m in middleware if isinstance(m, DeferredStructuredOutputMiddleware)
+        )
+        return deferred.provider_native
+
+    assert provider_native_for("auto-model") is True
+    assert provider_native_for("forced-model") is False
 
 
 @patch("app.agents.runtime.create_agent")

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel
 
 from app.agents.structured_output import (
     FORMAT_INSTRUCTION,
+    FORMAT_JSON_OBJECT,
+    FORMAT_PROVIDER_NATIVE,
     MAX_FORMAT_ATTEMPTS,
     DeferredStructuredOutputMiddleware,
     is_structured_output_artifact,
@@ -151,7 +153,7 @@ async def test_provider_native_formats_with_provider_strategy():
     """Providers whose API only allows tool_choice='auto' (Meta) format via the
     provider-native json_schema strategy (ProviderStrategy) from the first call —
     no forced tool_choice is ever sent, and no wasted rejected request."""
-    middleware = DeferredStructuredOutputMiddleware(provider_native=True)
+    middleware = DeferredStructuredOutputMiddleware(format_mode=FORMAT_PROVIDER_NATIVE)
     request = _make_request()  # response_format is the raw SCHEMA dict
     final_answer = AIMessage("2 + 2 = 4")
     formatted = AIMessage('{"answer": 4}')
@@ -178,6 +180,80 @@ async def test_provider_native_formats_with_provider_strategy():
     assert not isinstance(fmt, ToolStrategy)
     assert fmt.schema == SCHEMA
     assert response.structured_response == {"answer": 4}
+
+
+async def test_json_object_mode_parses_and_validates_plain_json():
+    """Providers that reject both a forced tool call and json_schema (DeepSeek
+    thinking) format via legacy json_object: the turn binds
+    response_format=json_object, drops tools, carries the schema in the prompt,
+    and the JSON text answer is parsed and validated here — no strategy is set,
+    so structured_response is produced from the message content, not the model."""
+    middleware = DeferredStructuredOutputMiddleware(format_mode=FORMAT_JSON_OBJECT)
+    request = _make_request()  # raw SCHEMA dict
+    final_answer = AIMessage("2 + 2 = 4")
+    # json_object returns bare JSON text; no strategy, so structured_response=None.
+    formatted = AIMessage('{"answer": 4}')
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[final_answer]),
+                ModelResponse(result=[formatted]),
+            ],
+            calls,
+        ),
+    )
+
+    assert len(calls) == 2
+    assert calls[0].response_format is None  # loop turn unconstrained
+    fmt_call = calls[1]
+    # No strategy (no forced tool_choice, no json_schema); json_object bound via
+    # model_settings; tools dropped so the turn only emits the JSON answer.
+    assert fmt_call.response_format is None
+    assert fmt_call.tools == []
+    assert fmt_call.model_settings["response_format"] == {"type": "json_object"}
+    # The schema rides in the prompt (json_object enforces only "is JSON").
+    assert '"answer"' in fmt_call.messages[-1].content
+    # Parsed from the message content and validated here.
+    assert response.structured_response == {"answer": 4}
+    prose, structured = response.result
+    assert prose == final_answer
+    assert is_structured_output_artifact(structured)
+    assert not is_structured_output_artifact(prose)
+
+
+async def test_json_object_mode_retries_on_invalid_json():
+    """A non-JSON answer is rejected and retried with the rejection fed back;
+    the failed attempt's messages never reach state."""
+    middleware = DeferredStructuredOutputMiddleware(format_mode=FORMAT_JSON_OBJECT)
+    request = _make_request()
+    final_answer = AIMessage("2 + 2 = 4")
+    garbage = AIMessage("here you go: not json")
+    formatted = AIMessage('{"answer": 4}')
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[final_answer]),
+                ModelResponse(result=[garbage]),
+                ModelResponse(result=[formatted]),
+            ],
+            calls,
+        ),
+    )
+
+    assert len(calls) == 3
+    assert "rejected" in calls[2].messages[-1].content
+    assert response.structured_response == {"answer": 4}
+    assert garbage not in response.result
+    assert [m.content for m in response.result] == [
+        final_answer.content,
+        formatted.content,
+    ]
 
 
 async def test_invalid_formatting_result_retries_with_error_feedback():

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -147,48 +147,37 @@ async def test_final_turn_adds_constrained_formatting_call():
     assert not is_structured_output_artifact(prose)
 
 
-async def test_auto_only_provider_retries_with_provider_native_strategy():
-    """A provider that rejects a forced tool call (Meta's tool_choice 400) is
-    retried on the formatting turn with the provider-native json_schema strategy
-    (ProviderStrategy), which carries no forced tool_choice."""
-    middleware = DeferredStructuredOutputMiddleware()
+async def test_provider_native_formats_with_provider_strategy():
+    """Providers whose API only allows tool_choice='auto' (Meta) format via the
+    provider-native json_schema strategy (ProviderStrategy) from the first call —
+    no forced tool_choice is ever sent, and no wasted rejected request."""
+    middleware = DeferredStructuredOutputMiddleware(provider_native=True)
     request = _make_request()  # response_format is the raw SCHEMA dict
+    final_answer = AIMessage("2 + 2 = 4")
     formatted = AIMessage('{"answer": 4}')
     calls: list[ModelRequest] = []
 
-    async def handler(req: ModelRequest) -> ModelResponse:
-        calls.append(req)
-        if len(calls) == 1:
-            return ModelResponse(result=[AIMessage("2 + 2 = 4")])  # loop turn
-        if not isinstance(req.response_format, ProviderStrategy):
-            raise ValueError('only "auto" is supported for `tool_choice`')
-        return ModelResponse(result=[formatted], structured_response={"answer": 4})
+    response = await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[final_answer]),
+                ModelResponse(result=[formatted], structured_response={"answer": 4}),
+            ],
+            calls,
+        ),
+    )
 
-    response = await middleware.awrap_model_call(request, handler)
-
-    # Loop turn, rejected forced turn, then the native retry.
-    assert len(calls) == 3
-    assert calls[1].response_format == SCHEMA  # forced attempt (rejected)
-    assert isinstance(calls[2].response_format, ProviderStrategy)  # native retry
-    assert calls[2].response_format.schema == SCHEMA
+    # One loop turn + one formatting turn: no extra rejected request.
+    assert len(calls) == 2
+    assert calls[0].response_format is None  # loop turn unconstrained
+    # Formatting turn wraps the schema in the provider-native strategy, not a
+    # ToolStrategy (which would emit a forced tool_choice).
+    fmt = calls[1].response_format
+    assert isinstance(fmt, ProviderStrategy)
+    assert not isinstance(fmt, ToolStrategy)
+    assert fmt.schema == SCHEMA
     assert response.structured_response == {"answer": 4}
-
-
-async def test_unrelated_formatting_error_is_not_swallowed():
-    """A 400 that isn't the tool_choice limitation must propagate, not trigger
-    the provider-native retry."""
-    middleware = DeferredStructuredOutputMiddleware()
-    request = _make_request()
-    calls: list[ModelRequest] = []
-
-    async def handler(req: ModelRequest) -> ModelResponse:
-        calls.append(req)
-        if len(calls) == 1:
-            return ModelResponse(result=[AIMessage("2 + 2 = 4")])
-        raise ValueError("context length exceeded")
-
-    with pytest.raises(ValueError, match="context length"):
-        await middleware.awrap_model_call(request, handler)
 
 
 async def test_invalid_formatting_result_retries_with_error_feedback():

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -147,64 +147,48 @@ async def test_final_turn_adds_constrained_formatting_call():
     assert not is_structured_output_artifact(prose)
 
 
-async def test_auto_only_provider_uses_provider_native_strategy():
-    """Providers whose API only allows tool_choice='auto' (Meta) format via
-    provider-native json_schema (ProviderStrategy), never a forced tool call —
-    the forced call is what those providers reject with a 400."""
-    middleware = DeferredStructuredOutputMiddleware(supports_forced_tool_choice=False)
+async def test_auto_only_provider_retries_with_provider_native_strategy():
+    """A provider that rejects a forced tool call (Meta's tool_choice 400) is
+    retried on the formatting turn with the provider-native json_schema strategy
+    (ProviderStrategy), which carries no forced tool_choice."""
+    middleware = DeferredStructuredOutputMiddleware()
     request = _make_request()  # response_format is the raw SCHEMA dict
-    final_answer = AIMessage("2 + 2 = 4")
     formatted = AIMessage('{"answer": 4}')
     calls: list[ModelRequest] = []
 
-    response = await middleware.awrap_model_call(
-        request,
-        _handler_recording(
-            [
-                ModelResponse(result=[final_answer]),
-                ModelResponse(result=[formatted], structured_response={"answer": 4}),
-            ],
-            calls,
-        ),
-    )
+    async def handler(req: ModelRequest) -> ModelResponse:
+        calls.append(req)
+        if len(calls) == 1:
+            return ModelResponse(result=[AIMessage("2 + 2 = 4")])  # loop turn
+        if not isinstance(req.response_format, ProviderStrategy):
+            raise ValueError('only "auto" is supported for `tool_choice`')
+        return ModelResponse(result=[formatted], structured_response={"answer": 4})
 
-    assert len(calls) == 2
-    # Loop turn stays unconstrained.
-    assert calls[0].response_format is None
-    # Formatting turn: schema wrapped in the provider-native strategy, not a
-    # ToolStrategy (which would emit a forced tool_choice).
-    fmt = calls[1].response_format
-    assert isinstance(fmt, ProviderStrategy)
-    assert not isinstance(fmt, ToolStrategy)
-    assert fmt.schema == SCHEMA
-    # The validated structured_response still flows through unchanged.
+    response = await middleware.awrap_model_call(request, handler)
+
+    # Loop turn, rejected forced turn, then the native retry.
+    assert len(calls) == 3
+    assert calls[1].response_format == SCHEMA  # forced attempt (rejected)
+    assert isinstance(calls[2].response_format, ProviderStrategy)  # native retry
+    assert calls[2].response_format.schema == SCHEMA
     assert response.structured_response == {"answer": 4}
 
 
-async def test_forced_tool_choice_provider_keeps_resolved_strategy():
-    """The default (deepseek etc.) path is untouched: the formatting turn keeps
-    the strategy resolved at agent setup, so those providers don't regress."""
-    middleware = DeferredStructuredOutputMiddleware()  # supports_forced_tool_choice=True
+async def test_unrelated_formatting_error_is_not_swallowed():
+    """A 400 that isn't the tool_choice limitation must propagate, not trigger
+    the provider-native retry."""
+    middleware = DeferredStructuredOutputMiddleware()
     request = _make_request()
     calls: list[ModelRequest] = []
 
-    await middleware.awrap_model_call(
-        request,
-        _handler_recording(
-            [
-                ModelResponse(result=[AIMessage("2 + 2 = 4")]),
-                ModelResponse(
-                    result=[AIMessage('{"answer": 4}')],
-                    structured_response={"answer": 4},
-                ),
-            ],
-            calls,
-        ),
-    )
+    async def handler(req: ModelRequest) -> ModelResponse:
+        calls.append(req)
+        if len(calls) == 1:
+            return ModelResponse(result=[AIMessage("2 + 2 = 4")])
+        raise ValueError("context length exceeded")
 
-    # Unchanged: the original response_format is passed through as-is.
-    assert calls[1].response_format == SCHEMA
-    assert not isinstance(calls[1].response_format, ProviderStrategy)
+    with pytest.raises(ValueError, match="context length"):
+        await middleware.awrap_model_call(request, handler)
 
 
 async def test_invalid_formatting_result_retries_with_error_feedback():

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
-from langchain.agents.structured_output import ToolStrategy
+from langchain.agents.structured_output import ProviderStrategy, ToolStrategy
 from langchain_core.messages import AIMessage, HumanMessage
 from pydantic import BaseModel
 
@@ -145,6 +145,66 @@ async def test_final_turn_adds_constrained_formatting_call():
     # rendered chat history; the prose answer is not.
     assert is_structured_output_artifact(structured)
     assert not is_structured_output_artifact(prose)
+
+
+async def test_auto_only_provider_uses_provider_native_strategy():
+    """Providers whose API only allows tool_choice='auto' (Meta) format via
+    provider-native json_schema (ProviderStrategy), never a forced tool call —
+    the forced call is what those providers reject with a 400."""
+    middleware = DeferredStructuredOutputMiddleware(supports_forced_tool_choice=False)
+    request = _make_request()  # response_format is the raw SCHEMA dict
+    final_answer = AIMessage("2 + 2 = 4")
+    formatted = AIMessage('{"answer": 4}')
+    calls: list[ModelRequest] = []
+
+    response = await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[final_answer]),
+                ModelResponse(result=[formatted], structured_response={"answer": 4}),
+            ],
+            calls,
+        ),
+    )
+
+    assert len(calls) == 2
+    # Loop turn stays unconstrained.
+    assert calls[0].response_format is None
+    # Formatting turn: schema wrapped in the provider-native strategy, not a
+    # ToolStrategy (which would emit a forced tool_choice).
+    fmt = calls[1].response_format
+    assert isinstance(fmt, ProviderStrategy)
+    assert not isinstance(fmt, ToolStrategy)
+    assert fmt.schema == SCHEMA
+    # The validated structured_response still flows through unchanged.
+    assert response.structured_response == {"answer": 4}
+
+
+async def test_forced_tool_choice_provider_keeps_resolved_strategy():
+    """The default (deepseek etc.) path is untouched: the formatting turn keeps
+    the strategy resolved at agent setup, so those providers don't regress."""
+    middleware = DeferredStructuredOutputMiddleware()  # supports_forced_tool_choice=True
+    request = _make_request()
+    calls: list[ModelRequest] = []
+
+    await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[AIMessage("2 + 2 = 4")]),
+                ModelResponse(
+                    result=[AIMessage('{"answer": 4}')],
+                    structured_response={"answer": 4},
+                ),
+            ],
+            calls,
+        ),
+    )
+
+    # Unchanged: the original response_format is passed through as-is.
+    assert calls[1].response_format == SCHEMA
+    assert not isinstance(calls[1].response_format, ProviderStrategy)
 
 
 async def test_invalid_formatting_result_retries_with_error_feedback():


### PR DESCRIPTION
Le problème

La sortie structurée (output_schema) passe par DeferredStructuredOutputMiddleware : le schéma est mis de côté pendant la boucle ReAct, puis appliqué sur un dernier tour de formatage. Sur ce tour, langchain résout le schéma en ToolStrategy, qui envoie tool_choice: "required" (ou une fonction nommée). L'API de Meta (muse-spark-1.1) n'accepte que tool_choice: "auto" → 400 → tout le run échoue. deepseek et les autres acceptent le tool_choice forcé, d'où l'absence de bug chez eux.

La correction (1 seul fichier de prod)

Sur le tour de formatage, j'intercepte le 400 spécifique au tool_choice et je rejoue le tour avec la stratégie native du fournisseur — Prose_format: {type:"json_schema"} — qui ne force aucun tool_choice. La doc Metconfirme que ce mschéma nativement.
                                                           Tout le reste estleMAX_FORMAT_ATTEMPTS, la validation jsonschema, le          StructuredOutputEgging des messagesde formatage. La détection se fait sur le message d'erreur (tool_choice + auisseurs codée endur : n'importe quel fournisseur « auto-only » est couvert automatiquement. ontext length »)sont propagés, pas avalés (test dédié).

Pourquoi cette version plutôt que la première                
Ma première version ajoutait un flag supports_forced_tool_chopropagé à traversent, build,build_runnable) → 3 fichiers, beaucoup de plomberie. La versisimplifiée ne tou(le fichier que tuavais ouvert) + les tests.                                   
Compromis assumé, marqué d'un commentaire ponytail: : un 400 vide » par tour durs auto-only(rejet immédiat côté API, sans génération de tokens). Si ce cdevient gênant un de capacité —l'upgrade path est documenté dans le code.                   
Vérification                                                 
- Tests : 23 (fichier ciblé) et 272 sur tests/agents/ — vertsLint OK.
- Sonde sur les vraies APIs : le 400 exact reproduit sur Metala voie native re (via OpenRouter), Claude (sonnet-5, sonnet-4-6, haiku-4-5, thinking activé) et deepseek accepten seul Meta étaitconcerné.
