### PR TITLE
fix(agents): drop tools on Meta formatting turn to prevent non-ASCII mojibake

### DIFF
--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -265,14 +265,28 @@ class DeferredStructuredOutputMiddleware(AgentMiddleware):
         conversation = [*request.messages, *response.result]
         instruction = FORMAT_INSTRUCTION
         response_format = request.response_format
+        overrides: dict[str, Any] = {}
         if self.format_mode == FORMAT_PROVIDER_NATIVE:
             response_format = ProviderStrategy(schema=_schema_of(response_format))
+            # Drop the agent's tools on the formatting turn. It only reformats the
+            # final answer (the ReAct loop already reached one), so the tools are
+            # dead weight here — and on the provider-native path langchain's
+            # create_agent binds them with strict=True (its ProviderStrategy
+            # branch, factory.py). Under strict tools + streaming, Meta's Model API
+            # intermittently escapes non-ASCII with an extra "00" (U+00E9 ->
+            # the 6-hex "\u0000e9" not "\u00e9"), which json.loads then reads as
+            # NUL + "e9" -- mojibake in the reply. No
+            # tools on the turn => no strict binding => clean UTF-8.
+            # ponytail: scoped to provider-native; other providers keep their tools
+            # on the formatting turn (they don't force strict, so they're unaffected).
+            overrides["tools"] = []
         error: str | None = None
         for _ in range(MAX_FORMAT_ATTEMPTS):
             format_response = await handler(
                 request.override(
                     messages=[*conversation, HumanMessage(instruction)],
                     response_format=response_format,
+                    **overrides,
                 )
             )
             error = validate_structured_response(

--- a/backend/tests/agents/test_structured_output.py
+++ b/backend/tests/agents/test_structured_output.py
@@ -182,6 +182,39 @@ async def test_provider_native_formats_with_provider_strategy():
     assert response.structured_response == {"answer": 4}
 
 
+async def test_provider_native_drops_tools_on_formatting_turn():
+    """On the provider-native path the formatting turn drops the agent's tools.
+
+    The turn only reformats the final answer, and langchain's create_agent binds
+    tools with strict=True for ProviderStrategy — under which Meta's streaming API
+    intermittently mangles non-ASCII (e.g. "é" comes back as NUL + "e9"). Dropping
+    the tools removes that strict binding. The loop turn still carries the tools
+    (the agent reasons and acts with them); only the final formatting turn drops
+    them.
+    """
+    middleware = DeferredStructuredOutputMiddleware(format_mode=FORMAT_PROVIDER_NATIVE)
+    tools = [{"name": "search"}]
+    request = _make_request().override(tools=tools)
+    calls: list[ModelRequest] = []
+
+    await middleware.awrap_model_call(
+        request,
+        _handler_recording(
+            [
+                ModelResponse(result=[AIMessage("2 + 2 = 4")]),
+                ModelResponse(
+                    result=[AIMessage('{"answer": 4}')],
+                    structured_response={"answer": 4},
+                ),
+            ],
+            calls,
+        ),
+    )
+
+    assert calls[0].tools == tools  # loop turn keeps the agent's tools
+    assert calls[1].tools == []  # formatting turn drops them
+
+
 async def test_json_object_mode_parses_and_validates_plain_json():
     """Providers that reject both a forced tool call and json_schema (DeepSeek
     thinking) format via legacy json_object: the turn binds


### PR DESCRIPTION
## Problème

Sur le chemin de sortie structurée **natif de Meta** (`muse-spark-1.1`), les caractères accentués et emojis revenaient en mojibake dans `structured_response` (ex. `é` relu comme `NUL` suivi de `e9`), alors que le texte libre du modèle reste propre.

## Cause

Sur le chemin `ProviderStrategy` (Meta), `create_agent` (langchain, `factory.py`) lie les tools avec `strict=True`. Sous **tools stricts + streaming**, l'API Meta insère par intermittence un `00` en trop dans l'échappement Unicode (6 chiffres hex au lieu de 4), que `json.loads` relit ensuite en `NUL` + reste littéral — d'où le mojibake.

Tout le reste est propre (octets bruts de Meta, parsing langchain, sérialisation du checkpoint, aller-retour Postgres) — seul ce chemin est touché.

## Correctif

Le tour de formatage ne fait que **reformater la réponse finale** : il n'a pas besoin des tools de l'agent. On les retire (`tools=[]`) sur le chemin natif, exactement comme `_format_via_json_object` le fait déjà pour DeepSeek. Sans tools, langchain n'a plus rien à lier en `strict=True`, et Meta renvoie de l'UTF-8 propre. Portée limitée à Meta ; les autres providers ne changent pas.

## Vérification

- `275 passed` sur `tests/agents/`, `ruff` OK. Nouveau test : `test_provider_native_drops_tools_on_formatting_turn`.
- ⚠️ Bug **intermittent** et non reproductible de façon fiable hors production (il faut une sortie française accentuée + l'aléa du modèle). À confirmer sur le benchmark réel en comptant les octets `NUL` dans `structured_response` avant/après.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mojibake in Meta’s native structured output by dropping tools on the final formatting turn. Accented characters and emojis now serialize correctly in `structured_response` without affecting other providers.

- **Bug Fixes**
  - On the provider-native formatting turn, pass `tools=[]` to avoid `langchain`’s strict tool binding with `ProviderStrategy`.
  - This sidesteps Meta’s intermittent streaming escape bug that produced `NUL`-prefixed sequences (e.g., `\u0000e9`).
  - Scope limited to Meta’s native path; reasoning loop keeps tools, only the final formatting turn drops them.
  - Added test `test_provider_native_drops_tools_on_formatting_turn` to verify behavior.

<sup>Written for commit 1f5bf4a37347eb045ec4a1fb7f2628c1a7d97246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

