### PR TITLE
perf(web): cut the /agents page request storm

### DIFF
--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -181,8 +181,9 @@ export default function AgentList({
 	const fetchAgents = useAgentsStore((state) => state.fetchAgents);
 	const removeAgent = useAgentsStore((state) => state.removeAgent);
 	const [archivedAgents, setArchivedAgents] = useState<Agent[]>([]);
-	// Starts true and never flips back: re-entering the archived view shows the
-	// previous data while the refetch runs, like the store-backed views do.
+	// The parent keys AgentList by active/archived, so entering the Archived
+	// view mounts a fresh instance: this starts true and flips false once the
+	// fetch resolves (the pre-store behavior, unchanged).
 	const [archivedLoading, setArchivedLoading] = useState(true);
 
 	useEffect(() => {

--- a/web/src/app/(protected)/agents/components/agent-list.tsx
+++ b/web/src/app/(protected)/agents/components/agent-list.tsx
@@ -7,6 +7,7 @@ import AgentCard from "@/app/(protected)/agents/components/agent-card";
 import AgentTable from "@/app/(protected)/agents/components/agent-table";
 import type { ViewMode } from "@/components/ui/view-toggle";
 import { api } from "@/lib/api/client";
+import { useAgentsStore } from "@/stores/agents-store";
 
 type View = "available" | "all" | "archived";
 
@@ -172,23 +173,49 @@ export default function AgentList({
 	onCreateAgent,
 }: AgentListProps) {
 	const archived = view === "archived";
-	const [agents, setAgents] = useState<Agent[]>([]);
-	const [isLoading, setIsLoading] = useState(true);
+	// Live views read the shared store (already fetched by the sidebar), so
+	// visiting the page never re-requests the list. Archived agents aren't in
+	// the store; that view keeps its own fetch.
+	const storeAgents = useAgentsStore((state) => state.agents);
+	const storeReady = useAgentsStore((state) => state.isInitialized);
+	const fetchAgents = useAgentsStore((state) => state.fetchAgents);
+	const removeAgent = useAgentsStore((state) => state.removeAgent);
+	const [archivedAgents, setArchivedAgents] = useState<Agent[]>([]);
+	// Starts true and never flips back: re-entering the archived view shows the
+	// previous data while the refetch runs, like the store-backed views do.
+	const [archivedLoading, setArchivedLoading] = useState(true);
 
 	useEffect(() => {
+		if (!archived) {
+			fetchAgents().catch(console.error);
+			return;
+		}
 		api
-			.get<Agent[]>(archived ? "/agents?archived=true" : "/agents")
+			.get<Agent[]>("/agents?archived=true")
 			.then((response) => {
-				setAgents(response.data);
+				setArchivedAgents(response.data);
 			})
 			.catch(console.error)
 			.finally(() => {
-				setIsLoading(false);
+				setArchivedLoading(false);
 			});
-	}, [archived]);
+	}, [archived, fetchAgents]);
+
+	const agents = archived ? archivedAgents : storeAgents;
+	const isLoading = archived ? archivedLoading : !storeReady;
 
 	const handleRemoved = (agentId: string) => {
-		setAgents((prev) => prev.filter((a) => a.id !== agentId));
+		if (archived) {
+			setArchivedAgents((prev) => prev.filter((a) => a.id !== agentId));
+			// A restored agent belongs in the live list again; a permanent delete
+			// changes nothing there. We can't tell which happened, so refresh.
+			void useAgentsStore
+				.getState()
+				.refreshAgents()
+				.catch(() => {});
+			return;
+		}
+		removeAgent(agentId);
 	};
 
 	const matches = useMemo(() => {

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -281,6 +281,10 @@ export function AppSidebar() {
 											>
 												<Link
 													href={`/agents/${thread.agentId}/chat/${thread.id}`}
+													// Every visible link would otherwise fire two router
+													// prefetches on page load — dozens of requests for
+													// threads the user rarely opens.
+													prefetch={false}
 													className="flex items-center gap-1.5 px-[5px]"
 												>
 													<span className="flex w-7 shrink-0 items-center justify-center">

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -7,6 +7,19 @@ export async function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 	const accessToken = request.cookies.get("access_token")?.value;
 	const isPublicPath = PUBLIC_PATHS.some((path) => pathname.startsWith(path));
+
+	// Router prefetches (Next 16 issues two per visible <Link>: a route-tree
+	// request and a segment request) would each pay a blocking backend
+	// round-trip here. They only warm the client cache — the real navigation
+	// still gets verified, and the backend authenticates every data call — so
+	// let them through unverified.
+	const isPrefetch =
+		request.headers.has("next-router-prefetch") ||
+		request.headers.has("next-router-segment-prefetch");
+	if (accessToken && isPrefetch && !isPublicPath) {
+		return NextResponse.next();
+	}
+
 	if (accessToken) {
 		try {
 			const verifyRes = await fetch(`${process.env.BACKEND_URL}/auth/me`, {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -12,7 +12,10 @@ export async function proxy(request: NextRequest) {
 	// request and a segment request) would each pay a blocking backend
 	// round-trip here. They only warm the client cache — the real navigation
 	// still gets verified, and the backend authenticates every data call — so
-	// let them through unverified.
+	// let them through unverified. Accepted trade-off: with an expired or
+	// revoked token, a prefetched server render's backend calls 401 and the
+	// prefetch is discarded; no protected data is served, and the actual
+	// navigation still redirects to /auth and clears the cookie.
 	const isPrefetch =
 		request.headers.has("next-router-prefetch") ||
 		request.headers.has("next-router-segment-prefetch");

--- a/web/src/stores/agents-store.ts
+++ b/web/src/stores/agents-store.ts
@@ -6,12 +6,17 @@ interface AgentsState {
 	agents: Agent[];
 	isInitialized: boolean;
 	fetchAgents: () => Promise<void>;
+	refreshAgents: () => Promise<void>;
 	addAgent: (agent: Agent) => void;
 	updateAgent: (agentId: string, agent: Partial<Agent>) => void;
 	removeAgent: (agentId: string) => void;
 	applyTagUpdate: (tag: AgentTag) => void;
 	applyTagRemoval: (tagId: string) => void;
 }
+
+// Shared across callers so concurrent mounts (sidebar + list page) coalesce
+// into a single /agents request instead of racing before isInitialized flips.
+let inflight: Promise<void> | null = null;
 
 export const useAgentsStore = create<AgentsState>((set, get) => ({
 	agents: [],
@@ -20,15 +25,22 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
 		if (get().isInitialized) {
 			return;
 		}
-
-		try {
-			const response = await api.get("/agents");
-			set({ agents: response.data, isInitialized: true });
-		} catch (error) {
-			console.error("Error fetching agents:", error);
-			set({ isInitialized: true });
-			throw error;
-		}
+		return get().refreshAgents();
+	},
+	refreshAgents: async () => {
+		inflight ??= (async () => {
+			try {
+				const response = await api.get("/agents");
+				set({ agents: response.data, isInitialized: true });
+			} catch (error) {
+				console.error("Error fetching agents:", error);
+				set({ isInitialized: true });
+				throw error;
+			} finally {
+				inflight = null;
+			}
+		})();
+		return inflight;
 	},
 	addAgent: (agent) => { set((state) => ({ agents: [agent, ...state.agents] })); },
 	updateAgent: (agentId, agent) =>

--- a/web/src/stores/agents-store.ts
+++ b/web/src/stores/agents-store.ts
@@ -25,10 +25,13 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
 		if (get().isInitialized) {
 			return;
 		}
+		if (inflight) {
+			return inflight;
+		}
 		return get().refreshAgents();
 	},
 	refreshAgents: async () => {
-		inflight ??= (async () => {
+		const load = async () => {
 			try {
 				const response = await api.get("/agents");
 				set({ agents: response.data, isInitialized: true });
@@ -36,11 +39,20 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
 				console.error("Error fetching agents:", error);
 				set({ isInitialized: true });
 				throw error;
-			} finally {
+			}
+		};
+		// A refresh must observe server state from after the caller's mutation,
+		// so it never joins a request that may have started earlier — it queues
+		// a fresh GET behind any in-flight one instead.
+		const next = inflight ? inflight.catch(() => {}).then(load) : load();
+		inflight = next;
+		try {
+			await next;
+		} finally {
+			if (inflight === next) {
 				inflight = null;
 			}
-		})();
-		return inflight;
+		}
 	},
 	addAgent: (agent) => { set((state) => ({ agents: [agent, ...state.agents] })); },
 	updateAgent: (agentId, agent) =>


### PR DESCRIPTION
## Problem

Opening or refreshing `/agents` took >1s. The Network tab showed ~37 requests: Next 16's Segment Cache prefetches two requests per visible sidebar thread link (~11 links → ~22 requests, indistinguishable from page GETs since Next 16 dropped `?_rsc`), every one of them paying a blocking `fetch(BACKEND_URL/auth/me)` in the middleware — plus the `/agents` list being fetched twice (sidebar store + the page's own fetch, with no in-flight dedupe).

## Changes

- **Middleware** (`proxy.ts`): requests carrying `next-router-prefetch` / `next-router-segment-prefetch` headers skip the backend auth round-trip. They only warm the client router cache — the real navigation is still verified, and the backend authenticates every data call.
- **Sidebar**: `prefetch={false}` on recent-thread links, removing the ~2×N prefetch storm. Nav links still prefetch.
- **Agents store**: concurrent `fetchAgents()` callers coalesce behind one in-flight promise (fixes the Strict-Mode/double-mount double fetch); new `refreshAgents()` forces a refetch.
- **Agent list**: live views read from the shared store (already populated by the sidebar) instead of refetching — opening `/agents` now typically issues zero list requests. The archived view keeps its own fetch (archived agents aren't in the store) and refreshes the store after restore/delete, since a restored agent belongs back in the live list.

## Behavior note

The agents list is now cached for the session (stale-while-revalidate): edits made through the app keep the store in sync via the existing `updateAgent`/`addAgent`/`removeAgent` calls; changes by other users appear on reload.

## Verification

- `tsc --noEmit` clean (only pre-existing `node_modules` noise)
- `eslint` clean on the four changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the /agents request storm by bypassing backend auth on Next 16 router prefetches, disabling sidebar thread prefetch, and deduping the agents list fetch. Before: each prefetch triggered a blocking `auth/me` and the page fetched agents twice; now live views typically issue zero list requests.

- proxy.ts: skip backend `auth/me` for requests with `next-router-prefetch` or `next-router-segment-prefetch` on non-public paths when an `access_token` exists. Real navigations and all API calls still verify. Accepted trade-off: with an expired/revoked token, a prefetched render 401s and is discarded; the actual navigation still redirects to /auth and clears the cookie.
- Sidebar: set `prefetch={false}` on recent-thread `<Link>`s to stop 2×N router prefetches.
- Agents store: coalesce concurrent `fetchAgents()` behind one in‑flight promise. Add `refreshAgents()` for forced refetches; it now queues a fresh GET behind any in‑flight request instead of joining it, so post‑mutation refreshes cannot observe pre‑mutation state.
- Agent list: live views read from the shared store; archived view keeps its own `/agents?archived=true` fetch and calls `refreshAgents()` after restore/delete.

- Agents list is session-cached (stale-while-revalidate). In‑app edits keep the store in sync; other users’ changes appear on reload. Auth behavior for actual navigations and data requests is unchanged; only prefetch warmups bypass backend auth.

<sup>Written for commit 08d2aea3eb1e9ee47ef62b2fb6e92b2946c85bc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

