### PR TITLE
fix(oom): Only load when needed

### DIFF
--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -115,7 +115,13 @@ def _seed_human_content(messages: list) -> str | None:
 
 
 @router.get("/{thread_id}/subagents/{tool_call_id}/state")
-async def get_subagent_state(thread_id: str, tool_call_id: str) -> dict:
+async def get_subagent_state(
+    thread_id: str,
+    tool_call_id: str,
+    current_user: UserDB = Depends(get_current_user),
+    service: ThreadService = Depends(get_thread_service),
+    agent_service: AgentService = Depends(get_agent_service),
+) -> dict:
     """Fetch a subagent's checkpoint state (its internal messages) by tool call ID.
 
     A subagent runs as a Pregel subgraph whose checkpoint namespace is keyed by an
@@ -124,6 +130,9 @@ async def get_subagent_state(thread_id: str, tool_call_id: str) -> dict:
     while streaming: match the ``task`` tool call's ``description`` against each
     subgraph checkpoint's seed message.
     """
+    thread = await service.get(thread_id)
+    await _resolve_viewer_role(thread, current_user, agent_service)
+
     async with get_checkpointer() as checkpointer:
         # The task call's description lives in the parent (root-namespace) state.
         parent = await checkpointer.aget_tuple(

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -270,6 +270,33 @@ def test_get_thread_not_found(client: TestClient, mock_db):
     assert response.json()["detail"] == "Thread not found"
 
 
+@pytest.mark.usefixtures("current_user")
+@patch("app.threads.router.get_checkpointer")
+def test_get_subagent_state_forbidden_for_non_owner(
+    mock_checkpointer, client: TestClient, mock_db
+):
+    """Checkpoint history must not be read before thread access is granted."""
+    thread_id = str(uuid4())
+    thread = ThreadDB(
+        id=thread_id,
+        user_id=uuid4(),
+        agent_id=uuid4(),
+        first_message_content="Someone else's thread",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    mock_result.all.return_value = []
+    mock_db.execute.return_value = mock_result
+
+    response = client.get(f"/threads/{thread_id}/subagents/call_1/state")
+
+    assert response.status_code in (403, 404)
+    mock_checkpointer.assert_not_called()
+
+
 def test_update_thread(client: TestClient, mock_db, current_user):
     """Owner can rename their own thread (updates first_message_content only)."""
     thread_id = str(uuid4())

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -427,6 +427,7 @@ const ChatPage = () => {
   const [subagentMessages, setSubagentMessages] = useState<
     Record<string, unknown[]>
   >({});
+  const fetchedSubagentHistory = useRef(new Set<string>());
 
   const { mcpServers } = useMcpServersStore();
   // Sidebar populates the agents store; when this agent is there and the
@@ -694,40 +695,27 @@ const ChatPage = () => {
     );
   };
 
-  // ---- Fetch subagent internal messages after reconstruction ----
+  const loadSubagentHistory = useCallback(
+    async (toolCallId: string) => {
+      const key = `${threadId}:${toolCallId}`;
+      if (fetchedSubagentHistory.current.has(key)) return;
+      fetchedSubagentHistory.current.add(key);
 
-  const hasFetchedSubagentHistory = useRef(false);
-
-  useEffect(() => {
-    if (hasFetchedSubagentHistory.current) return;
-    if (isLoading) return;
-    if (!subagentApi.subagents || subagentApi.subagents.size === 0) return;
-
-    // Find subagents that were reconstructed but have no internal messages
-    const toFetch = [...subagentApi.subagents.entries()].filter(
-      ([, s]) =>
-        s.messages.length === 0 &&
-        (s.status === "complete" || s.status === "error"),
-    );
-    if (toFetch.length === 0) return;
-
-    hasFetchedSubagentHistory.current = true;
-
-    Promise.all(
-      toFetch.map(async ([toolCallId]) => {
-        try {
-          const res = await api.get(
-            `/threads/${threadId}/subagents/${toolCallId}/state`,
-          );
-          const msgs = res.data?.messages;
-          if (!Array.isArray(msgs) || msgs.length === 0) return;
+      try {
+        const res = await api.get(
+          `/threads/${threadId}/subagents/${toolCallId}/state`,
+        );
+        const msgs = res.data?.messages;
+        if (Array.isArray(msgs) && msgs.length > 0) {
           setSubagentMessages((prev) => ({ ...prev, [toolCallId]: msgs }));
-        } catch {
-          // Subgraph checkpoint may not exist — ignore
         }
-      }),
-    );
-  }, [subagentApi, thread, isLoading, threadId]);
+      } catch {
+        // Allow a later open to retry a transient failure.
+        fetchedSubagentHistory.current.delete(key);
+      }
+    },
+    [threadId],
+  );
 
   // ---- Initialization ----
 
@@ -1087,6 +1075,13 @@ const ChatPage = () => {
                               key={sub.id}
                               subagent={sub}
                               mcpServers={mcpServers}
+                              onOpen={
+                                sub.messages.length === 0 &&
+                                (sub.status === "complete" ||
+                                  sub.status === "error")
+                                  ? () => void loadSubagentHistory(sub.id)
+                                  : undefined
+                              }
                               fallbackMessages={subagentMessages[sub.id]}
                             />
                           ))}

--- a/web/src/components/ai-elements/subagent.test.tsx
+++ b/web/src/components/ai-elements/subagent.test.tsx
@@ -27,4 +27,24 @@ describe("SubAgentCard", () => {
 		await userEvent.click(screen.getByRole("button"));
 		expect(onOpen).toHaveBeenCalledOnce();
 	});
+
+	it("loads restored history for an error card that starts open", () => {
+		const onOpen = vi.fn();
+		const subagent = {
+			id: "call_2",
+			status: "error",
+			toolCall: { args: { description: "Inspect the failed task" } },
+			messages: [],
+			values: {},
+			error: "Failed",
+		} as unknown as SubagentStreamInterface<
+			Record<string, unknown>,
+			Record<string, unknown>,
+			string
+		>;
+
+		render(<SubAgentCard subagent={subagent} onOpen={onOpen} />);
+
+		expect(onOpen).toHaveBeenCalledOnce();
+	});
 });

