### PR TITLE
fix(agents): seed MCP tool map on connect so explicit save persists all servers

### DIFF
--- a/backend/app/agents/toolset.py
+++ b/backend/app/agents/toolset.py
@@ -102,9 +102,7 @@ def _build_tool_ui_metadata(
     if not resource_uri:
         return None
 
-    server_name = _resolve_server_name_from_prefixed_tool_name(
-        tool.name, server_names
-    )
+    server_name = _resolve_server_name_from_prefixed_tool_name(tool.name, server_names)
     if not server_name:
         return None
 
@@ -161,7 +159,9 @@ def _assemble_agent_tools(
     server_names = list(server_id_by_name.keys())
     agent_tools: list[AgentTool] = []
     for server_id, lc_tools in tools_by_server:
-        settings = tool_settings.get(str(server_id), {})
+        # A null map means "never synced" — treat it as no configured tools
+        # rather than letting None.items() blow up the whole agent build.
+        settings = tool_settings.get(str(server_id)) or {}
         allowed_names = {
             server_id + "_" + t
             for t, status in settings.items()

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -78,6 +78,25 @@ export default function AgentMCPServer({
 		onToolsChange?.({ ...materializeTools(tools), [toolName]: status });
 	};
 
+	// Seed the draft's tool map the first time a connected server's tools become
+	// known, so a Save persists a complete map instead of null (= "never synced",
+	// which the backend treats as zero usable tools). Only seeds a null binding —
+	// an explicit map (even empty) is left untouched.
+	const seedIfUnsynced = useCallback(
+		(fetchedTools: MCPServerTool[]) => {
+			if (readOnly || binding.tools !== null) return;
+			onToolsChange?.(
+				Object.fromEntries(
+					fetchedTools.map((tool) => [
+						tool.name,
+						"always_allow" as ToolStatus,
+					]),
+				),
+			);
+		},
+		[readOnly, binding.tools, onToolsChange],
+	);
+
 	const fetchTools = useCallback(async () => {
 		setIsLoading(true);
 		try {
@@ -85,6 +104,7 @@ export default function AgentMCPServer({
 			const fetchedTools = res.data as MCPServerTool[];
 			setTools(fetchedTools);
 			setToolsFetched(true);
+			seedIfUnsynced(fetchedTools);
 		} catch (error: unknown) {
 			// Check if this is an OAuth authorization required error
 			if (
@@ -125,17 +145,7 @@ export default function AgentMCPServer({
 							setTools(fetchedTools);
 							setToolsFetched(true);
 							setIsLoading(false);
-
-							if (!readOnly && binding.tools === null) {
-								onToolsChange?.(
-									Object.fromEntries(
-										fetchedTools.map((tool) => [
-											tool.name,
-											"always_allow" as ToolStatus,
-										]),
-									),
-								);
-							}
+							seedIfUnsynced(fetchedTools);
 
 							if (popup && !popup.closed) {
 								popup.close();
@@ -162,7 +172,7 @@ export default function AgentMCPServer({
 		} finally {
 			setIsLoading(false);
 		}
-	}, [server.id, readOnly, binding.tools, onToolsChange]);
+	}, [server.id, seedIfUnsynced]);
 
 	const handleConnect = async () => {
 		await fetchTools();

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -17,6 +17,12 @@ interface AgentMCPServerProps {
 	readOnly?: boolean;
 	/** Draft update: the complete per-tool map for this server. */
 	onToolsChange?: (tools: Record<string, ToolStatus>) => void;
+	/**
+	 * Draft update: seed a never-synced binding. Applied conditionally against
+	 * the latest state (only fills a still-null map), so parallel seeds from
+	 * sibling servers merge instead of clobbering each other.
+	 */
+	onSeedTools?: (tools: Record<string, ToolStatus>) => void;
 	/** Draft update: detach this server. */
 	onRemove?: () => void;
 }
@@ -31,6 +37,7 @@ export default function AgentMCPServer({
 	binding,
 	readOnly,
 	onToolsChange,
+	onSeedTools,
 	onRemove,
 }: AgentMCPServerProps) {
 	const [isExpanded, setIsExpanded] = useState(false);
@@ -80,12 +87,13 @@ export default function AgentMCPServer({
 
 	// Seed the draft's tool map the first time a connected server's tools become
 	// known, so a Save persists a complete map instead of null (= "never synced",
-	// which the backend treats as zero usable tools). Only seeds a null binding —
-	// an explicit map (even empty) is left untouched.
+	// which the backend treats as zero usable tools). Routed through onSeedTools,
+	// which fills only a still-null binding against the latest state — so parallel
+	// seeds from sibling servers merge and user edits are never clobbered.
 	const seedIfUnsynced = useCallback(
 		(fetchedTools: MCPServerTool[]) => {
-			if (readOnly || binding.tools !== null) return;
-			onToolsChange?.(
+			if (readOnly) return;
+			onSeedTools?.(
 				Object.fromEntries(
 					fetchedTools.map((tool) => [
 						tool.name,
@@ -94,7 +102,7 @@ export default function AgentMCPServer({
 				),
 			);
 		},
-		[readOnly, binding.tools, onToolsChange],
+		[readOnly, onSeedTools],
 	);
 
 	const fetchTools = useCallback(async () => {

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Image from "next/image";
 import { MCPServer } from "@/types/mcp-servers";
 import { ToolStatus } from "@/types/agents";
@@ -105,6 +105,16 @@ export default function AgentMCPServer({
 		[readOnly, onSeedTools],
 	);
 
+	// Keep `fetchTools` stable (identity keyed only on server.id) so a sibling
+	// server's seed re-rendering the parent — which hands us a fresh inline
+	// onSeedTools each time — can't churn fetchTools' identity and retrigger the
+	// mount effect, restarting an in-flight fetch. The ref tracks the latest seed
+	// closure so behavior stays current without becoming a dependency.
+	const seedRef = useRef(seedIfUnsynced);
+	useEffect(() => {
+		seedRef.current = seedIfUnsynced;
+	}, [seedIfUnsynced]);
+
 	const fetchTools = useCallback(async () => {
 		setIsLoading(true);
 		try {
@@ -112,7 +122,7 @@ export default function AgentMCPServer({
 			const fetchedTools = res.data as MCPServerTool[];
 			setTools(fetchedTools);
 			setToolsFetched(true);
-			seedIfUnsynced(fetchedTools);
+			seedRef.current(fetchedTools);
 		} catch (error: unknown) {
 			// Check if this is an OAuth authorization required error
 			if (
@@ -153,7 +163,7 @@ export default function AgentMCPServer({
 							setTools(fetchedTools);
 							setToolsFetched(true);
 							setIsLoading(false);
-							seedIfUnsynced(fetchedTools);
+							seedRef.current(fetchedTools);
 
 							if (popup && !popup.closed) {
 								popup.close();
@@ -180,7 +190,7 @@ export default function AgentMCPServer({
 		} finally {
 			setIsLoading(false);
 		}
-	}, [server.id, seedIfUnsynced]);
+	}, [server.id]);
 
 	const handleConnect = async () => {
 		await fetchTools();

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
@@ -14,7 +14,15 @@ interface AgentToolListProps {
 	mcpServers: AgentMCPServerForm[];
 	hasCodeInterpreter: boolean;
 	readOnly?: boolean;
-	onMcpServersChange?: (servers: AgentMCPServerForm[]) => void;
+	/**
+	 * Functional updater — applied against the LATEST draft state. Never rebuild
+	 * the array from the `mcpServers` prop: several servers can seed their tool
+	 * maps concurrently (async `fetchTools`), and a snapshot-based update would
+	 * let a late callback clobber a sibling's already-seeded map.
+	 */
+	onMcpServersChange?: (
+		update: (prev: AgentMCPServerForm[]) => AgentMCPServerForm[],
+	) => void;
 	onHasCodeInterpreterChange?: (enabled: boolean) => void;
 }
 
@@ -49,24 +57,39 @@ export default function AgentToolList({
 		serverId: string,
 		tools: Record<string, ToolStatus>,
 	) => {
-		onMcpServersChange?.(
-			mcpServers.map((s) =>
-				s.mcpServerId === serverId ? { ...s, tools } : s,
+		onMcpServersChange?.((prev) =>
+			prev.map((s) => (s.mcpServerId === serverId ? { ...s, tools } : s)),
+		);
+	};
+
+	// Seed a never-synced binding, evaluated against the latest state: only fill
+	// when `tools` is still null so concurrent seeds merge instead of clobbering,
+	// and a user's in-progress edits are never overwritten.
+	const handleSeedTools = (
+		serverId: string,
+		tools: Record<string, ToolStatus>,
+	) => {
+		onMcpServersChange?.((prev) =>
+			prev.map((s) =>
+				s.mcpServerId === serverId && s.tools === null
+					? { ...s, tools }
+					: s,
 			),
 		);
 	};
 
 	const handleRemoveServer = (serverId: string) => {
-		onMcpServersChange?.(
-			mcpServers.filter((s) => s.mcpServerId !== serverId),
+		onMcpServersChange?.((prev) =>
+			prev.filter((s) => s.mcpServerId !== serverId),
 		);
 	};
 
 	const handleAddServer = (serverId: string) => {
-		onMcpServersChange?.([
-			...mcpServers,
-			{ mcpServerId: serverId, tools: null },
-		]);
+		onMcpServersChange?.((prev) =>
+			prev.some((s) => s.mcpServerId === serverId)
+				? prev
+				: [...prev, { mcpServerId: serverId, tools: null }],
+		);
 	};
 
 	const hasTools = hasCodeInterpreter || enabledServers.length > 0;
@@ -106,6 +129,9 @@ export default function AgentToolList({
 								readOnly={readOnly}
 								onToolsChange={(tools) => {
 									handleToolsChange(server.id, tools);
+								}}
+								onSeedTools={(tools) => {
+									handleSeedTools(server.id, tools);
 								}}
 								onRemove={() => {
 									handleRemoveServer(server.id);

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -261,7 +261,12 @@ export default function AgentEditor({
 					<AgentToolList
 						mcpServers={form.mcpServers}
 						hasCodeInterpreter={form.hasCodeInterpreter}
-						onMcpServersChange={(mcpServers) => { setField("mcpServers", mcpServers); }}
+						onMcpServersChange={(update) => {
+							setForm((prev) => ({
+								...prev,
+								mcpServers: update(prev.mcpServers),
+							}));
+						}}
 						onHasCodeInterpreterChange={(enabled) => { setField("hasCodeInterpreter", enabled); }}
 					/>
 					{isAdmin && (


### PR DESCRIPTION
## Summary

Fixes #221 — since the explicit-save refactor (#215), tool settings weren't properly saved when saving an agent's config: only the last-touched MCP server persisted, leaving agents not ready to use in chat.

## Root cause

`AgentMCPServerService.set_for_agent` now writes each server's per-tool map **exactly as the client sends it, with zero network calls** — so the editor is responsible for materializing the complete map before Save. The editor only seeded that map in two spots: on a tool toggle (`handleStatusChange` → `materializeTools`) and after an OAuth reconnect. It **never** seeded in the normal `fetchTools` success path — the path that runs for a server that's already connected when you open the editor.

Result: any bound server the user didn't manually poke was saved with `tools = null`, which the toolset treats as **zero usable tools** (`_assemble_agent_tools`). Since users typically interact with one server, only that one materialized → "only the last MCP tool settings get saved", and the agent had no tools in chat.

## Changes

- **`web/.../agent-mcp-server.tsx`** — extracted a `seedIfUnsynced` helper and call it in the normal `fetchTools` success path (not just the OAuth reconnect path). When a connected server's tools are fetched and the draft binding is still `null`, seed the complete map (all `always_allow`), mirroring the pre-#215 auto-sync-on-attach behavior. Only truly-`null` bindings are seeded — an explicit map (even empty, or with disabled tools) is left untouched.
- **`backend/app/agents/toolset.py`** — defensive `tool_settings.get(...) or {}` so a stray `null` map (e.g. a server saved while disconnected, or an agent created via the API) yields zero tools instead of crashing the agent build on `None.items()`.

## Behavior note

Opening the editor for an agent with an already-connected-but-never-synced server now seeds its map on load, which marks the form dirty immediately. That's the intended "make it ready" behavior and matches how attaching a server worked before #215. A server that is **not connected** at edit time still saves `null` (nothing to sync) — but readiness (`GET /agents/{id}/is-ready`) now surfaces that as `not_configured` rather than a silent no-op.

## Testing

- 275 backend agent tests pass
- ESLint clean on the changed frontend file; ruff check/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds MCP tool maps when MCP servers connect or load so a Save persists all connected servers, fixing agents that lost tools and showed as not ready in chat. Also avoids seed races and duplicate tool fetches, and handles null tool maps safely on the backend.

- **Bug Fixes**
  - Frontend: seed on `fetchTools` success and OAuth reconnect via `seedIfUnsynced`; use functional updates and `onSeedTools` so concurrent seeds merge without overwriting user edits; stabilize `fetchTools` with a ref so sibling server seeds don’t restart in‑flight fetches or issue duplicates.
  - Backend: treat a null `tool_settings` map as `{}` in `_assemble_agent_tools` to avoid crashes and yield zero tools.
  - Behavior: opening the editor with already connected servers now seeds maps immediately (form becomes dirty). Disconnected servers still save `null` and readiness reports `not_configured`.

<sup>Written for commit f8722edec2d911af1fddf04957968ce41603d2ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

