### PR TITLE
fix(mcp): bound every MCP request with a read deadline

### DIFF
--- a/backend/app/mcp/client/connectivity.py
+++ b/backend/app/mcp/client/connectivity.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.exceptions import DomainError
 from app.mcp.client.auth import WebOAuthClientProvider, build_oauth_client_metadata
 from app.mcp.client.exceptions import OAuthAuthorizationRequired
+from app.mcp.client.factory import MCP_REQUEST_TIMEOUT
 from app.mcp.client.storage import RedisTokenStorage, TokenStorageFactory
 from app.mcp.servers.encryption import decrypt_value as decrypt_api_key
 from app.mcp.servers.models import MCPAuthType, MCPServerDB
@@ -132,7 +133,9 @@ async def _open_session(
     async with streamablehttp_client(
         **client_args, terminate_on_close=terminate_on_close
     ) as (read, write, _):
-        async with ClientSession(read, write) as session:
+        async with ClientSession(
+            read, write, read_timeout_seconds=MCP_REQUEST_TIMEOUT
+        ) as session:
             await session.initialize()
             try:
                 tools = await _list_all_tools(session)

--- a/backend/app/mcp/client/factory.py
+++ b/backend/app/mcp/client/factory.py
@@ -1,9 +1,24 @@
+from datetime import timedelta
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.mcp.client.auth import WebOAuthClientProvider, build_oauth_client_metadata
 from app.mcp.client.storage import TokenStorageFactory
 from app.mcp.servers.models import MCPAuthType, MCPServerDB
 from app.mcp.servers.repository import MCPServerRepository
+
+
+# Deadline for every MCP JSON-RPC request (tools/call, tools/list). Without it
+# ``mcp.shared.session`` awaits the response under ``anyio.fail_after(None)`` —
+# a literally unbounded wait. On 2026-07-24 an MCP server was OOM-killed after
+# it had already streamed its 200 headers; the transport break was swallowed,
+# no response ever arrived, and two runs parked for 29.5 min until Cloud Run's
+# 1800 s request timeout turned them into 504s.
+#
+# 120 s is the largest value that can still fire: it matches the MCP servers'
+# own Cloud Run ``timeoutSeconds``, so nothing server-side can legitimately
+# outlive it. Observed tool calls run 0.1–11.5 s (p95 14.1 s).
+MCP_REQUEST_TIMEOUT = timedelta(seconds=120)
 
 
 class MCPClientConfigFactory:
@@ -17,6 +32,7 @@ class MCPClientConfigFactory:
         base_config = {
             "transport": "http",
             "url": config.url,
+            "session_kwargs": {"read_timeout_seconds": MCP_REQUEST_TIMEOUT},
         }
 
         if config.auth_type == MCPAuthType.none:

--- a/backend/tests/mcp/client/test_factory.py
+++ b/backend/tests/mcp/client/test_factory.py
@@ -1,8 +1,12 @@
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 import pytest
+from mcp import ClientSession
+from mcp.shared.exceptions import McpError
 
-from app.mcp.client.factory import MCPClientConfigFactory
+from app.mcp.client.factory import MCP_REQUEST_TIMEOUT, MCPClientConfigFactory
 from app.mcp.servers.models import MCPAuthType
 
 
@@ -86,3 +90,40 @@ async def test_unsupported_auth_type_raises():
     factory = MCPClientConfigFactory(db=MagicMock(), user_id="u1")
     with pytest.raises(ValueError, match="Unsupported auth type"):
         await factory.build(_config("weird"))
+
+
+@pytest.mark.asyncio
+@patch("app.mcp.client.factory.WebOAuthClientProvider")
+@patch("app.mcp.client.factory.build_oauth_client_metadata", return_value={})
+@patch("app.mcp.client.factory.TokenStorageFactory")
+async def test_every_auth_branch_carries_a_request_deadline(*_mocks):
+    # Regression guard for the 2026-07-24 incident: without
+    # read_timeout_seconds, mcp.shared.session awaits responses under
+    # anyio.fail_after(None) and a dropped reply parks the run until Cloud
+    # Run's 1800 s request timeout. Every branch spreads **base_config, so a
+    # new branch that rebuilds the dict from scratch would silently lose this.
+    with patch("app.mcp.client.factory.MCPServerRepository") as mock_repo_cls:
+        mock_repo_cls.return_value.get_api_key = AsyncMock(return_value="secret")
+        factory = MCPClientConfigFactory(db=MagicMock(), user_id="u1")
+
+        for auth_type in (MCPAuthType.none, MCPAuthType.api_key, MCPAuthType.oauth2):
+            result = await factory.build(_config(auth_type))
+            assert result["session_kwargs"] == {
+                "read_timeout_seconds": MCP_REQUEST_TIMEOUT
+            }, auth_type
+
+
+@pytest.mark.asyncio
+async def test_read_timeout_turns_a_lost_reply_into_an_error():
+    # The behaviour the config above buys: a peer that never answers raises
+    # McpError instead of hanging forever. Drives ClientSession over in-memory
+    # streams — no HTTP, no stub server — with a short deadline so the test is
+    # fast; MCP_REQUEST_TIMEOUT is asserted separately above.
+    _read_send, read_recv = anyio.create_memory_object_stream(10)
+    write_send, _write_recv = anyio.create_memory_object_stream(10)
+
+    async with ClientSession(
+        read_recv, write_send, read_timeout_seconds=timedelta(milliseconds=100)
+    ) as session:
+        with pytest.raises(McpError, match="Timed out"):
+            await session.list_tools()


### PR DESCRIPTION
MCP client sessions were built without `read_timeout_seconds`, so `mcp.shared.session` awaited every response under `anyio.fail_after(None)` — a literally unbounded wait.

On 2026-07-24 the Scraper MCP server was OOM-killed after it had already streamed its 200 headers. The streamable-HTTP transport swallowed the resulting break (`logger.debug("SSE stream ended")`, and with no SSE event ids the reconnect branch is skipped), so no `CONNECTION_CLOSED` was ever delivered to the pending request. Two runs parked for 29.5 min until Cloud Run's 1800s request timeout turned them into 504s and paged SRE. 8 such 504s in 28 days.

Set a 120s deadline at the session level, so it covers `tools/call` and `tools/list` on every auth branch and every server. 120s matches the MCP servers' own Cloud Run `timeoutSeconds`, so nothing server-side can legitimately outlive it; observed tool calls run 0.1-11.5s (p95 14.1s).

On expiry the SDK raises `McpError`, which `ToolErrorMiddleware` already converts into an error `ToolMessage` — so the agent recovers and still answers the ticket instead of hanging.

Note the existing reconnect path (`_DEAD_SESSION_ERRORS`) cannot help here: it only retries raised exceptions, and a lost reply raises nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 120s read deadline to all MCP JSON‑RPC requests to prevent unbounded waits when a server drops a reply. This aligns with server `timeoutSeconds` and surfaces a handled error instead of stalling.

- **Bug Fixes**
  - Set `session_kwargs={"read_timeout_seconds": MCP_REQUEST_TIMEOUT}` in `MCPClientConfigFactory` and pass it through `_open_session` to `ClientSession`.
  - Apply the timeout to `tools/call` and `tools/list` across all auth types; lost replies now raise `McpError` handled by `ToolErrorMiddleware`.
  - Tests ensure the deadline is included on every auth branch and that a non‑reply times out and raises `McpError`.

<sup>Written for commit 09c54843053338b0abb5e50a3baedbc3aa8b02f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