--- a/web/src/components/ai-elements/subagent.test.tsx
+++ b/web/src/components/ai-elements/subagent.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { SubagentStreamInterface } from "@langchain/langgraph-sdk/ui";
+import { describe, expect, it, vi } from "vitest";
+
+import { SubAgentCard } from "./subagent";
+
+
+describe("SubAgentCard", () => {
+	it("loads restored history only when opened", async () => {
+		const onOpen = vi.fn();
+		const subagent = {
+			id: "call_1",
+			status: "complete",
+			toolCall: { args: { description: "Inspect the incident" } },
+			messages: [],
+			values: {},
+		} as unknown as SubagentStreamInterface<
+			Record<string, unknown>,
+			Record<string, unknown>,
+			string
+		>;
+
+		render(<SubAgentCard subagent={subagent} onOpen={onOpen} />);
+
+		expect(onOpen).not.toHaveBeenCalled();
+		await userEvent.click(screen.getByRole("button"));
+		expect(onOpen).toHaveBeenCalledOnce();
+	});
+});

--- a/web/src/components/ai-elements/subagent.tsx
+++ b/web/src/components/ai-elements/subagent.tsx
@@ -238,14 +238,15 @@ interface SubAgentCardProps {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	subagent: SubagentStreamInterface<any, any, any>;
 	mcpServers?: MCPServerInfo[];
+	onOpen?: () => void;
 	// Internal conversation restored from the subgraph checkpoint on refresh.
 	// The SDK can't inject these into the (reconstructed) subagent via the custom
-	// transport, so the page fetches them separately and passes them here.
+	// transport, so the page fetches them on demand and passes them here.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	fallbackMessages?: any[];
 }
 
-export const SubAgentCard = memo(({ subagent, mcpServers, fallbackMessages }: SubAgentCardProps) => {
+export const SubAgentCard = memo(({ subagent, mcpServers, onOpen, fallbackMessages }: SubAgentCardProps) => {
 	const { status, toolCall, result, startedAt, completedAt, messages, values } =
 		subagent;
 	const isStreaming = status === "running";
@@ -275,11 +276,16 @@ export const SubAgentCard = memo(({ subagent, mcpServers, fallbackMessages }: Su
 	const hasBody =
 		description || todos.length > 0 || hasConversation || result || isError;
 
+	const handleOpenChange = (open: boolean) => {
+		setIsOpen(open);
+		if (open) onOpen?.();
+	};
+
 	return (
 		<Collapsible
 			className="not-prose w-full rounded-lg border border-border bg-card shadow-sm overflow-hidden"
 			open={isOpen}
-			onOpenChange={setIsOpen}
+			onOpenChange={handleOpenChange}
 		>
 			{/* ---- Header ---- */}
 			<CollapsibleTrigger className="flex w-full items-center justify-between gap-3 p-3 text-sm transition-colors hover:bg-muted/50 cursor-pointer">

--- a/web/src/components/ai-elements/subagent.tsx
+++ b/web/src/components/ai-elements/subagent.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { ChevronDownIcon } from "lucide-react";
-import { memo, useEffect } from "react";
+import { memo, useEffect, useRef } from "react";
 import { Loader } from "@/components/ai-elements/loader";
 import {
 	Tool,
@@ -265,10 +265,18 @@ export const SubAgentCard = memo(({ subagent, mcpServers, onOpen, fallbackMessag
 	const [isOpen, setIsOpen] = useControllableState({
 		defaultProp: isStreaming || isError,
 	});
+	const requestedInitialHistory = useRef(false);
 
 	useEffect(() => {
 		if (isStreaming) setIsOpen(true);
 	}, [isStreaming, setIsOpen]);
+
+	useEffect(() => {
+		if (isError && onOpen && !requestedInitialHistory.current) {
+			requestedInitialHistory.current = true;
+			onOpen();
+		}
+	}, [isError, onOpen]);
 
 	const convoMessages =
 		messages && messages.length > 0 ? messages : (fallbackMessages ?? []);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Load subagent history only when a card is opened (including error cards that auto-open), and enforce thread access checks on the subagent state API. This reduces memory on page load and blocks unauthorized reads.

- **Bug Fixes**
  - Frontend: replaced eager fetch with on-demand `loadSubagentHistory` called by `SubAgentCard` on open; dedupes per thread+subagent and retries after transient errors; triggers automatically for error cards that start open.
  - Backend: `GET /threads/{thread_id}/subagents/{tool_call_id}/state` now requires the current user and validates thread access before reading from the checkpointer.
  - Tests: added component tests for click-to-open and auto-open error cases; added an API test to ensure non-owners get 403/404 and the checkpointer is not called.

<sup>Written for commit 7db73ab3fcf76fe5d541e86c60242a1c116b7ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

