### PR TITLE
fix(agents): persist MCP tool maps the editor UI already shows

### DIFF
--- a/agent-tools-map-not-saved.md
+++ b/agent-tools-map-not-saved.md
@@ -1,0 +1,115 @@
+# Investigation: tools shown in the UI but never saved to the agent config
+
+**Date**: 2026-08-18
+**Status**: FIXED 2026-08-19 — see "Fix (implemented)" below. Behavior tests in
+`web/src/app/(protected)/agents/[id]/components/agent-tool-list.test.tsx`
+(replaces the original repro test file) and
+`backend/tests/agents/mcp_servers/test_service.py` (`_sync_tools` merge).
+
+## Symptoms
+
+1. Adding an OAuth MCP server to an agent: after consent the tools load in the
+   UI, but the tools map is never persisted → agent "not configured", chat runs
+   without the tools.
+2. An already-bound MCP server gains new tools: they appear (enabled) in the
+   UI, but are never saved into the binding's tools map → chat never gets them.
+
+## Root cause
+
+A three-way disagreement introduced by the explicit-save editor refactor
+(read/edit split + atomic `PUT /agents/{id}/config`):
+
+1. **The runtime excludes unknown tools.** `_assemble_agent_tools`
+   (`backend/app/agents/toolset.py:162-181`) only binds tools whose name is in
+   the saved map with `always_allow` / `needs_approval`; a missing key — or a
+   `tools=null` map — means the tool is silently dropped.
+2. **The UI defaults unknown tools to enabled.** `statusFor`
+   (`web/.../agent-mcp-server.tsx:61-68`) falls back to `"always_allow"` for
+   any tool not in the map, so the editor renders exactly the opposite of what
+   the runtime will do.
+3. **The draft map is only seeded when it is still `null` AND the editor is in
+   edit mode.** `seedIfUnsynced` early-returns on `readOnly`
+   (`agent-mcp-server.tsx:93-106`), and `handleSeedTools`
+   (`agent-tool-list.tsx:68-79`) only fills a binding whose `tools === null`.
+   `PUT /agents/{id}/config` → `set_for_agent`
+   (`backend/app/agents/mcp_servers/service.py:104`) intentionally writes the
+   map *exactly as the client sends it* — no discovery, no merge.
+
+### Symptom 1 walkthrough (OAuth)
+
+The natural flow is: add server (draft binding `tools: null`) → **Save** →
+`onSaved` flips the page back to read mode (`agent-detail.tsx:51`) → card
+shows NOT CONNECTED and still renders the **Connect** button in read mode
+(`agent-mcp-server.tsx:261-277`) → consent → poll fetches and displays tools →
+`seedIfUnsynced` bails on `readOnly` → nothing is dirty, nothing saved. DB
+keeps `tools=null`, which the runtime treats as zero tools.
+
+The old per-link endpoints did handle this: `create_or_update` runs
+`_sync_tools` server-side after checking OAuth authorization, and
+`POST /agents/{id}/mcp-servers/{id}/sync-tools` exists
+(`backend/app/agents/router.py:250`) — but the explicit-save frontend never
+calls either (no `sync-tools` reference anywhere in `web/src`). The post-OAuth
+discovery path was lost in the refactor.
+
+### Symptom 2 walkthrough (new tools on the server)
+
+Binding map is non-null (e.g. `{search: always_allow}`), server now exposes
+`create_page`. The UI lists `create_page` as enabled (the `statusFor`
+fallback), but the seed only fills null maps, so the draft never changes:
+Save stays disabled, and even a save triggered by another edit sends the stale
+map. `set_for_agent` writes it verbatim; the runtime keeps excluding the new
+tool.
+
+## Reproduction
+
+`cd web && npx vitest run src/app/\(protected\)/agents/\[id\]/components/agent-tool-list.repro.test.tsx`
+
+- **CONTROL**: edit mode + never-synced binding → seed fills the draft, form
+  dirty, payload carries the full map (the intended path works).
+- **BUG 1**: read mode + `tools: null` + connected server → tools render as
+  "Always allow", payload still `"tools": null`.
+- **BUG 1b**: read mode still renders the Connect button, inviting the
+  unsavable flow.
+- **BUG 2**: edit mode + stale non-null map → new tool renders enabled, form
+  never dirty, payload lacks the new tool.
+
+## Fix (implemented 2026-08-19)
+
+- **Merge-seed** (`agent-tool-list.tsx` `handleSeedTools`,
+  `agent-mcp-server.tsx` `seedFromFetched`): whenever a connected server's
+  tools are fetched in edit mode, the fetched list becomes the draft map's key
+  universe — curated statuses preserved, new tools added as `always_allow`,
+  vanished tools dropped. An out-of-date map dirties the form (honest UNSAVED
+  chip); an up-to-date one is left identical (no spurious dirty). Fixes
+  symptom 2 and the edit-mode half of symptom 1.
+- **Read mode self-heals stale maps** (`agent-mcp-server.tsx`
+  `persistIfStale`): whenever tools are fetched in read mode — on page load
+  for connected servers (incl. no-auth / API-key, which have no Connect
+  action) and after the OAuth connect poll — the frontend compares the
+  fetched list with the saved map and, when they disagree (never synced, or
+  the server gained/lost tools), calls
+  `POST /agents/{id}/mcp-servers/{id}/sync-tools` and mirrors the saved map
+  into the agents store (`onToolsPersisted` → `onBindingPersisted` →
+  `updateAgent`). An up-to-date map is a no-op, so plain viewing stays
+  write-free. Fixes symptom 1 and symptom 2 in read mode.
+- **Backend `_sync_tools` now merges instead of clobbering**
+  (`backend/app/agents/mcp_servers/service.py`): server tool list is the key
+  universe, existing statuses win, new tools default to `always_allow`. Makes
+  the sync-tools endpoint safe to call on a curated binding.
+- **Connected pill**: each MCP server card in the agent editor now shows
+  CONNECTED (success tokens) / NOT CONNECTED, replacing the
+  not-connected-only badge.
+
+### Residual gaps (accepted)
+
+- The map only updates when someone *opens the agent page* (read-mode
+  self-heal or edit + Save). Agents that are only ever run via triggers or
+  Slack keep a stale map until a page view; runtime-side sync during
+  `Agent.build` would close that but is a bigger change.
+- A read-mode sync by a user whose credentials see a narrower tool list (e.g.
+  restricted OAuth scopes) persists that narrower list (statuses preserved
+  for surviving tools) — same property as the pre-refactor
+  `create_or_update` discovery.
+- The staleness check compares tool-name sets only; the sync-tools POST is
+  skipped when names match, so a pure description change never writes (tool
+  descriptions aren't stored in the map at all).

--- a/agent-tools-map-not-saved.md
+++ b/agent-tools-map-not-saved.md
@@ -62,16 +62,19 @@ tool.
 
 ## Reproduction
 
-`cd web && npx vitest run src/app/\(protected\)/agents/\[id\]/components/agent-tool-list.repro.test.tsx`
+The original repro tests asserted the buggy behavior (read mode + `tools:
+null` kept `"tools": null` in the payload; a stale map never dirtied the
+form). They were replaced by the behavior tests for the fixed semantics:
 
-- **CONTROL**: edit mode + never-synced binding → seed fills the draft, form
-  dirty, payload carries the full map (the intended path works).
-- **BUG 1**: read mode + `tools: null` + connected server → tools render as
-  "Always allow", payload still `"tools": null`.
-- **BUG 1b**: read mode still renders the Connect button, inviting the
-  unsavable flow.
-- **BUG 2**: edit mode + stale non-null map → new tool renders enabled, form
-  never dirty, payload lacks the new tool.
+`cd web && npx vitest run src/app/\(protected\)/agents/\[id\]/components/agent-tool-list.test.tsx`
+
+- edit mode + never-synced binding → seed fills the draft, form dirty,
+  payload carries the full map.
+- edit mode + stale map → merge-seed adds new tools, preserves curated
+  statuses, drops vanished keys, dirties the form.
+- read mode + null/stale map → self-heals via sync-tools on view; an
+  up-to-date map never writes.
+- read mode + OAuth connect poll → persists via sync-tools after consent.
 
 ## Fix (implemented 2026-08-19)
 

--- a/backend/app/agents/mcp_servers/service.py
+++ b/backend/app/agents/mcp_servers/service.py
@@ -43,7 +43,12 @@ class AgentMCPServerService(BaseService[AgentMCPServerDB, AgentMCPServerReposito
     ) -> None:
         try:
             async with connect_to_server(mcp_server, user_id, self.db) as (_, tools):
-                db_link.tools = {tool.name: "always_allow" for tool in tools}
+                # Merge, don't clobber: the server's tool list is the key
+                # universe, but a curated status survives a re-sync.
+                existing = db_link.tools or {}
+                db_link.tools = {
+                    tool.name: existing.get(tool.name, "always_allow") for tool in tools
+                }
                 self.db.add(db_link)
                 await self.db.flush()
                 await self.db.refresh(db_link)

--- a/backend/app/agents/mcp_servers/service.py
+++ b/backend/app/agents/mcp_servers/service.py
@@ -43,15 +43,21 @@ class AgentMCPServerService(BaseService[AgentMCPServerDB, AgentMCPServerReposito
     ) -> None:
         try:
             async with connect_to_server(mcp_server, user_id, self.db) as (_, tools):
-                # Merge, don't clobber: the server's tool list is the key
-                # universe, but a curated status survives a re-sync.
-                existing = db_link.tools or {}
-                db_link.tools = {
-                    tool.name: existing.get(tool.name, "always_allow") for tool in tools
-                }
-                self.db.add(db_link)
-                await self.db.flush()
-                await self.db.refresh(db_link)
+                fetched_names = [tool.name for tool in tools]
+            # The fetch can take seconds, so a concurrent save may have
+            # rewritten the map meanwhile. Reload the row under a lock and
+            # merge against the fresh state — otherwise this assignment
+            # would silently revert that save (lost update).
+            await self.db.refresh(db_link, with_for_update=True)
+            # Merge, don't clobber: the server's tool list is the key
+            # universe, but a curated status survives a re-sync.
+            existing = db_link.tools or {}
+            db_link.tools = {
+                name: existing.get(name, "always_allow") for name in fetched_names
+            }
+            self.db.add(db_link)
+            await self.db.flush()
+            await self.db.refresh(db_link)
         except Exception as e:
             logger.warning(f"Failed to fetch tools for MCP server {mcp_server.id}: {e}")
 

--- a/backend/tests/agents/mcp_servers/test_service.py
+++ b/backend/tests/agents/mcp_servers/test_service.py
@@ -1,4 +1,6 @@
+from contextlib import asynccontextmanager
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -466,3 +468,75 @@ async def test_sync_tools_calls_fetch_and_save_and_returns_link(
 
     mock_fetch.assert_awaited_once_with(link, server, "user-id")
     assert result is link
+
+
+# ---------------------------------------------------------------------------
+# _sync_tools (map computation)
+# ---------------------------------------------------------------------------
+
+
+def make_connect_to_server(tool_names):
+    """Async-context-manager stand-in for connect_to_server yielding tools."""
+    tools = [SimpleNamespace(name=name) for name in tool_names]
+
+    @asynccontextmanager
+    async def _connect(server, user_id, db):
+        yield (MagicMock(), tools)
+
+    return _connect
+
+
+async def test_sync_tools_seeds_never_synced_map(service):
+    server = make_mcp_server()
+    link = make_link(tools=None)
+
+    with patch(
+        "app.agents.mcp_servers.service.connect_to_server",
+        new=make_connect_to_server(["search", "write"]),
+    ):
+        await service._sync_tools(link, server, "user-id")
+
+    assert link.tools == {
+        "search": ToolStatus.always_allow,
+        "write": ToolStatus.always_allow,
+    }
+
+
+async def test_sync_tools_merges_preserving_curated_statuses(service):
+    """Re-sync keeps curated statuses, adds new tools as always_allow, and
+    drops tools the server no longer exposes."""
+    server = make_mcp_server()
+    link = make_link(
+        tools={
+            "search": ToolStatus.needs_approval,
+            "vanished": ToolStatus.disabled,
+        }
+    )
+
+    with patch(
+        "app.agents.mcp_servers.service.connect_to_server",
+        new=make_connect_to_server(["search", "create_page"]),
+    ):
+        await service._sync_tools(link, server, "user-id")
+
+    assert link.tools == {
+        "search": ToolStatus.needs_approval,
+        "create_page": ToolStatus.always_allow,
+    }
+
+
+async def test_sync_tools_keeps_map_on_connect_failure(service):
+    """A failed fetch must never wipe an existing map."""
+    server = make_mcp_server()
+    original = {"search": ToolStatus.needs_approval}
+    link = make_link(tools=dict(original))
+
+    @asynccontextmanager
+    async def _broken(server, user_id, db):
+        raise RuntimeError("boom")
+        yield  # pragma: no cover
+
+    with patch("app.agents.mcp_servers.service.connect_to_server", new=_broken):
+        await service._sync_tools(link, server, "user-id")
+
+    assert link.tools == original

--- a/backend/tests/agents/mcp_servers/test_service.py
+++ b/backend/tests/agents/mcp_servers/test_service.py
@@ -486,7 +486,7 @@ def make_connect_to_server(tool_names):
     return _connect
 
 
-async def test_sync_tools_seeds_never_synced_map(service):
+async def test_sync_tools_seeds_never_synced_map(service, mock_db):
     server = make_mcp_server()
     link = make_link(tools=None)
 
@@ -499,6 +499,34 @@ async def test_sync_tools_seeds_never_synced_map(service):
     assert link.tools == {
         "search": ToolStatus.always_allow,
         "write": ToolStatus.always_allow,
+    }
+    # The map isn't just mutated in memory — it is staged and flushed.
+    mock_db.add.assert_called_once_with(link)
+    mock_db.flush.assert_awaited_once()
+
+
+async def test_sync_tools_merges_against_row_reloaded_under_lock(service, mock_db):
+    """The merge uses the row as reloaded (FOR UPDATE) after the slow network
+    fetch — a save that landed mid-fetch is merged with, not reverted."""
+    server = make_mcp_server()
+    link = make_link(tools={"search": ToolStatus.always_allow})
+
+    async def refresh(instance, attribute_names=None, with_for_update=None):
+        if with_for_update:
+            # A concurrent save committed while tools were being fetched.
+            instance.tools = {"search": ToolStatus.disabled}
+
+    mock_db.refresh = AsyncMock(side_effect=refresh)
+
+    with patch(
+        "app.agents.mcp_servers.service.connect_to_server",
+        new=make_connect_to_server(["search", "create_page"]),
+    ):
+        await service._sync_tools(link, server, "user-id")
+
+    assert link.tools == {
+        "search": ToolStatus.disabled,
+        "create_page": ToolStatus.always_allow,
     }
 
 

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -196,23 +196,37 @@ export default function AgentMCPServer({
 							connectHandled = true;
 							clearInterval(pollInterval);
 
-							// Connecting is a deliberate action, so it must land in
-							// the config: in edit mode the seed merges the tools into
-							// the draft (saved on Save), in read mode sync-tools
-							// persists the map server-side immediately.
-							const retryRes = await api.get(
-								`/mcp-servers/${server.id}/list-tools`,
-							);
-							const fetchedTools = retryRes.data as MCPServerTool[];
-							setTools(fetchedTools);
-							setToolsFetched(true);
-							// Only after toolsFetched, in the same batch — flipping
-							// isConnected first re-renders with toolsFetched=false
-							// and the mount effect starts a duplicate fetch.
-							setIsConnected(true);
-							setIsLoading(false);
-							seedRef.current(fetchedTools);
-							await persistRef.current(fetchedTools);
+							try {
+								// Connecting is a deliberate action, so it must land
+								// in the config: in edit mode the seed merges the
+								// tools into the draft (saved on Save), in read mode
+								// sync-tools persists the map server-side immediately.
+								const retryRes = await api.get(
+									`/mcp-servers/${server.id}/list-tools`,
+								);
+								const fetchedTools = retryRes.data as MCPServerTool[];
+								setTools(fetchedTools);
+								setToolsFetched(true);
+								// Only after toolsFetched, in the same batch —
+								// flipping isConnected first re-renders with
+								// toolsFetched=false and the mount effect starts a
+								// duplicate fetch.
+								setIsConnected(true);
+								setIsLoading(false);
+								seedRef.current(fetchedTools);
+								await persistRef.current(fetchedTools);
+							} catch (fetchError) {
+								console.error(
+									"Failed to fetch tools after connect:",
+									fetchError,
+								);
+								// The server IS connected — expose that even though
+								// the fetch failed: with toolsFetched still false,
+								// the mount effect retries the fetch instead of the
+								// card sticking at NOT CONNECTED with polling dead.
+								setIsConnected(true);
+								setIsLoading(false);
+							}
 
 							if (popup && !popup.closed) {
 								popup.close();

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -10,17 +10,24 @@ import { AgentMCPServerForm } from "../../lib/agent-form";
 import { api } from "@/lib/api/client";
 
 interface AgentMCPServerProps {
+	/** Saved agent id — undefined in create mode. */
+	agentId?: string;
 	server: MCPServer;
 	binding: AgentMCPServerForm;
 	readOnly?: boolean;
 	/** Draft update: the complete per-tool map for this server. */
 	onToolsChange?: (tools: Record<string, ToolStatus>) => void;
 	/**
-	 * Draft update: seed a never-synced binding. Applied conditionally against
-	 * the latest state (only fills a still-null map), so parallel seeds from
-	 * sibling servers merge instead of clobbering each other.
+	 * Draft update: merge freshly fetched tool names into the binding's map.
+	 * Applied against the latest state (existing statuses win), so parallel
+	 * seeds from sibling servers and in-progress edits never clobber.
 	 */
-	onSeedTools?: (tools: Record<string, ToolStatus>) => void;
+	onSeedTools?: (fetchedNames: string[]) => void;
+	/**
+	 * A read-mode connect persisted the tool map server-side (sync-tools) —
+	 * `tools` is the map the backend saved.
+	 */
+	onToolsPersisted?: (tools: Record<string, ToolStatus>) => void;
 	/** Draft update: detach this server. */
 	onRemove?: () => void;
 }
@@ -31,11 +38,13 @@ interface MCPServerTool {
 }
 
 export default function AgentMCPServer({
+	agentId,
 	server,
 	binding,
 	readOnly,
 	onToolsChange,
 	onSeedTools,
+	onToolsPersisted,
 	onRemove,
 }: AgentMCPServerProps) {
 	// Collapsed on page open; not-connected servers auto-expand (effect
@@ -85,35 +94,64 @@ export default function AgentMCPServer({
 		onToolsChange?.({ ...materializeTools(tools), [toolName]: status });
 	};
 
-	// Seed the draft's tool map the first time a connected server's tools become
-	// known, so a Save persists a complete map instead of null (= "never synced",
-	// which the backend treats as zero usable tools). Routed through onSeedTools,
-	// which fills only a still-null binding against the latest state — so parallel
-	// seeds from sibling servers merge and user edits are never clobbered.
-	const seedIfUnsynced = useCallback(
+	// Merge fetched tools into the draft's map whenever a connected server's
+	// tools become known, so a Save always persists the complete, current map:
+	// null (= never synced) gets seeded, and a stale map gains the server's new
+	// tools — the runtime EXCLUDES any tool missing from the saved map, so a
+	// draft that lags the server would silently drop tools from the agent.
+	// Read mode has no draft to save; the post-connect sync-tools call below
+	// covers persistence there.
+	const seedFromFetched = useCallback(
 		(fetchedTools: MCPServerTool[]) => {
 			if (readOnly) return;
-			onSeedTools?.(
-				Object.fromEntries(
-					fetchedTools.map((tool) => [
-						tool.name,
-						"always_allow" as ToolStatus,
-					]),
-				),
-			);
+			onSeedTools?.(fetchedTools.map((tool) => tool.name));
 		},
 		[readOnly, onSeedTools],
+	);
+
+	// Read mode has no draft, so a saved map that disagrees with the server's
+	// live tool list (never synced after an OAuth connect, or a keyless server
+	// that gained/lost tools) must be healed server-side: sync-tools merges —
+	// curated statuses survive, new tools default to enabled, vanished tools
+	// drop. No-op when the map is already current, so merely viewing an
+	// up-to-date agent never writes.
+	const persistIfStale = useCallback(
+		async (fetchedTools: MCPServerTool[]) => {
+			if (!readOnly || !agentId) return;
+			const existing = binding.tools;
+			const upToDate =
+				existing !== null &&
+				Object.keys(existing).length === fetchedTools.length &&
+				fetchedTools.every((tool) => Object.hasOwn(existing, tool.name));
+			if (upToDate) return;
+			try {
+				const res = await api.post(
+					`/agents/${agentId}/mcp-servers/${server.id}/sync-tools`,
+				);
+				const savedTools = res.data.tools as Record<string, ToolStatus> | null;
+				if (savedTools) {
+					onToolsPersisted?.(savedTools);
+				}
+			} catch (error) {
+				console.error("Failed to sync tools:", error);
+			}
+		},
+		[readOnly, agentId, binding.tools, server.id, onToolsPersisted],
 	);
 
 	// Keep `fetchTools` stable (identity keyed only on server.id) so a sibling
 	// server's seed re-rendering the parent — which hands us a fresh inline
 	// onSeedTools each time — can't churn fetchTools' identity and retrigger the
-	// mount effect, restarting an in-flight fetch. The ref tracks the latest seed
-	// closure so behavior stays current without becoming a dependency.
-	const seedRef = useRef(seedIfUnsynced);
+	// mount effect, restarting an in-flight fetch. The refs track the latest
+	// closures so behavior stays current without becoming dependencies.
+	const seedRef = useRef(seedFromFetched);
 	useEffect(() => {
-		seedRef.current = seedIfUnsynced;
-	}, [seedIfUnsynced]);
+		seedRef.current = seedFromFetched;
+	}, [seedFromFetched]);
+	const persistRef = useRef(persistIfStale);
+	useEffect(() => {
+		persistRef.current = persistIfStale;
+	}, [persistIfStale]);
 
 	const fetchTools = useCallback(async () => {
 		setIsLoading(true);
@@ -123,6 +161,7 @@ export default function AgentMCPServer({
 			setTools(fetchedTools);
 			setToolsFetched(true);
 			seedRef.current(fetchedTools);
+			await persistRef.current(fetchedTools);
 		} catch (error: unknown) {
 			// Check if this is an OAuth authorization required error
 			if (
@@ -153,9 +192,10 @@ export default function AgentMCPServer({
 							clearInterval(pollInterval);
 							setIsConnected(true);
 
-							// Fetch tools for display; connecting is a deliberate
-							// action, so it also seeds the draft's tool map when
-							// the binding was never synced.
+							// Connecting is a deliberate action, so it must land in
+							// the config: in edit mode the seed merges the tools into
+							// the draft (saved on Save), in read mode sync-tools
+							// persists the map server-side immediately.
 							const retryRes = await api.get(
 								`/mcp-servers/${server.id}/list-tools`,
 							);
@@ -164,6 +204,7 @@ export default function AgentMCPServer({
 							setToolsFetched(true);
 							setIsLoading(false);
 							seedRef.current(fetchedTools);
+							await persistRef.current(fetchedTools);
 
 							if (popup && !popup.closed) {
 								popup.close();
@@ -238,11 +279,16 @@ export default function AgentMCPServer({
 				<span className="truncate text-[13.5px] font-semibold text-foreground">
 					{server.name}
 				</span>
-				{!isCheckingConnection && !isConnected && (
-					<span className="rounded-[4px] bg-[#FBEFED] px-2 py-0.5 font-mono text-[9.5px] font-semibold tracking-[0.05em] text-[#B04A3A]">
-						NOT CONNECTED
-					</span>
-				)}
+				{!isCheckingConnection &&
+					(isConnected ? (
+						<span className="rounded-[4px] bg-success-bg px-2 py-0.5 font-mono text-[9.5px] font-semibold tracking-[0.05em] text-success">
+							CONNECTED
+						</span>
+					) : (
+						<span className="rounded-[4px] bg-[#FBEFED] px-2 py-0.5 font-mono text-[9.5px] font-semibold tracking-[0.05em] text-[#B04A3A]">
+							NOT CONNECTED
+						</span>
+					))}
 				<button
 					onClick={handleToggleExpand}
 					aria-label={isExpanded ? "Collapse" : "Expand"}

--- a/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-mcp-server.tsx
@@ -181,6 +181,10 @@ export default function AgentMCPServer({
 
 				const popup = window.open(authUrl, "_blank", "width=600,height=700");
 
+				// Poll ticks overlap when a response is slow — only the first
+				// tick that sees the connection may run the fetch/persist leg,
+				// or sync-tools would fire once per in-flight tick.
+				let connectHandled = false;
 				const poll = async () => {
 					try {
 						const statusRes = await api.get(
@@ -188,9 +192,9 @@ export default function AgentMCPServer({
 						);
 						const statusData = statusRes.data;
 
-						if (statusData.connected) {
+						if (statusData.connected && !connectHandled) {
+							connectHandled = true;
 							clearInterval(pollInterval);
-							setIsConnected(true);
 
 							// Connecting is a deliberate action, so it must land in
 							// the config: in edit mode the seed merges the tools into
@@ -202,6 +206,10 @@ export default function AgentMCPServer({
 							const fetchedTools = retryRes.data as MCPServerTool[];
 							setTools(fetchedTools);
 							setToolsFetched(true);
+							// Only after toolsFetched, in the same batch — flipping
+							// isConnected first re-renders with toolsFetched=false
+							// and the mount effect starts a duplicate fetch.
+							setIsConnected(true);
 							setIsLoading(false);
 							seedRef.current(fetchedTools);
 							await persistRef.current(fetchedTools);

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.test.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.test.tsx
@@ -1,0 +1,360 @@
+/**
+ * Tool-map persistence: the runtime EXCLUDES any tool missing from the saved
+ * map (backend toolset.py), so the editor must keep the map complete:
+ *
+ *  - edit mode: fetched tools are MERGE-seeded into the draft (new tools
+ *    added as always_allow, curated statuses preserved, stale keys dropped),
+ *    making the form dirty so Save persists them;
+ *  - read mode: a successful OAuth connect persists server-side via
+ *    POST sync-tools (there is no draft to save after the editor flips back
+ *    to read mode on Save).
+ */
+import { useMemo, useState } from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api/client";
+import type { MCPServer } from "@/types/mcp-servers";
+import type { ToolStatus } from "@/types/agents";
+import AgentToolList from "./agent-tool-list";
+import {
+	AgentFormState,
+	AgentMCPServerForm,
+	defaultAgentForm,
+	isFormDirty,
+	toPayload,
+} from "../../lib/agent-form";
+
+vi.mock("@/lib/api/client", () => ({
+	api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock("next/image", () => ({
+	default: (props: Record<string, unknown>) => (
+		// eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
+		<img {...(props as React.ImgHTMLAttributes<HTMLImageElement>)} />
+	),
+}));
+
+vi.mock("./add-agent-tool-dialog", () => ({ default: () => null }));
+
+vi.mock("@/components/ai-elements/chain-of-thought", () => ({
+	humanizeToolName: (name: string) => name,
+}));
+
+const AGENT_ID = "agent-1";
+
+const SERVER: MCPServer = {
+	id: "server-1",
+	name: "Notion",
+	url: "https://notion.example.com/mcp",
+	authType: "oauth2",
+	createdAt: "2026-08-01T00:00:00Z",
+	updatedAt: "2026-08-01T00:00:00Z",
+};
+
+/** Minimal stand-in for AgentEditor's form state + save wiring. */
+function Harness({
+	initialServers,
+	readOnly,
+	onBindingPersisted,
+}: {
+	initialServers: AgentMCPServerForm[];
+	readOnly: boolean;
+	onBindingPersisted?: (
+		serverId: string,
+		tools: Record<string, ToolStatus>,
+	) => void;
+}) {
+	const initialForm = useMemo<AgentFormState>(
+		() => ({ ...defaultAgentForm(), name: "a", mcpServers: initialServers }),
+		[initialServers],
+	);
+	const [form, setForm] = useState(initialForm);
+	return (
+		<>
+			<AgentToolList
+				agentId={AGENT_ID}
+				readOnly={readOnly}
+				mcpServers={form.mcpServers}
+				hasCodeInterpreter={false}
+				onMcpServersChange={(update) => {
+					setForm((prev) => ({
+						...prev,
+						mcpServers: update(prev.mcpServers),
+					}));
+				}}
+				onBindingPersisted={onBindingPersisted}
+			/>
+			<output data-testid="dirty">
+				{String(!readOnly && isFormDirty(form, initialForm))}
+			</output>
+			<output data-testid="payload">
+				{JSON.stringify(toPayload(form).mcpServers)}
+			</output>
+		</>
+	);
+}
+
+function mockApi({
+	connected,
+	tools,
+}: {
+	connected: boolean;
+	tools: { name: string }[];
+}) {
+	vi.mocked(api.get).mockImplementation((url: string) => {
+		if (url === "/mcp-servers") return Promise.resolve({ data: [SERVER] });
+		if (url === `/mcp-servers/${SERVER.id}/is-connected`)
+			return Promise.resolve({ data: { connected } });
+		if (url === `/mcp-servers/${SERVER.id}/list-tools`)
+			return Promise.resolve({ data: tools });
+		return Promise.reject(new Error(`unexpected GET ${url}`));
+	});
+}
+
+async function expandServerCard() {
+	const expand = await screen.findByRole("button", { name: "Expand" });
+	fireEvent.click(expand);
+}
+
+function payload() {
+	return screen.getByTestId("payload").textContent ?? "";
+}
+
+describe("agent tool map persistence", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("edit mode, never-synced binding: seed fills the draft so Save persists the full map", async () => {
+		mockApi({ connected: true, tools: [{ name: "search" }] });
+		render(
+			<Harness
+				readOnly={false}
+				initialServers={[{ mcpServerId: SERVER.id, tools: null }]}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(payload()).toContain('"search":"always_allow"');
+		});
+		expect(screen.getByTestId("dirty").textContent).toBe("true");
+	});
+
+	it("edit mode, server gained a tool: merge-seed adds it, preserves curated statuses, drops stale keys, and dirties the form", async () => {
+		mockApi({
+			connected: true,
+			tools: [{ name: "search" }, { name: "create_page" }],
+		});
+		render(
+			<Harness
+				readOnly={false}
+				initialServers={[
+					{
+						mcpServerId: SERVER.id,
+						tools: {
+							search: "needs_approval",
+							removed_tool: "disabled",
+						},
+					},
+				]}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(payload()).toContain('"create_page":"always_allow"');
+		});
+		// Curated status preserved, vanished tool dropped.
+		expect(payload()).toContain('"search":"needs_approval"');
+		expect(payload()).not.toContain("removed_tool");
+		// The form is dirty — Save is enabled and the UNSAVED chip shows.
+		expect(screen.getByTestId("dirty").textContent).toBe("true");
+	});
+
+	it("edit mode, map already current: fetch does not dirty the form", async () => {
+		mockApi({ connected: true, tools: [{ name: "search" }] });
+		render(
+			<Harness
+				readOnly={false}
+				initialServers={[
+					{ mcpServerId: SERVER.id, tools: { search: "needs_approval" } },
+				]}
+			/>,
+		);
+
+		await expandServerCard();
+		await screen.findByText("search");
+		expect(screen.getByTestId("dirty").textContent).toBe("false");
+	});
+
+	it("read mode: OAuth connect persists the map via sync-tools and reports it upward", async () => {
+		vi.useFakeTimers();
+		let connected = false;
+		vi.mocked(api.get).mockImplementation((url: string) => {
+			if (url === "/mcp-servers") return Promise.resolve({ data: [SERVER] });
+			if (url === `/mcp-servers/${SERVER.id}/is-connected`)
+				return Promise.resolve({ data: { connected } });
+			if (url === `/mcp-servers/${SERVER.id}/list-tools`) {
+				return connected
+					? Promise.resolve({ data: [{ name: "search" }] })
+					: Promise.reject({
+							response: {
+								status: 401,
+								data: { auth_url: "https://oauth.example.com" },
+							},
+						});
+			}
+			return Promise.reject(new Error(`unexpected GET ${url}`));
+		});
+		vi.mocked(api.post).mockResolvedValue({
+			data: {
+				agentId: AGENT_ID,
+				mcpServerId: SERVER.id,
+				tools: { search: "always_allow" },
+			},
+		});
+		const openSpy = vi
+			.spyOn(window, "open")
+			.mockReturnValue(null as unknown as Window);
+		const persisted = vi.fn();
+
+		render(
+			<Harness
+				readOnly
+				initialServers={[{ mcpServerId: SERVER.id, tools: null }]}
+				onBindingPersisted={persisted}
+			/>,
+		);
+
+		// Not-connected cards auto-expand; Connect stays available in read mode.
+		const connect = await vi.waitFor(() => {
+			const button = screen.queryByRole("button", { name: "Connect" });
+			if (!button) throw new Error("Connect not rendered yet");
+			return button;
+		});
+		fireEvent.click(connect);
+		await vi.waitFor(() => {
+			expect(openSpy).toHaveBeenCalledWith(
+				"https://oauth.example.com",
+				"_blank",
+				"width=600,height=700",
+			);
+		});
+
+		// User consents in the popup; the next poll tick finds the connection.
+		connected = true;
+		await vi.advanceTimersByTimeAsync(2000);
+
+		expect(api.post).toHaveBeenCalledWith(
+			`/agents/${AGENT_ID}/mcp-servers/${SERVER.id}/sync-tools`,
+		);
+		expect(persisted).toHaveBeenCalledWith(SERVER.id, {
+			search: "always_allow",
+		});
+	});
+
+	it("read mode: a never-synced binding self-heals on view via sync-tools", async () => {
+		mockApi({ connected: true, tools: [{ name: "search" }] });
+		vi.mocked(api.post).mockResolvedValue({
+			data: {
+				agentId: AGENT_ID,
+				mcpServerId: SERVER.id,
+				tools: { search: "always_allow" },
+			},
+		});
+		const persisted = vi.fn();
+		render(
+			<Harness
+				readOnly
+				initialServers={[{ mcpServerId: SERVER.id, tools: null }]}
+				onBindingPersisted={persisted}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(api.post).toHaveBeenCalledWith(
+				`/agents/${AGENT_ID}/mcp-servers/${SERVER.id}/sync-tools`,
+			);
+		});
+		expect(persisted).toHaveBeenCalledWith(SERVER.id, {
+			search: "always_allow",
+		});
+	});
+
+	it("read mode: a stale map (server gained a tool, no OAuth involved) self-heals on view", async () => {
+		mockApi({
+			connected: true,
+			tools: [{ name: "search" }, { name: "create_page" }],
+		});
+		vi.mocked(api.post).mockResolvedValue({
+			data: {
+				agentId: AGENT_ID,
+				mcpServerId: SERVER.id,
+				tools: { search: "needs_approval", create_page: "always_allow" },
+			},
+		});
+		const persisted = vi.fn();
+		render(
+			<Harness
+				readOnly
+				initialServers={[
+					{ mcpServerId: SERVER.id, tools: { search: "needs_approval" } },
+				]}
+				onBindingPersisted={persisted}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(api.post).toHaveBeenCalledWith(
+				`/agents/${AGENT_ID}/mcp-servers/${SERVER.id}/sync-tools`,
+			);
+		});
+		expect(persisted).toHaveBeenCalledWith(SERVER.id, {
+			search: "needs_approval",
+			create_page: "always_allow",
+		});
+	});
+
+	it("read mode: an up-to-date map never writes on view", async () => {
+		mockApi({ connected: true, tools: [{ name: "search" }] });
+		render(
+			<Harness
+				readOnly
+				initialServers={[
+					{ mcpServerId: SERVER.id, tools: { search: "needs_approval" } },
+				]}
+			/>,
+		);
+
+		await expandServerCard();
+		await screen.findByText("search");
+		expect(api.post).not.toHaveBeenCalled();
+	});
+
+	it("shows a CONNECTED pill on connected servers and NOT CONNECTED otherwise", async () => {
+		mockApi({ connected: true, tools: [{ name: "search" }] });
+		const { unmount } = render(
+			<Harness
+				readOnly
+				initialServers={[{ mcpServerId: SERVER.id, tools: null }]}
+			/>,
+		);
+		const card = (await screen.findByText(SERVER.name)).closest("div");
+		expect(await within(card!.parentElement!).findByText("CONNECTED"))
+			.toBeInTheDocument();
+		unmount();
+
+		mockApi({ connected: false, tools: [] });
+		render(
+			<Harness
+				readOnly
+				initialServers={[{ mcpServerId: SERVER.id, tools: null }]}
+			/>,
+		);
+		expect(await screen.findByText("NOT CONNECTED")).toBeInTheDocument();
+	});
+});

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.test.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.test.tsx
@@ -10,7 +10,7 @@
  *    to read mode on Save).
  */
 import { useMemo, useState } from "react";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "@/lib/api/client";
 import type { MCPServer } from "@/types/mcp-servers";
@@ -29,9 +29,9 @@ vi.mock("@/lib/api/client", () => ({
 }));
 
 vi.mock("next/image", () => ({
-	default: (props: Record<string, unknown>) => (
-		// eslint-disable-next-line jsx-a11y/alt-text, @next/next/no-img-element
-		<img {...(props as React.ImgHTMLAttributes<HTMLImageElement>)} />
+	default: ({ alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+		// eslint-disable-next-line @next/next/no-img-element
+		<img alt={alt ?? ""} {...props} />
 	),
 }));
 
@@ -201,12 +201,14 @@ describe("agent tool map persistence", () => {
 			if (url === `/mcp-servers/${SERVER.id}/list-tools`) {
 				return connected
 					? Promise.resolve({ data: [{ name: "search" }] })
-					: Promise.reject({
-							response: {
-								status: 401,
-								data: { auth_url: "https://oauth.example.com" },
-							},
-						});
+					: Promise.reject(
+							Object.assign(new Error("Unauthorized"), {
+								response: {
+									status: 401,
+									data: { auth_url: "https://oauth.example.com" },
+								},
+							}),
+						);
 			}
 			return Promise.reject(new Error(`unexpected GET ${url}`));
 		});
@@ -343,9 +345,8 @@ describe("agent tool map persistence", () => {
 				initialServers={[{ mcpServerId: SERVER.id, tools: null }]}
 			/>,
 		);
-		const card = (await screen.findByText(SERVER.name)).closest("div");
-		expect(await within(card!.parentElement!).findByText("CONNECTED"))
-			.toBeInTheDocument();
+		// The single rendered card holds the pill — no scoping needed.
+		expect(await screen.findByText("CONNECTED")).toBeInTheDocument();
 		unmount();
 
 		mockApi({ connected: false, tools: [] });

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
@@ -84,19 +84,24 @@ export default function AgentToolList({
 		onMcpServersChange?.((prev) =>
 			prev.map((s) => {
 				if (s.mcpServerId !== serverId) return s;
+				// A Map lookup, not `s.tools[name]`: a tool named like a
+				// prototype member ("toString", …) must never resolve to an
+				// inherited value.
+				const existing = new Map(Object.entries(s.tools ?? {}));
+				// Keep the same object when nothing changed so an unchanged
+				// fetch never dirties the form or churns identities.
+				const upToDate =
+					s.tools !== null &&
+					existing.size === fetchedNames.length &&
+					fetchedNames.every((name) => existing.has(name));
+				if (upToDate) return s;
 				const merged: Record<string, ToolStatus> = Object.fromEntries(
 					fetchedNames.map((name) => [
 						name,
-						s.tools?.[name] ?? ("always_allow" as ToolStatus),
+						existing.get(name) ?? ("always_allow" as ToolStatus),
 					]),
 				);
-				// Keep the same object when nothing changed so an unchanged
-				// fetch never dirties the form or churns identities.
-				const same =
-					s.tools !== null &&
-					Object.keys(s.tools).length === fetchedNames.length &&
-					fetchedNames.every((name) => s.tools?.[name] === merged[name]);
-				return same ? s : { ...s, tools: merged };
+				return { ...s, tools: merged };
 			}),
 		);
 	};

--- a/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
+++ b/web/src/app/(protected)/agents/[id]/components/agent-tool-list.tsx
@@ -11,6 +11,8 @@ import { AgentMCPServerForm } from "../../lib/agent-form";
 import { api } from "@/lib/api/client";
 
 interface AgentToolListProps {
+	/** Saved agent id — undefined in create mode (`/agents/new`). */
+	agentId?: string;
 	mcpServers: AgentMCPServerForm[];
 	hasCodeInterpreter: boolean;
 	readOnly?: boolean;
@@ -24,14 +26,24 @@ interface AgentToolListProps {
 		update: (prev: AgentMCPServerForm[]) => AgentMCPServerForm[],
 	) => void;
 	onHasCodeInterpreterChange?: (enabled: boolean) => void;
+	/**
+	 * A read-mode connect persisted this binding's tool map server-side
+	 * (sync-tools) — lets the page refresh its copy of the saved agent.
+	 */
+	onBindingPersisted?: (
+		serverId: string,
+		tools: Record<string, ToolStatus>,
+	) => void;
 }
 
 export default function AgentToolList({
+	agentId,
 	mcpServers,
 	hasCodeInterpreter,
 	readOnly,
 	onMcpServersChange,
 	onHasCodeInterpreterChange,
+	onBindingPersisted,
 }: AgentToolListProps) {
 	const [allMCPServers, setAllMCPServers] = useState<MCPServer[]>([]);
 	const [dialogOpen, setDialogOpen] = useState(false);
@@ -62,19 +74,30 @@ export default function AgentToolList({
 		);
 	};
 
-	// Seed a never-synced binding, evaluated against the latest state: only fill
-	// when `tools` is still null so concurrent seeds merge instead of clobbering,
-	// and a user's in-progress edits are never overwritten.
-	const handleSeedTools = (
-		serverId: string,
-		tools: Record<string, ToolStatus>,
-	) => {
+	// Merge freshly fetched tool names into a binding's map, evaluated against
+	// the latest state so concurrent seeds and in-progress user edits are never
+	// clobbered. The fetched list is the key universe (stale keys drop out);
+	// existing statuses win, unknown tools default to enabled. This is what
+	// keeps the draft honest when a server has gained tools since the last
+	// save — the runtime excludes any tool missing from the saved map.
+	const handleSeedTools = (serverId: string, fetchedNames: string[]) => {
 		onMcpServersChange?.((prev) =>
-			prev.map((s) =>
-				s.mcpServerId === serverId && s.tools === null
-					? { ...s, tools }
-					: s,
-			),
+			prev.map((s) => {
+				if (s.mcpServerId !== serverId) return s;
+				const merged: Record<string, ToolStatus> = Object.fromEntries(
+					fetchedNames.map((name) => [
+						name,
+						s.tools?.[name] ?? ("always_allow" as ToolStatus),
+					]),
+				);
+				// Keep the same object when nothing changed so an unchanged
+				// fetch never dirties the form or churns identities.
+				const same =
+					s.tools !== null &&
+					Object.keys(s.tools).length === fetchedNames.length &&
+					fetchedNames.every((name) => s.tools?.[name] === merged[name]);
+				return same ? s : { ...s, tools: merged };
+			}),
 		);
 	};
 
@@ -126,14 +149,18 @@ export default function AgentToolList({
 					{enabledServers.map((server) => (
 						<AgentMCPServer
 							key={server.id}
+							agentId={agentId}
 							server={server}
 							binding={bindingFor(server.id)}
 							readOnly={readOnly}
 							onToolsChange={(tools) => {
 								handleToolsChange(server.id, tools);
 							}}
-							onSeedTools={(tools) => {
-								handleSeedTools(server.id, tools);
+							onSeedTools={(fetchedNames) => {
+								handleSeedTools(server.id, fetchedNames);
+							}}
+							onToolsPersisted={(tools) => {
+								onBindingPersisted?.(server.id, tools);
 							}}
 							onRemove={() => {
 								handleRemoveServer(server.id);

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -469,14 +469,20 @@ export default function AgentEditor({
 							}));
 						}}
 						onBindingPersisted={(serverId, tools) => {
-							// A read-mode connect wrote the binding server-side;
+							// A read-mode sync wrote the binding server-side;
 							// mirror it into the store so the next edit-mode
 							// snapshot (and dirty baseline) starts from what is
-							// actually saved.
+							// actually saved. Read the store's latest copy, not
+							// the `agent` prop: several bindings can self-heal
+							// concurrently, and a render-closure snapshot would
+							// let the later callback revert a sibling's map.
 							if (!agent) return;
+							const current =
+								useAgentsStore
+									.getState()
+									.agents.find((a) => a.id === agent.id) ?? agent;
 							updateAgent(agent.id, {
-								...agent,
-								mcpServers: (agent.mcpServers ?? []).map((server) =>
+								mcpServers: (current.mcpServers ?? []).map((server) =>
 									server.mcpServerId === serverId
 										? { ...server, tools }
 										: server,

--- a/web/src/app/(protected)/agents/components/agent-editor.tsx
+++ b/web/src/app/(protected)/agents/components/agent-editor.tsx
@@ -458,6 +458,7 @@ export default function AgentEditor({
 				{/* Right: capabilities */}
 				<div className="min-w-0 overflow-y-auto bg-sidebar p-7 md:flex-1 dark:bg-white/[0.02] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 					<AgentToolList
+						agentId={agent?.id}
 						readOnly={readOnly}
 						mcpServers={form.mcpServers}
 						hasCodeInterpreter={form.hasCodeInterpreter}
@@ -466,6 +467,21 @@ export default function AgentEditor({
 								...prev,
 								mcpServers: update(prev.mcpServers),
 							}));
+						}}
+						onBindingPersisted={(serverId, tools) => {
+							// A read-mode connect wrote the binding server-side;
+							// mirror it into the store so the next edit-mode
+							// snapshot (and dirty baseline) starts from what is
+							// actually saved.
+							if (!agent) return;
+							updateAgent(agent.id, {
+								...agent,
+								mcpServers: (agent.mcpServers ?? []).map((server) =>
+									server.mcpServerId === serverId
+										? { ...server, tools }
+										: server,
+								),
+							});
 						}}
 						onHasCodeInterpreterChange={(enabled) => {
 							setField("hasCodeInterpreter", enabled);


### PR DESCRIPTION
## Problem

Two reported behaviours, one root cause (full write-up in `agent-tools-map-not-saved.md`, reproduced by tests before fixing):

1. Adding an **OAuth MCP server** to an agent: after consent the tools loaded in the UI, but the binding stayed `tools=null` → agent "not configured", chat ran without the tools.
2. A bound server **gained new tools**: they appeared enabled in the UI but were never saved into the map → the runtime kept excluding them.

The runtime (`toolset.py`) excludes any tool missing from the saved map, while the editor UI rendered unknown tools as `always_allow` — and the explicit-save refactor only seeded `tools === null` bindings, skipped seeding in read mode, and dropped the old post-OAuth discovery calls entirely (`sync-tools` existed but was never called).

## Fix

- **Edit mode — merge-seed**: fetched tools merge into the draft map (fetched list is the key universe, curated statuses preserved, vanished tools dropped). An out-of-date map dirties the form so the UNSAVED chip and Save are honest; an up-to-date map produces zero changes.
- **Read mode — self-heal on view**: whenever tools are fetched (page load for connected servers, incl. no-auth/API-key, and after the OAuth connect poll) and the fetched names disagree with the saved map, the frontend calls `POST /agents/{id}/mcp-servers/{id}/sync-tools` and mirrors the saved map into the agents store. Up-to-date maps never write.
- **Backend `_sync_tools` merges instead of clobbering**: server tool list is the key universe, existing `needs_approval`/`disabled` statuses survive a re-sync, new tools default to `always_allow`.
- **Connected pill**: each MCP server card in the agent editor now shows CONNECTED / NOT CONNECTED.

## Tests

- `web`: `agent-tool-list.test.tsx` — 8 tests covering merge-seed (preserve/drop/no-spurious-dirty), the read-mode OAuth connect poll persisting via sync-tools (fake timers), read-mode self-heal for null and stale maps, no write for current maps, and the pills. Full suite: 41 passed.
- `backend`: `_sync_tools` merge semantics (seed, preserve-curated/drop-vanished, keep map on connect failure). Module: 34 passed. Ruff clean.

## Known boundary

The map updates on page views only — agents run exclusively via triggers/Slack keep a stale map until someone opens the page. Runtime-side sync during `Agent.build` would close that; noted in the write-up as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists MCP tool maps so the runtime binds the same tools the editor shows. Previously, OAuth-connected servers or servers that gained tools looked enabled in the UI but the saved map stayed null or stale, so the runtime excluded them.

- Edit mode: merge-seed fetched tool names into the draft map (existing `needs_approval`/`disabled` preserved, new default to `always_allow`, vanished dropped). The form dirties only when the map actually changes.
- Read mode: when fetched tool names disagree with the saved map, call `POST /agents/{id}/mcp-servers/{id}/sync-tools` and mirror the saved map into the store; up-to-date maps never write. OAuth connect uses the same path, guards overlapping poll ticks, flips `isConnected` after tools are fetched to avoid duplicate syncs, and if the post-connect fetch fails it still marks CONNECTED so the mount effect retries.
- Backend: `_sync_tools` now merges instead of clobbering and reloads the row `FOR UPDATE` before merging to avoid lost updates; curated statuses survive, new tools default to `always_allow`.
- UI: each MCP server card shows a CONNECTED / NOT CONNECTED pill. Merge-seed uses Map-based lookups to avoid prototype-name collisions.

**Review and rollout**
- Frontend: `web/.../agent-tool-list.tsx`, `web/.../agent-mcp-server.tsx`, `web/.../agent-editor.tsx`. Backend: `backend/app/agents/mcp_servers/service.py`. Doc: `agent-tools-map-not-saved.md`.
- Tests cover edit merge-seed, read-mode self-heal (incl. OAuth and fetch-failure recovery), backend merge and lost-update guard: `web/.../agent-tool-list.test.tsx`, `backend/tests/agents/mcp_servers/test_service.py`.
- No migration. Existing agents self-heal on page view or immediately after OAuth connect; agents used only via triggers/Slack remain stale until someone opens the agent page.

<sup>Written for commit 9b8817a45ca2c2086e7afd3ae9ced6416c7fbea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

