### PR TITLE
perf(agents): drop instructions and tool maps from the list response

### DIFF
--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -9,6 +9,7 @@ from app.agents.mcp_servers.service import (
 )
 from app.agents.schemas import (
     AgentConfig,
+    AgentListResponse,
     AgentMCPServerCreate,
     AgentMCPServerPatch,
     AgentMCPServerResponse,
@@ -52,7 +53,10 @@ async def create_agent(
     )
 
 
-@router.get("/", response_model=list[AgentResponse])
+# The list endpoint serializes through the slim schema: response_model
+# filtering drops `instructions` and the bindings' tool maps, which cuts the
+# payload by ~80% on real workspaces. Detail (GET /{agent_id}) stays full.
+@router.get("/", response_model=list[AgentListResponse])
 async def get_agents(
     archived: bool = False,
     current_user: UserDB = Depends(get_current_user),

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -91,6 +91,17 @@ class AgentMCPServerPatch(SQLModel):
     tools: dict[str, ToolStatus] | None = None
 
 
+class AgentMCPServerListResponse(SQLModel):
+    """Slim binding for list responses — identifies the server without the
+    per-tool map, which only the agent detail/editor flow consumes."""
+
+    id: UUID
+    agent_id: UUID
+    mcp_server_id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+
 class AgentMCPServerResponse(AgentMCPServerBase):
     id: UUID
     created_at: datetime
@@ -142,10 +153,17 @@ class AgentOwnerInfo(SQLModel):
     email: str | None = None
 
 
-class AgentResponse(SQLModel):
+class AgentListResponse(SQLModel):
+    """List-row projection: everything the agents list and pickers render.
+
+    Omits the heavyweight fields — ``instructions`` (agent prompts run to
+    tens of KB each) and the bindings' per-tool maps — which only the detail
+    endpoint returns. GET /agents/ serializes through this schema; the
+    service still assembles full ``AgentResponse`` objects internally.
+    """
+
     id: UUID
     name: str
-    instructions: str
     owner_id: UUID
     emoji: str | None
     color: str | None
@@ -154,9 +172,14 @@ class AgentResponse(SQLModel):
     is_archived: bool = False
     created_at: datetime
     updated_at: datetime
-    mcp_servers: list[AgentMCPServerResponse] | None = None
+    mcp_servers: list[AgentMCPServerListResponse] | None = None
     subagents: list[SubagentResponse] | None = None
     tag: TagInfo | None = None
     owner: AgentOwnerInfo | None = None
     is_subagent: bool = False
     current_user_permission: str | None = None
+
+
+class AgentResponse(AgentListResponse):
+    instructions: str
+    mcp_servers: list[AgentMCPServerResponse] | None = None

--- a/web/src/app/(protected)/agents/components/agent-detail.tsx
+++ b/web/src/app/(protected)/agents/components/agent-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Agent } from "@/types/agents";
 import AgentEditor from "./agent-editor";
 import { useAgentsStore } from "@/stores/agents-store";
@@ -17,9 +17,21 @@ interface AgentDetailProps {
 export default function AgentDetail({ agent }: AgentDetailProps) {
 	const updateAgent = useAgentsStore((state) => state.updateAgent);
 
-	const liveAgent = useAgentsStore(
-		(state) => state.agents.find((a) => a.id === agent.id) ?? agent,
+	const storeAgent = useAgentsStore((state) =>
+		state.agents.find((a) => a.id === agent.id),
 	);
+
+	// The list fetch stores slim rows (no instructions / tool maps), and the
+	// editor snapshots its form from the first agent it renders with — so a
+	// slim copy must never reach it (a save would wipe the missing fields).
+	// Use the store copy only once it's full (merged below or written back by
+	// a save); otherwise fall back to the server-rendered full prop.
+	const liveAgent = useMemo(() => {
+		if (!storeAgent || storeAgent.instructions === undefined) {
+			return agent;
+		}
+		return storeAgent;
+	}, [storeAgent, agent]);
 
 	const [mode, setMode] = useState<"read" | "edit">("read");
 

--- a/web/src/types/agents.ts
+++ b/web/src/types/agents.ts
@@ -4,7 +4,9 @@ export type ToolStatus = "always_allow" | "needs_approval" | "disabled";
 
 interface AgentMCPServer extends MCPServer {
 	mcpServerId: string;
-	tools: Record<string, ToolStatus> | null;
+	/** Absent on list responses; the detail response carries the full map
+	 * (null = never synced). */
+	tools?: Record<string, ToolStatus> | null;
 }
 
 export type AgentPermission = "owner" | "admin" | "editor" | "member";
@@ -35,7 +37,9 @@ export interface AgentOwner {
 export interface Agent {
 	id: string;
 	name: string;
-	instructions: string;
+	/** Absent on list responses (GET /agents returns slim rows); present on
+	 * detail responses (GET /agents/{id}) and save results. */
+	instructions?: string;
 	ownerId: string;
 	emoji?: string | null;
 	color?: string | null;


### PR DESCRIPTION
## Problem

Follow-up to #265. With the request storm gone, the remaining cost of the /agents page is the list payload itself: `GET /agents/` returned every agent's full `instructions` text plus each MCP binding's per-tool map. In dev that's 80KB for 13 agents (one prompt alone is 32KB); on a 167-agent workspace it's roughly an order of magnitude more — all for fields nothing on the list page renders.

## Changes

**Backend** — `AgentResponse` is split into a slim base + full detail:
- `AgentListResponse` / `AgentMCPServerListResponse`: everything the list and pickers render, minus `instructions` and `tools`
- `AgentResponse(AgentListResponse)` keeps the full shape for `GET /agents/{id}`, create, patch, config-save, and restore
- The list endpoint serializes through `response_model=list[AgentListResponse]`; the service layer is untouched (Slack handlers etc. still see full objects)

**Web**:
- `Agent.instructions` and binding `tools` become optional (absent on list rows, present on detail/save responses)
- `AgentDetail` hands the store copy to the editor only once it's full (`instructions !== undefined`), falling back to the server-rendered prop otherwise. This matters: the editor snapshots its form from the first agent it renders with, and a slim snapshot saved through the full-replace `PUT /config` would wipe instructions/tool config (the #262 bug class). The store's slim rows can never reach the editor now.

## Measured

- List payload: **80,380B → 10,094B (−87%)** on the dev workspace, verified against the running backend; detail response unchanged (full instructions + tools)
- Backend list latency stays ~12–30ms; the win is serialization, transfer, and client parse — it scales with workspace size

## Verification

- `uv run pytest tests/agents/core` — 115 passed
- `ruff check` / `ruff format` clean
- `tsc --noEmit` and `eslint` clean on the web changes
- Live curl checks: list response has no `instructions` and slim `mcp_servers`; `GET /agents/{id}` still returns both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `instructions` and per-binding tool maps from `GET /agents` to shrink list payloads by ~87%. `GET /agents/{id}` still returns the full agent, so detail behavior is unchanged.

- API: `GET /agents` excludes `instructions` and `mcp_servers[*].tools`; `GET /agents/{id}` remains full.
- Backend: adds `AgentListResponse` and `AgentMCPServerListResponse`; the list endpoint serializes via the slim schema; services still use full `AgentResponse` objects.
- Web: makes `Agent.instructions` and binding `tools` optional; `AgentDetail` only passes a full agent to the editor (falls back to the server-rendered prop until the store has `instructions`), preventing saves from wiping missing fields.

**Migration**
- If a client relied on `instructions` or `mcp_servers[*].tools` from the list response, fetch the detail (`GET /agents/{id}`) or treat these fields as optional.

<sup>Written for commit 9fd59b043acc51c48ccd8d138806dae79953d1d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

