### PR TITLE
fix(mcp): discover AS metadata via path-aware OIDC for servers without PRM

### DIFF
--- a/backend/app/mcp/client/auth.py
+++ b/backend/app/mcp/client/auth.py
@@ -207,9 +207,13 @@ class WebOAuthClientProvider(OAuthClientProvider):
         with no static secret), then ``client_secret_basic``. If the server
         advertises none of the methods this client can perform, raise rather than
         registering with a method we can't honour (which would only fail later at
-        token exchange). Servers that don't advertise the field keep our default.
+        token exchange). Servers that don't advertise the field — or for which no
+        AS metadata was discovered at all — keep our default.
         """
-        supported = self.context.oauth_metadata.token_endpoint_auth_methods_supported
+        metadata = self.context.oauth_metadata
+        if metadata is None:
+            return
+        supported = metadata.token_endpoint_auth_methods_supported
         if not supported:
             return
         current = self.context.client_metadata.token_endpoint_auth_method
@@ -268,9 +272,26 @@ class WebOAuthClientProvider(OAuthClientProvider):
                     break
 
             # Step 2: Authorization Server Metadata (RFC 8414 / OIDC fallbacks).
-            for url in build_oauth_authorization_server_metadata_discovery_urls(
+            #
+            # When PRM discovery found no authorization server (auth_server_url is
+            # None), the SDK helper only probes the *root*
+            # /.well-known/oauth-authorization-server. That misses servers that
+            # publish no RFC 9728 PRM yet host their metadata under the MCP path
+            # — e.g. TikTok serves OIDC discovery at
+            # {server_path}/.well-known/openid-configuration and no PRM at all.
+            # Fall back to path-aware discovery derived from the MCP server URL
+            # so those servers are still found; keep the root URL first so
+            # conformant legacy servers (metadata at the origin root) are
+            # unaffected.
+            discovery_urls = build_oauth_authorization_server_metadata_discovery_urls(
                 self.context.auth_server_url, self.context.server_url
-            ):
+            )
+            if not self.context.auth_server_url:
+                path_aware = build_oauth_authorization_server_metadata_discovery_urls(
+                    str(self.context.server_url), self.context.server_url
+                )
+                discovery_urls = list(dict.fromkeys([*discovery_urls, *path_aware]))
+            for url in discovery_urls:
                 response = await client.send(create_oauth_metadata_request(url))
                 ok, asm = await handle_auth_metadata_response(response)
                 if ok and asm:

--- a/backend/tests/mcp/client/test_auth.py
+++ b/backend/tests/mcp/client/test_auth.py
@@ -201,6 +201,57 @@ async def test_dynamic_client_registration_when_no_static_creds(monkeypatch):
     assert "scope" not in query
 
 
+async def test_as_metadata_discovery_falls_back_to_path_aware_urls(monkeypatch):
+    # TikTok publishes no RFC 9728 PRM (every PRM URL 404s) and hosts its AS
+    # metadata at {server_path}/.well-known/openid-configuration. With PRM
+    # discovery yielding no authorization server, the AS-metadata step must
+    # still probe the path-aware OIDC suffix URL — not only the origin root —
+    # otherwise oauth_metadata stays None and registration crashes / fails.
+    tiktok_url = "https://business-api.tiktok.com/open_mcp/tt-ads-mcp-layer/oauth"
+
+    probed: list[str] = []
+    orig_request = auth_module.create_oauth_metadata_request
+
+    def _record(url):
+        probed.append(url)
+        return orig_request(url)
+
+    monkeypatch.setattr(auth_module, "create_oauth_metadata_request", _record)
+    monkeypatch.setattr(httpx.AsyncClient, "send", AsyncMock(return_value=object()))
+    # No PRM anywhere -> auth_server_url stays None.
+    monkeypatch.setattr(
+        auth_module, "handle_protected_resource_response", AsyncMock(return_value=None)
+    )
+    # We only assert which URLs get probed, so no AS metadata is "found".
+    monkeypatch.setattr(
+        auth_module,
+        "handle_auth_metadata_response",
+        AsyncMock(return_value=(True, None)),
+    )
+    monkeypatch.setattr(
+        auth_module,
+        "handle_registration_response",
+        AsyncMock(
+            return_value=OAuthClientInformationFull(
+                client_id="dcr-client-id",
+                redirect_uris=["https://app.example/cb"],
+            )
+        ),
+    )
+
+    provider = WebOAuthClientProvider(
+        server_url=tiktok_url,
+        client_metadata=build_oauth_client_metadata(),
+        storage=_FakeStorage(),
+    )
+    with pytest.raises(OAuthAuthorizationRequired):
+        await provider.initiate_authorization()
+
+    # The path-aware OIDC suffix (where TikTok actually serves its metadata) was
+    # probed, in addition to the origin-root URL the SDK helper generates alone.
+    assert f"{tiktok_url}/.well-known/openid-configuration" in probed
+
+
 # ---------------------------------------------------------------------------
 # token_endpoint_auth_method negotiation before dynamic registration
 #
@@ -253,6 +304,19 @@ def test_negotiate_keeps_default_when_supported():
 def test_negotiate_keeps_default_when_server_omits_field():
     provider = _provider_no_creds()
     provider.context.oauth_metadata = _asm_with_methods(None)
+    provider._negotiate_registration_auth_method()
+    assert (
+        provider.context.client_metadata.token_endpoint_auth_method
+        == "client_secret_post"
+    )
+
+
+def test_negotiate_keeps_default_when_no_metadata():
+    # AS metadata discovery found nothing at all (e.g. TikTok, which publishes
+    # no PRM and hosts metadata under a non-standard path) -> oauth_metadata is
+    # None. Negotiation must not raise AttributeError and keeps our default.
+    provider = _provider_no_creds()
+    provider.context.oauth_metadata = None
     provider._negotiate_registration_auth_method()
     assert (
         provider.context.client_metadata.token_endpoint_auth_method


### PR DESCRIPTION
## Problem

Testing the TikTok MCP server's OAuth connection crashed with:

```
'NoneType' object has no attribute 'token_endpoint_auth_methods_supported'
```

PR #224 added `_negotiate_registration_auth_method` to handle public-only servers like TikTok (which advertise `token_endpoint_auth_methods_supported: ["none"]`), but for TikTok that logic **never ran** — `oauth_metadata` was `None` and negotiation crashed before reaching it.

## Root cause

Two distinct bugs, confirmed by probing TikTok's live endpoints:

1. **Discovery gap.** TikTok publishes **no** RFC 9728 Protected Resource Metadata — every PRM URL 404s — so `auth_server_url` stays `None`. The SDK's URL builder then only probes the origin-root `/.well-known/oauth-authorization-server` (also 404). TikTok actually serves its metadata at the **path-aware OIDC suffix** `{server_path}/.well-known/openid-configuration` (`200`, with `token_endpoint_auth_methods_supported: ["none"]`). That URL is only generated when `auth_server_url` is set, so it was never tried → `oauth_metadata` stayed `None`.

2. **Unguarded dereference.** `_negotiate_registration_auth_method` read `oauth_metadata.token_endpoint_auth_methods_supported` without checking for `None`, hence the crash.

## Fix

- **`initiate_authorization` step 2**: when PRM yields no authorization server, merge in path-aware discovery URLs derived from the MCP server URL so the OIDC suffix is probed. The root URL is kept first, so conformant legacy servers (metadata at the origin root) are unaffected.
- **`_negotiate_registration_auth_method`**: guard against `oauth_metadata is None` and keep the default, consistent with the existing "server omits the field" branch.

## Verification

- Probed TikTok's live endpoints: PRM 404s everywhere; `{path}/.well-known/openid-configuration` returns 200 with `token_endpoint_auth_methods_supported: ["none"]`.
- Confirmed the fixed code produces a URL list whose last entry is exactly that suffix, root URL first.
- Added tests: `test_negotiate_keeps_default_when_no_metadata` (crash regression) and `test_as_metadata_discovery_falls_back_to_path_aware_urls` (asserts the suffix is probed for a TikTok-shaped server). All 15 tests in the module pass; lint clean.

⚠️ Not verified: the full live OAuth handshake (needs real credentials + browser redirect). The metadata document, its auth method, and the probed URL are all confirmed against TikTok's live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth discovery for MCP servers that don’t publish PRM (e.g., TikTok) by probing path-aware OIDC metadata and guarding auth-method negotiation when metadata is missing. Prevents the TikTok OAuth crash and preserves the default registration method.

- **Bug Fixes**
  - Discovery: When PRM finds no auth server, also probe `{server_path}/.well-known/openid-configuration`; root discovery remains first.
  - Negotiation: Handle `oauth_metadata` being `None` and keep the default client auth method.

<sup>Written for commit 9a2fc9bdbebbe850d3542e9181b59fe083d30043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

