### PR TITLE
fix(web): strip stale encoding headers in the backend proxy

### DIFF
--- a/web/src/app/api/backend/[...path]/route.ts
+++ b/web/src/app/api/backend/[...path]/route.ts
@@ -26,9 +26,16 @@ async function proxyRequest(
 		duplex: "half",
 	});
 
+	// fetch already decoded any Content-Encoding on the backend response, so
+	// the encoding headers describe a body we no longer have — forwarding
+	// them makes the browser try to gunzip plain JSON and fail every call.
+	const responseHeaders = new Headers(response.headers);
+	responseHeaders.delete("content-encoding");
+	responseHeaders.delete("content-length");
+
 	return new Response(response.body, {
 		status: response.status,
-		headers: response.headers,
+		headers: responseHeaders,
 	});
 }
 


### PR DESCRIPTION
## Problem

Urgent follow-up to #268 — **without this, gzip breaks the whole app behind the Next proxy.**

Node's `fetch` (undici) transparently decompresses the backend's gzipped body, but leaves `content-encoding: gzip` and the original `content-length` in `response.headers`. The proxy route forwarded those headers verbatim with the already-decoded body, so the browser attempted to gunzip plain JSON, every `/api/backend/*` response failed to decode, and all stores rendered empty (agents, threads, MCP servers, triggers).

## Change

The proxy deletes `content-encoding` and `content-length` from the forwarded response headers — they describe the encoded body, which no longer exists after fetch's decoding. SSE streaming is unaffected (excluded from gzip upstream; streaming responses carry neither header).

## Verified

Reproduced against the running dev stack (empty agents page), applied the fix, and confirmed `/api/backend/agents` returns valid JSON with all 13 agents again.

⚠️ Recommend merging before deploying the #268 release — or deploying both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips stale Content-Encoding headers in the backend proxy so decoded responses render correctly. Before: the proxy forwarded `content-encoding: gzip` and the original `content-length` even though `fetch` (`undici`) had already decompressed the body, causing the browser to try to gunzip plain JSON and fail. After: the proxy removes both headers and returns the decoded body with accurate headers.

- Affects only non-SSE responses; SSE is not gzip’d upstream and does not include these headers.
- Change is limited to `web/src/app/api/backend/[...path]/route.ts`; no config or client changes required.

<sup>Written for commit 8107ca55e64b09e9a364afc11a9f53253c8d5436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

