### PR TITLE
deps(backend): upgrade langfuse SDK to v4

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "mcp>=1.26.0",
     "slack-sdk>=3.34.0",
     "aiohttp>=3.13.3",
-    "langfuse>=3.14.1",
+    "langfuse>=4.14.4",
     "h2>=4.3.0",
     "langchain-ai-sdk-adapter",
     "deepagents>=0.5.6",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -349,7 +349,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.2.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=1.1.1" },
-    { name = "langfuse", specifier = ">=3.14.1" },
+    { name = "langfuse", specifier = ">=4.14.4" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.1" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "opensandbox", specifier = ">=0.1.6" },
@@ -1420,23 +1420,21 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "3.14.1"
+version = "4.14.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "httpx" },
-    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pydantic" },
-    { name = "requests" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/7a/ddd8df7f2c5d8c2112a8b20fa88b2513917e2c25d2ef87034c0927f87596/langfuse-3.14.1.tar.gz", hash = "sha256:404a6104cd29353d7829aa417ec46565b04917e5599afdda96c5b0865f4bc991", size = 234530, upload-time = "2026-02-09T15:37:45.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/3f/d3387db1f472d2fd4b5de40eb6abedc2f59c9da2224e9d0a79d054a90b81/langfuse-4.14.4.tar.gz", hash = "sha256:48c4bdefc290f61a42881b8048a904ab6b81d37e02496473166836e71ee0ab3a", size = 389680, upload-time = "2026-08-11T17:03:20.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/b9/e8ac3072469737358975da66ec4218dc1cee0051555dd4665b3e34a28420/langfuse-3.14.1-py3-none-any.whl", hash = "sha256:17bed605dbfc9947cbd1738a715f6d27c1b80b6da9f2946586171958fa5820d0", size = 420336, upload-time = "2026-02-09T15:37:44.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1b/a198adc52aa4ffd0886ca0d4e9bb97d45f4f326db206d2395bac67677f5d/langfuse-4.14.4-py3-none-any.whl", hash = "sha256:78692a1d4785a8c255bf6ea967e673e1ee30ce078d646e7b5f7ff44549d45cce", size = 688351, upload-time = "2026-08-11T17:03:21.881Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `langfuse` from **3.14.1** to **4.14.4** (pin floor raised to `>=4.14.4` so v3 can no longer resolve), ahead of upgrading our Langfuse instance to v4.

No code changes required — our entire integration surface is unchanged in SDK v4:

- `Langfuse(public_key, secret_key, host, timeout)` constructor (`app/integrations/langfuse/callback.py`) — verified all kwargs still exist
- `CallbackHandler` from `langfuse.langchain` — still subclasses `langchain_core`'s `BaseCallbackHandler`, compatible with our langchain 1.2.x (no langchain bump needed; langfuse has no langchain dependency)
- `langfuse_session_id` metadata key (`app/agents/runtime.py`) — still the documented v4 approach for session grouping

v4 breaking changes (`start_span`/`start_generation` → `start_observation`, `update_current_trace` → `propagate_attributes`, datasets API, `api.*` namespace, default OTel span filter) all target APIs we don't use.

Reference: https://langfuse.com/docs/observability/sdk/upgrade-path/python-v3-to-v4

## Test plan

- [x] `uv lock --upgrade-package langfuse && uv sync` — only langfuse moved in the lockfile
- [x] Import/signature check of constructor, handler, and `app.integrations.langfuse.callback` against the installed 4.14.4
- [ ] After deploy: run one agent turn with Langfuse env vars set and confirm the trace lands grouped under the thread's session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade backend dependency `langfuse` from 3.14.1 to 4.14.4 and raise the minimum to `>=4.14.4` to prepare for our Langfuse v4 instance. No behavior change; our integration surface is unchanged and we don’t use removed v4 APIs.

- Code: only `backend/pyproject.toml` and `backend/uv.lock` updated; no application code changes.
- Compatibility: existing usage stays valid (`Langfuse(...)` constructor, `langfuse.langchain.CallbackHandler`, `langfuse_session_id` metadata); no `langchain` bump required.
- Action: run `uv sync` to install `langfuse` v4 locally. After deploy, with Langfuse env vars set, run one agent turn and confirm the trace groups under the thread session.

<sup>Written for commit aa560921afea652dceb71d2a09edf523defe6348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

