### PR TITLE
fix(agents): contain tool errors and reconnect dead MCP sessions

### DIFF
--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -97,10 +97,15 @@ def build_runnable(
     full stack; subagents pass only ``CurrentDateMiddleware``.
     ``DeferredStructuredOutputMiddleware`` is
     appended whenever an ``output_schema`` is given (it keeps the schema off the
-    tool-calling loop and applies it on one final formatting turn). On the
-    sandbox path ``ToolErrorMiddleware`` is appended and the caller's
-    ``PatchToolCallsMiddleware`` is dropped, since ``create_deep_agent`` injects
-    its own and langchain asserts against duplicates.
+    tool-calling loop and applies it on one final formatting turn).
+    ``ToolErrorMiddleware`` is appended on BOTH paths: without it the ToolNode
+    has no tool-call wrapper, and langgraph's default handler re-raises any
+    exception that isn't a ``ToolInvocationError`` — an MCP transport failure
+    in a tool (or in a subagent reached through ``task``) then kills the whole
+    run instead of feeding back to the model as an error ToolMessage. On the
+    sandbox path the caller's ``PatchToolCallsMiddleware`` is dropped, since
+    ``create_deep_agent`` injects its own and langchain asserts against
+    duplicates.
 
     ``subagents`` (already-compiled ``CompiledSubAgent`` runnables) wire in via
     ``SubAgentMiddleware`` on the no-sandbox path and via the ``subagents=`` arg
@@ -137,7 +142,7 @@ def build_runnable(
         tools=tools,
         system_prompt=system_prompt,
         checkpointer=checkpointer,
-        middleware=middleware,
+        middleware=[*middleware, ToolErrorMiddleware()],
         response_format=output_schema,
     )
 

--- a/backend/app/agents/tool_errors.py
+++ b/backend/app/agents/tool_errors.py
@@ -52,8 +52,12 @@ class ToolErrorMiddleware(AgentMiddleware):
             return await handler(request)
         except Exception as exc:
             inner = root_cause(exc)
+            # Some transport errors stringify to "" (e.g. anyio's
+            # ClosedResourceError) — fall back to the type name so the model
+            # gets something actionable.
+            detail = str(inner) or type(inner).__name__
             return ToolMessage(
-                content=f"Error: {inner}",
+                content=f"Error: {detail}",
                 tool_call_id=request.tool_call["id"],
             )
 

--- a/backend/app/agents/toolset.py
+++ b/backend/app/agents/toolset.py
@@ -4,6 +4,7 @@ import re
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
+import anyio
 from langchain_core.tools import Tool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
