### PR TITLE
perf(api): gzip JSON responses

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.agents.router import router as agents_router
@@ -194,6 +195,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Compress JSON responses (the /agents list alone runs to hundreds of KB on
+# large workspaces). Starlette excludes text/event-stream by default, so the
+# /runs/stream SSE endpoints keep flushing tokens unbuffered.
+app.add_middleware(GZipMiddleware, minimum_size=1024)
 
 # SessionMiddleware is required for OAuth flows (stores state during authorization)
 app.add_middleware(


### PR DESCRIPTION
## Problem

Neither the backend nor the Next proxy compresses anything, so large JSON payloads cross every network leg uncompressed. The `/agents` list is the worst offender — hundreds of KB on real workspaces (167 agents), and #267 only shrinks the JSON itself, not the wire format.

## Change

`GZipMiddleware` on the FastAPI app (`minimum_size=1024`): responses under 1KB stay untouched, everything larger is compressed when the client sends `Accept-Encoding: gzip` (browsers and Node/undici both do).

**Streaming stays safe**: Starlette 0.52 excludes `text/event-stream` from compression by default, and both `/runs/stream` endpoints use exactly that media type — token streaming keeps flushing unbuffered.

## Measured

Against the running dev backend: `/agents` body **80,380B → 24,600B (−69%)**, `Content-Encoding: gzip` + `Vary: Accept-Encoding` set correctly. Combined with #267's slim payload, the list lands around ~3KB on the wire.

## Verification

- Full backend suite: 623 passed (one pre-existing local failure, `test_publishable_copy_matches_bundled_snapshot`, is caused by an uncommitted local `catalog/catalog.yaml` edit — unrelated)
- `ruff check` clean
- Live curl checks with `Accept-Encoding: gzip` vs `identity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compresses large JSON responses to reduce bandwidth and latency. Previously all responses were uncompressed; now responses ≥1KB are gzipped when the client sends Accept-Encoding: gzip, with SSE left uncompressed.

- Adds Starlette `GZipMiddleware(minimum_size=1024)` to the `FastAPI` app.
- Excludes `text/event-stream`; `/runs/stream` continues to flush tokens without buffering.
- Automatically sets `Content-Encoding: gzip` and `Vary: Accept-Encoding`.
- Measured: `/agents` body 80,380B → 24,600B (−69%) in dev; with #267’s payload trim, ~3KB on the wire.
- No client changes required; browsers and Node/undici already advertise gzip.

<sup>Written for commit 26dc20096576274500c3ab55c9e556c0faeb2df0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