@@ -189,10 +190,112 @@ def _assemble_agent_tools(
     return agent_tools
 
 
+# Raised when sending on a session whose streams already closed — the request
+# never left the client, so retrying it on a fresh session is safe.
+_DEAD_SESSION_ERRORS = (anyio.ClosedResourceError, anyio.BrokenResourceError)
+
+
+class _SessionSupervisor:
+    """Opens replacement MCP sessions for servers whose transport died mid-stream.
+
+    Each replacement is hosted in its own task (same anyio cancel-scope
+    ownership rule as ``_open_sessions``) and torn down in ``close()`` at the
+    end of ``Toolset.open``. ``replaced`` records which servers were
+    reconnected, so ``_open_sessions`` demotes the dead primaries' teardown
+    errors to warnings instead of raising them at stream end.
+    """
+
+    def __init__(self, client: MultiServerMCPClient | None):
+        self._client = client
+        self._stop = asyncio.Event()
+        self._tasks: list[asyncio.Task] = []
+        self.replaced: set[str] = set()
+
+    async def reopen(self, name: str):
+        loop = asyncio.get_running_loop()
+        ready: asyncio.Future = loop.create_future()
+
+        async def _host() -> None:
+            try:
+                async with self._client.session(name) as session:
+                    ready.set_result(session)
+                    await self._stop.wait()
+            except BaseException as exc:
+                if not ready.done():
+                    ready.set_exception(exc)
+                else:
+                    raise
+
+        self._tasks.append(asyncio.create_task(_host()))
+        session = await ready
+        self.replaced.add(name)
+        return session
+
+    async def close(self) -> None:
+        self._stop.set()
+        results = await asyncio.gather(*self._tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, BaseException) and not isinstance(
+                result, asyncio.CancelledError
+            ):
+                logger.warning("Replacement MCP session teardown failed: %r", result)
+
+
+class ReconnectingSession:
+    """Per-server ``ClientSession`` proxy that survives a dead transport.
+
+    All of a server's tools are bound to this proxy (not to the raw session),
+    so when the transport dies mid-run — the server drops the connection, the
+    GET stream flaps — the next ``call_tool`` reopens the session once and
+    retries, instead of every remaining call failing on the same corpse.
+
+    Only ``_DEAD_SESSION_ERRORS`` are retried: they mean the request was never
+    sent, so at-most-once execution is preserved. Mid-flight failures (e.g.
+    ``McpError`` "Connection closed") are NOT retried — the call may have
+    executed server-side; they surface as error ToolMessages via
+    ToolErrorMiddleware, and the next call on this server reconnects.
+    """
+
+    def __init__(self, name: str, session, supervisor: _SessionSupervisor):
+        self._session = session
+        self._name = name
+        self._generation = 0
+        self._supervisor = supervisor
+        self._lock = asyncio.Lock()
+
+    def __getattr__(self, attr: str):
+        # Rest of the session API (list_tools at load time, etc.) hits the
+        # current live session directly, without retry.
+        return getattr(self._session, attr)
+
+    async def call_tool(self, *args, **kwargs):
+        session, generation = self._session, self._generation
+        try:
+            return await session.call_tool(*args, **kwargs)
+        except _DEAD_SESSION_ERRORS as exc:
+            session = await self._reconnect(generation, exc)
+            return await session.call_tool(*args, **kwargs)
+
+    async def _reconnect(self, seen_generation: int, cause: BaseException):
+        """Reopen once per dead session, even under concurrent callers."""
+        async with self._lock:
+            if self._generation == seen_generation:
+                logger.warning(
+                    "MCP session '%s' is dead (%s); opening a replacement",
+                    self._name,
+                    type(cause).__name__,
+                )
+                self._session = await self._supervisor.reopen(self._name)
+                self._generation += 1
+            return self._session
+
+
 @asynccontextmanager
 async def _open_sessions(
     client: MultiServerMCPClient | None,
     server_names: list[str],
+    *,
+    replaced: set[str] | None = None,
 ):
     """Open one live MCP session per server, concurrently.
 
@@ -200,6 +303,10 @@ async def _open_sessions(
     host task: the streamable-HTTP transport is built on anyio cancel scopes,
     which must exit in the task that entered them — entering the contexts from
     a ``gather`` onto a shared exit stack would crash at teardown.
+
+    ``replaced`` (shared with the ``_SessionSupervisor``) names servers whose
+    primary session died and was replaced mid-stream: their teardown errors
+    are expected, so they are logged instead of raised.
     """
     if not server_names:
         yield {}
@@ -237,11 +344,19 @@ async def _open_sessions(
         await _teardown()
         raise
     else:
-        for result in await _teardown():
-            if isinstance(result, BaseException) and not isinstance(
+        for name, result in zip(server_names, await _teardown(), strict=True):
+            if not isinstance(result, BaseException) or isinstance(
                 result, asyncio.CancelledError
             ):
-                raise result
+                continue
+            if replaced and name in replaced:
+                logger.warning(
+                    "Dead MCP session '%s' teardown failed after it was replaced: %r",
+                    name,
+                    result,
+                )
+                continue
+            raise result
 
 
 class Toolset:
@@ -339,29 +454,42 @@ class Toolset:
 
         The sessions stay open for the whole ``async with`` block, so a handle
         minted by one tool call (e.g. Metabase ``construct_query``'s
-        ``query_handle``) survives to the next call (``visualize_query``). MCP tool
-        execution errors (isError=True) are surfaced as ToolMessage(status="error")
-        natively by langchain-mcp-adapters; transport/protocol failures raise and
-        are caught globally by ToolErrorMiddleware.
+        ``query_handle``) survives to the next call (``visualize_query``). Tools
+        are bound to a ``ReconnectingSession`` proxy, so a session whose
+        transport dies mid-run is reopened on the next call instead of failing
+        every remaining call. MCP tool execution errors (isError=True) are
+        surfaced as ToolMessage(status="error") natively by
+        langchain-mcp-adapters; transport/protocol failures raise and are
+        caught globally by ToolErrorMiddleware.
         """
-        async with _open_sessions(prepared.client, prepared.server_names) as sessions:
-            results = await asyncio.gather(
-                *[
-                    load_mcp_tools(
-                        sessions[name], server_name=name, tool_name_prefix=True
-                    )
+        supervisor = _SessionSupervisor(prepared.client)
+        async with _open_sessions(
+            prepared.client, prepared.server_names, replaced=supervisor.replaced
+        ) as sessions:
+            try:
+                proxies = {
+                    name: ReconnectingSession(name, sessions[name], supervisor)
                     for name in prepared.server_names
-                ]
-            )
-            tools_by_server = list(zip(prepared.server_names, results, strict=True))
+                }
+                results = await asyncio.gather(
+                    *[
+                        load_mcp_tools(
+                            proxies[name], server_name=name, tool_name_prefix=True
+                        )
+                        for name in prepared.server_names
+                    ]
+                )
+                tools_by_server = list(zip(prepared.server_names, results, strict=True))
 
-            agent_tools = _assemble_agent_tools(
-                tools_by_server, prepared.tool_settings, prepared.server_id_by_name
-            )
-            toolset = cls(tools=agent_tools)
-            if prepared.apply_ui:
-                toolset.apply_ui_metadata()
-            yield toolset
+                agent_tools = _assemble_agent_tools(
+                    tools_by_server, prepared.tool_settings, prepared.server_id_by_name
+                )
+                toolset = cls(tools=agent_tools)
+                if prepared.apply_ui:
+                    toolset.apply_ui_metadata()
+                yield toolset
+            finally:
+                await supervisor.close()
 
     def apply_ui_metadata(self) -> None:
         """Inject UI metadata into tool coroutines.

--- a/backend/app/agents/toolset.py
+++ b/backend/app/agents/toolset.py
@@ -249,6 +249,11 @@ class ReconnectingSession:
     GET stream flaps — the next ``call_tool`` reopens the session once and
     retries, instead of every remaining call failing on the same corpse.
 
+    ``list_tools`` gets the same treatment so tool discovery
+    (``Toolset.open`` → ``load_mcp_tools``) survives a transport that dies
+    right after the session opened, instead of aborting the whole run at
+    setup.
+
     Only ``_DEAD_SESSION_ERRORS`` are retried: they mean the request was never
     sent, so at-most-once execution is preserved. Mid-flight failures (e.g.
     ``McpError`` "Connection closed") are NOT retried — the call may have
@@ -264,17 +269,23 @@ class ReconnectingSession:
         self._lock = asyncio.Lock()
 
     def __getattr__(self, attr: str):
-        # Rest of the session API (list_tools at load time, etc.) hits the
-        # current live session directly, without retry.
+        # Rest of the session API hits the current live session directly,
+        # without retry.
         return getattr(self._session, attr)
 
     async def call_tool(self, *args, **kwargs):
+        return await self._retry_on_dead_session("call_tool", *args, **kwargs)
+
+    async def list_tools(self, *args, **kwargs):
+        return await self._retry_on_dead_session("list_tools", *args, **kwargs)
+
+    async def _retry_on_dead_session(self, method: str, *args, **kwargs):
         session, generation = self._session, self._generation
         try:
-            return await session.call_tool(*args, **kwargs)
+            return await getattr(session, method)(*args, **kwargs)
         except _DEAD_SESSION_ERRORS as exc:
             session = await self._reconnect(generation, exc)
-            return await session.call_tool(*args, **kwargs)
+            return await getattr(session, method)(*args, **kwargs)
 
     async def _reconnect(self, seen_generation: int, cause: BaseException):
         """Reopen once per dead session, even under concurrent callers."""

--- a/backend/app/sandbox/lazy.py
+++ b/backend/app/sandbox/lazy.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from deepagents.backends.protocol import (
+    EditResult,
     ExecuteResponse,
     FileDownloadResponse,
     FileUploadResponse,
+    GlobResult,
+    GrepResult,
+    LsResult,
+    ReadResult,
+    WriteResult,
 )
 from deepagents.backends.sandbox import BaseSandbox
 from opensandbox import SandboxSync
@@ -13,7 +19,9 @@ from opensandbox import SandboxSync
 from app.sandbox.backend import OpenSandbox
 
 
-NOT_CONNECTED_MSG = "No sandbox connected. Call create_sandbox or connect_sandbox first."
+NOT_CONNECTED_MSG = (
+    "No sandbox connected. Call create_sandbox or connect_sandbox first."
+)
 
 
 class LazySandboxBackend(BaseSandbox):
@@ -21,6 +29,15 @@ class LazySandboxBackend(BaseSandbox):
 
     All BaseSandbox file operations (ls, read, write, edit, grep, glob)
     route through execute(), so connecting the inner backend is sufficient.
+
+    While disconnected, the file operations return their protocol error
+    results instead of raising: deepagents calls them OUTSIDE any tool-call
+    wrapper — large-tool-result eviction and conversation-history eviction
+    both `backend.write()` from middleware hooks — so a raise there escapes
+    ToolErrorMiddleware and kills the whole run, while an error result makes
+    deepagents skip the eviction and carry on. Only `execute` (always reached
+    through the `execute` tool, whose exceptions ToolErrorMiddleware converts
+    to error ToolMessages) still raises.
     """
 
     def __init__(self) -> None:
@@ -53,3 +70,50 @@ class LazySandboxBackend(BaseSandbox):
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         return self._inner.upload_files(files)
+
+    # File operations return protocol error results while disconnected (the
+    # async variants inherit this: BackendProtocol's a* defaults delegate to
+    # the sync methods via asyncio.to_thread).
+
+    def ls(self, path: str) -> LsResult:
+        if self._backend is None:
+            return LsResult(error=NOT_CONNECTED_MSG)
+        return self._backend.ls(path)
+
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> ReadResult:
+        if self._backend is None:
+            return ReadResult(error=NOT_CONNECTED_MSG)
+        return self._backend.read(file_path, offset=offset, limit=limit)
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        if self._backend is None:
+            return WriteResult(error=NOT_CONNECTED_MSG)
+        return self._backend.write(file_path, content)
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,  # noqa: FBT001, FBT002 - protocol signature
+    ) -> EditResult:
+        if self._backend is None:
+            return EditResult(error=NOT_CONNECTED_MSG)
+        return self._backend.edit(
+            file_path, old_string, new_string, replace_all=replace_all
+        )
+
+    def glob(self, pattern: str, path: str = "/") -> GlobResult:
+        if self._backend is None:
+            return GlobResult(error=NOT_CONNECTED_MSG)
+        return self._backend.glob(pattern, path=path)
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+    ) -> GrepResult:
+        if self._backend is None:
+            return GrepResult(error=NOT_CONNECTED_MSG)
+        return self._backend.grep(pattern, path=path, glob=glob)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ license = "AGPL-3.0-or-later"
 requires-python = ">=3.11"
 dependencies = [
     "alembic>=1.15.0",
+    "anyio>=4.5.0",
     "fastapi>=0.121.1",
     "greenlet>=3.1.1",
     "langchain-deepseek>=1.0.1",

--- a/backend/tests/agents/test_runtime.py
+++ b/backend/tests/agents/test_runtime.py
@@ -94,6 +94,21 @@ def test_build_agent_without_output_schema(mock_create_agent):
     )
 
 
+@patch("app.agents.runtime.create_agent")
+def test_build_agent_appends_tool_error_middleware(mock_create_agent):
+    """The non-sandbox path must also contain tool errors: without a
+    wrap_tool_call middleware the ToolNode has no wrapper and langgraph's
+    default handler re-raises anything that isn't a ToolInvocationError — an
+    MCP transport failure (in a tool, or in a subagent reached through `task`)
+    then crashes the whole run instead of feeding back to the model."""
+    agent = _build_agent()
+
+    agent._build_agent(checkpointer=None)
+
+    middleware = mock_create_agent.call_args.kwargs["middleware"]
+    assert isinstance(middleware[-1], ToolErrorMiddleware)
+
+
 @patch("app.sandbox.tools.create_sandbox_tools", return_value=[])
 @patch("app.agents.runtime.create_deep_agent")
 @patch("app.agents.runtime.sandbox_settings")

--- a/backend/tests/agents/test_toolset.py
+++ b/backend/tests/agents/test_toolset.py
@@ -511,3 +511,207 @@ class TestOpenSessions:
             async with _open_sessions(_FakeClient(cms), ["a"]):
                 raise ValueError("body boom")
         assert any(e == "exit" and n == "a" for e, n, t in log)
+
+    @pytest.mark.asyncio
+    async def test_replaced_session_teardown_error_is_excused(self):
+        """A dead primary that was replaced mid-stream tears down noisily —
+        that error must be logged, not raised at the end of a successful run."""
+        from app.agents.toolset import _open_sessions
+
+        log = []
+        cms = {
+            "dead": _FakeSessionCM("dead", log, fail_exit=True),
+            "ok": _FakeSessionCM("ok", log),
+        }
+        async with _open_sessions(
+            _FakeClient(cms), ["dead", "ok"], replaced={"dead"}
+        ) as sessions:
+            assert sessions["dead"] == "session-dead"
+
+    @pytest.mark.asyncio
+    async def test_unreplaced_teardown_error_still_raises(self):
+        from app.agents.toolset import _open_sessions
+
+        log = []
+        cms = {"a": _FakeSessionCM("a", log, fail_exit=True)}
+        with pytest.raises(RuntimeError, match="exit failed: a"):
+            async with _open_sessions(_FakeClient(cms), ["a"], replaced={"other"}):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# ReconnectingSession — retry-once on dead transport
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Stand-in ClientSession: fails every call_tool with `fail_with` if set."""
+
+    def __init__(self, name: str, fail_with: BaseException | None = None):
+        self.name = name
+        self.calls: list[str] = []
+        self.fail_with = fail_with
+
+    async def call_tool(self, tool_name, args=None, **kwargs):
+        self.calls.append(tool_name)
+        if self.fail_with is not None:
+            raise self.fail_with
+        return f"{self.name}:{tool_name}"
+
+    async def list_tools(self, cursor=None):
+        return f"tools-from-{self.name}"
+
+
+class _FakeSupervisor:
+    """Hands out pre-baked replacement sessions and counts reopens."""
+
+    def __init__(self, replacements: list[_FakeSession]):
+        self._replacements = list(replacements)
+        self.reopened: list[str] = []
+        self.replaced: set[str] = set()
+
+    async def reopen(self, name: str):
+        self.reopened.append(name)
+        self.replaced.add(name)
+        return self._replacements.pop(0)
+
+
+class TestReconnectingSession:
+    @pytest.mark.asyncio
+    async def test_dead_transport_reconnects_and_retries(self):
+        import anyio
+
+        from app.agents.toolset import ReconnectingSession
+
+        dead = _FakeSession("dead", fail_with=anyio.ClosedResourceError())
+        fresh = _FakeSession("fresh")
+        supervisor = _FakeSupervisor([fresh])
+        proxy = ReconnectingSession("slack", dead, supervisor)
+
+        result = await proxy.call_tool("read_channel")
+
+        assert result == "fresh:read_channel"
+        assert supervisor.reopened == ["slack"]
+        # The failed call never reached the server; the retry did.
+        assert dead.calls == ["read_channel"]
+        assert fresh.calls == ["read_channel"]
+
+    @pytest.mark.asyncio
+    async def test_non_transport_errors_are_not_retried(self):
+        from app.agents.toolset import ReconnectingSession
+
+        dead = _FakeSession("dead", fail_with=ValueError("mid-flight failure"))
+        supervisor = _FakeSupervisor([])
+        proxy = ReconnectingSession("slack", dead, supervisor)
+
+        with pytest.raises(ValueError, match="mid-flight failure"):
+            await proxy.call_tool("send_message")
+        assert supervisor.reopened == []
+
+    @pytest.mark.asyncio
+    async def test_concurrent_failures_reconnect_once(self):
+        """N concurrent calls on a dead session must trigger ONE reopen, and
+        all of them must retry on the same replacement."""
+        import asyncio
+
+        import anyio
+
+        from app.agents.toolset import ReconnectingSession
+
+        dead = _FakeSession("dead", fail_with=anyio.ClosedResourceError())
+        fresh = _FakeSession("fresh")
+        supervisor = _FakeSupervisor([fresh])
+        proxy = ReconnectingSession("slack", dead, supervisor)
+
+        results = await asyncio.gather(
+            proxy.call_tool("a"), proxy.call_tool("b"), proxy.call_tool("c")
+        )
+
+        assert sorted(results) == ["fresh:a", "fresh:b", "fresh:c"]
+        assert supervisor.reopened == ["slack"]
+
+    @pytest.mark.asyncio
+    async def test_second_death_reconnects_again(self):
+        import anyio
+
+        from app.agents.toolset import ReconnectingSession
+
+        dead1 = _FakeSession("dead1", fail_with=anyio.BrokenResourceError())
+        dead2 = _FakeSession("dead2", fail_with=anyio.BrokenResourceError())
+        fresh = _FakeSession("fresh")
+        supervisor = _FakeSupervisor([dead2, fresh])
+        proxy = ReconnectingSession("slack", dead1, supervisor)
+
+        # First call: dead1 -> reopen -> dead2 -> retry fails (one retry only).
+        with pytest.raises(anyio.BrokenResourceError):
+            await proxy.call_tool("a")
+        # Next call fails on dead2, reopens again onto fresh, succeeds.
+        assert await proxy.call_tool("b") == "fresh:b"
+        assert supervisor.reopened == ["slack", "slack"]
+
+    @pytest.mark.asyncio
+    async def test_getattr_delegates_to_current_session(self):
+        import anyio
+
+        from app.agents.toolset import ReconnectingSession
+
+        dead = _FakeSession("dead", fail_with=anyio.ClosedResourceError())
+        fresh = _FakeSession("fresh")
+        supervisor = _FakeSupervisor([fresh])
+        proxy = ReconnectingSession("slack", dead, supervisor)
+
+        assert await proxy.list_tools() == "tools-from-dead"
+        await proxy.call_tool("t")
+        assert await proxy.list_tools() == "tools-from-fresh"
+
+
+# ---------------------------------------------------------------------------
+# _SessionSupervisor — replacement host lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSupervisor:
+    @pytest.mark.asyncio
+    async def test_reopen_hosts_session_and_records_replacement(self):
+        import asyncio
+
+        from app.agents.toolset import _SessionSupervisor
+
+        log = []
+        cms = {"a": _FakeSessionCM("a", log)}
+        supervisor = _SessionSupervisor(_FakeClient(cms))
+
+        session = await supervisor.reopen("a")
+        assert session == "session-a"
+        assert supervisor.replaced == {"a"}
+        # Entered in a dedicated task, not the caller's.
+        enter_task = next(t for e, n, t in log if e == "enter")
+        assert enter_task is not asyncio.current_task()
+
+        await supervisor.close()
+        exit_task = next(t for e, n, t in log if e == "exit")
+        assert exit_task is enter_task
+
+    @pytest.mark.asyncio
+    async def test_close_logs_teardown_errors_instead_of_raising(self):
+        from app.agents.toolset import _SessionSupervisor
+
+        log = []
+        cms = {"a": _FakeSessionCM("a", log, fail_exit=True)}
+        supervisor = _SessionSupervisor(_FakeClient(cms))
+        await supervisor.reopen("a")
+
+        await supervisor.close()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_reopen_failure_propagates_to_caller(self):
+        from app.agents.toolset import _SessionSupervisor
+
+        log = []
+        cms = {"a": _FakeSessionCM("a", log, fail_enter=True)}
+        supervisor = _SessionSupervisor(_FakeClient(cms))
+
+        with pytest.raises(RuntimeError, match="enter failed: a"):
+            await supervisor.reopen("a")
+        assert supervisor.replaced == set()
+        await supervisor.close()

--- a/backend/tests/agents/test_toolset.py
+++ b/backend/tests/agents/test_toolset.py
@@ -545,7 +545,7 @@ class TestOpenSessions:
 
 
 class _FakeSession:
-    """Stand-in ClientSession: fails every call_tool with `fail_with` if set."""
+    """Stand-in ClientSession: fails every request with `fail_with` if set."""
 
     def __init__(self, name: str, fail_with: BaseException | None = None):
         self.name = name
@@ -559,6 +559,8 @@ class _FakeSession:
         return f"{self.name}:{tool_name}"
 
     async def list_tools(self, cursor=None):
+        if self.fail_with is not None:
+            raise self.fail_with
         return f"tools-from-{self.name}"
 
 
@@ -650,6 +652,23 @@ class TestReconnectingSession:
         assert supervisor.reopened == ["slack", "slack"]
 
     @pytest.mark.asyncio
+    async def test_list_tools_reconnects_and_retries(self):
+        """Tool discovery (Toolset.open → load_mcp_tools → list_tools) must
+        survive a transport that died right after the session opened, not
+        abort the whole run at setup."""
+        import anyio
+
+        from app.agents.toolset import ReconnectingSession
+
+        dead = _FakeSession("dead", fail_with=anyio.ClosedResourceError())
+        fresh = _FakeSession("fresh")
+        supervisor = _FakeSupervisor([fresh])
+        proxy = ReconnectingSession("slack", dead, supervisor)
+
+        assert await proxy.list_tools() == "tools-from-fresh"
+        assert supervisor.reopened == ["slack"]
+
+    @pytest.mark.asyncio
     async def test_getattr_delegates_to_current_session(self):
         import anyio
 
@@ -660,9 +679,10 @@ class TestReconnectingSession:
         supervisor = _FakeSupervisor([fresh])
         proxy = ReconnectingSession("slack", dead, supervisor)
 
-        assert await proxy.list_tools() == "tools-from-dead"
+        # `name` is not a wrapped method — it resolves on the live session.
+        assert proxy.name == "dead"
         await proxy.call_tool("t")
-        assert await proxy.list_tools() == "tools-from-fresh"
+        assert proxy.name == "fresh"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/sandbox/test_lazy.py
+++ b/backend/tests/sandbox/test_lazy.py
@@ -1,0 +1,67 @@
+"""Unit tests for the lazy sandbox backend."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.sandbox.lazy import NOT_CONNECTED_MSG, LazySandboxBackend
+
+
+def test_disconnected_execute_raises():
+    backend = LazySandboxBackend()
+    assert backend.connected is False
+    with pytest.raises(RuntimeError, match=NOT_CONNECTED_MSG):
+        backend.execute("echo hi")
+
+
+def test_disconnected_file_ops_return_error_results():
+    """deepagents calls file ops from middleware hooks (large-tool-result and
+    conversation-history eviction), OUTSIDE any tool-call wrapper — a raise
+    there escapes ToolErrorMiddleware and kills the run. Disconnected file ops
+    must return protocol error results so deepagents skips the eviction."""
+    backend = LazySandboxBackend()
+
+    assert backend.ls("/").error == NOT_CONNECTED_MSG
+    assert backend.read("/f.txt").error == NOT_CONNECTED_MSG
+    assert backend.write("/f.txt", "content").error == NOT_CONNECTED_MSG
+    assert backend.edit("/f.txt", "a", "b").error == NOT_CONNECTED_MSG
+    assert backend.glob("*.txt").error == NOT_CONNECTED_MSG
+    assert backend.grep("needle").error == NOT_CONNECTED_MSG
+
+
+@pytest.mark.asyncio
+async def test_disconnected_awrite_returns_error_result():
+    """The eviction path calls the async variant; it inherits the guard via
+    BackendProtocol's asyncio.to_thread delegation to the sync method."""
+    backend = LazySandboxBackend()
+    result = await backend.awrite("/large_tool_results/x", "big payload")
+    assert result.error == NOT_CONNECTED_MSG
+
+
+def test_connected_file_ops_delegate():
+    backend = LazySandboxBackend()
+    inner = MagicMock()
+    backend.connect(MagicMock(), inner)
+    assert backend.connected is True
+
+    backend.write("/f.txt", "content")
+    inner.write.assert_called_once_with("/f.txt", "content")
+    backend.read("/f.txt", offset=3, limit=10)
+    inner.read.assert_called_once_with("/f.txt", offset=3, limit=10)
+    backend.edit("/f.txt", "a", "b", replace_all=True)
+    inner.edit.assert_called_once_with("/f.txt", "a", "b", replace_all=True)
+    backend.ls("/")
+    inner.ls.assert_called_once_with("/")
+    backend.glob("*.py", path="/src")
+    inner.glob.assert_called_once_with("*.py", path="/src")
+    backend.grep("needle", path="/src", glob="*.py")
+    inner.grep.assert_called_once_with("needle", path="/src", glob="*.py")
+
+
+def test_connected_execute_delegates():
+    backend = LazySandboxBackend()
+    inner = MagicMock()
+    backend.connect(MagicMock(), inner)
+
+    backend.execute("echo hi", timeout=5)
+    inner.execute.assert_called_once_with("echo hi", timeout=5)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -283,6 +283,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
+    { name = "anyio" },
     { name = "authlib" },
     { name = "croniter" },
     { name = "deepagents" },
@@ -327,6 +328,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "alembic", specifier = ">=1.15.0" },
+    { name = "anyio", specifier = ">=4.5.0" },
     { name = "authlib", specifier = ">=1.6.6" },
     { name = "croniter", specifier = ">=6.2.3" },
     { name = "deepagents", specifier = ">=0.5.6" },


### PR DESCRIPTION
## Incident

During a multi-subagent run (6 parallel Slack investigators + BigQuery), the shared Slack MCP session's transport died mid-run. The next `call_tool` raised `anyio.ClosedResourceError` from `mcp/shared/session.py` (send on a closed write stream), and the exception propagated through **two** pregel loops — the subagent's tool node and the parent's — because neither had a tool-call wrapper: langgraph's default handler only formats `ToolInvocationError` and re-raises everything else (`tool_node.py:390`). The whole stream crashed; the model never saw the failure.

A second, related crash: with a code-interpreter agent whose sandbox hasn't been created yet, any tool result over the eviction threshold (~20k tokens) made deepagents' `FilesystemMiddleware` call `backend.awrite()` on the disconnected `LazySandboxBackend` **from a middleware hook, outside any tool-call wrapper** — the raised `RuntimeError("No sandbox connected...")` killed the run the same way. Verified unfixed in deepagents 0.6.12 and 0.7.0a7; the backend contract there is to *return* `Result(error=...)`, not raise.

## Fixes

1. **`ToolErrorMiddleware` on every path** (`runtime.py`): the no-sandbox `create_agent` branch of `build_runnable` (parent + all subagents) now appends it too, so any uncaught tool exception feeds back to the model as an error `ToolMessage` instead of crashing the run. Errors that stringify to `""` (e.g. `ClosedResourceError`) fall back to the exception type name.

2. **Self-healing MCP sessions** (`toolset.py`): tools are bound to a `ReconnectingSession` proxy per server. On `ClosedResourceError`/`BrokenResourceError` — raised *before* the request is handed to the transport, so a retry cannot double-execute a side-effectful tool — the session is reopened in a fresh host task (`_SessionSupervisor`, same anyio cancel-scope ownership rule as `_open_sessions`) and the call retried once. A generation counter makes N concurrent failures on the same dead session reconnect exactly once. Mid-flight failures are deliberately not retried. A replaced primary's noisy teardown at stream end is logged instead of raised, so recovery isn't undone at the end of a successful run.

3. **Contract-conformant lazy sandbox** (`sandbox/lazy.py`): disconnected file ops (`ls`/`read`/`write`/`edit`/`glob`/`grep`) return protocol error results instead of raising — deepagents' eviction hooks then skip the eviction and carry on. The async variants inherit the guard via the protocol's `to_thread` delegation. Only `execute` still raises (always reached through the `execute` tool, where `ToolErrorMiddleware` contains it).

`anyio` is promoted from transitive to declared dependency (now imported directly).

## Tests

- `test_runtime.py`: non-sandbox path appends `ToolErrorMiddleware`.
- `test_toolset.py`: reconnect-and-retry, no retry on non-transport errors, single reconnect under concurrent failures, repeated deaths, replaced-session teardown excused, supervisor host-task lifecycle.
- `tests/sandbox/test_lazy.py`: disconnected file ops return error results (sync + async), connected delegation, `execute` still raises.

Verified end-to-end with a local repro (scripted model + tool raising `ClosedResourceError`: old stack crashes, new stack completes; live FastMCP server killed mid-session and restarted: proxy reconnects and the next call succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents agent runs from crashing when MCP transports die or the sandbox isn’t connected by containing tool errors and auto-reconnecting dead MCP sessions. Errors now surface as tool error messages, disconnected sandbox file ops return protocol errors, and tool discovery now retries on dead sessions.

- **Bug Fixes**
  - Append `ToolErrorMiddleware` on both sandbox and no-sandbox paths so uncaught tool exceptions become error ToolMessages; empty error strings fall back to the exception type.
  - Bind MCP tools to a reconnecting session: on `anyio.ClosedResourceError`/`anyio.BrokenResourceError` reopen once and retry (including `list_tools` during discovery); no retry for mid-flight failures; concurrent failures trigger a single reconnect; teardown errors of replaced sessions are logged.
  - Make `LazySandboxBackend` file ops (`ls`, `read`, `write`, `edit`, `glob`, `grep`) return protocol error results when disconnected; async variants inherit; `execute` still raises.

- **Dependencies**
  - Add `anyio` as a direct dependency.

<sup>Written for commit ffb2f7e186973b5839e19ffdb5ddd975f386a250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

