### PR TITLE
feat(users): store SSO profile pictures and show avatars in users table

### DIFF
--- a/backend/CONVENTIONS.md
+++ b/backend/CONVENTIONS.md
@@ -150,7 +150,7 @@ Relationship and filter qualifiers stay (`list_for_user`, `list_for_supervisor`,
 
 These are not generic CRUD; they name a domain action and stay as-is:
 
-- **Auth**: `signin`, `signout`, `setup`, `accept_invite`, `google_signin_or_link`
+- **Auth**: `signin`, `signout`, `setup`, `accept_invite`, `oauth_signin_or_link`
 - **MCP / tools**: `sync_tools`, `reset_server`, `list_tools`, `handle_oauth_callback`
 - **Misc**: `encrypt_value` / `decrypt_value`, `sanitize_tool_name`, `wrap_tool_errors`
 - **Scheduling**: `claim_*` (`claim_due`, `claim_and_enqueue`) — atomically lock-and-take due work so concurrent workers partition it (`FOR UPDATE SKIP LOCKED`); a claim both reads and consumes, so neither `list_*` nor `update_*` fits. `run_now` — fire one occurrence of a scheduled entity immediately, bypassing its schedule

--- a/backend/alembic/versions/1d60a5dabb57_add_picture_url_to_users.py
+++ b/backend/alembic/versions/1d60a5dabb57_add_picture_url_to_users.py
@@ -1,0 +1,30 @@
+"""add picture_url to users
+
+Revision ID: 1d60a5dabb57
+Revises: d7b3f1c05a92
+Create Date: 2026-08-21 15:51:13.278817
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '1d60a5dabb57'
+down_revision: Union[str, Sequence[str], None] = 'd7b3f1c05a92'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'users',
+        sa.Column('picture_url', sa.String(length=1024), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'picture_url')

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -187,10 +187,12 @@ async def google_callback(
     invite_token = request.session.pop("invite_token", None)
 
     try:
-        user, access_token = await service.google_signin_or_link(
-            google_sub=google_sub,
+        user, access_token = await service.oauth_signin_or_link(
+            provider="google",
+            sub_id=google_sub,
             email=email,
             name=userinfo.get("name"),
+            picture_url=userinfo.get("picture"),
             invite_token=invite_token,
         )
     except NoInviteError:
@@ -200,7 +202,8 @@ async def google_callback(
         )
 
     response = RedirectResponse(
-        url=f"{auth_settings.FRONTEND_URL}/agents", status_code=302,
+        url=f"{auth_settings.FRONTEND_URL}/agents",
+        status_code=302,
     )
     _attach_auth_cookie(response, access_token)
     return response

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -92,14 +92,28 @@ class AuthService:
         await self.db.refresh(user)
         return self.build_jwt_for_user(user)
 
-    async def google_signin_or_link(
+    def _refresh_picture(self, user: UserDB, picture_url: str | None) -> None:
+        """Update the cached avatar from the provider's claim on each sign-in.
+
+        Provider photo URLs rotate when users change their picture, so the
+        stored value is a cache refreshed at every OAuth sign-in. ``None`` is
+        left alone: a provider that stops sending the claim (or a secondary
+        provider without one) must not erase a previously stored avatar.
+        """
+        if picture_url and user.picture_url != picture_url:
+            user.picture_url = picture_url
+            self.db.add(user)
+
+    async def oauth_signin_or_link(
         self,
-        google_sub: str,
+        provider: str,
+        sub_id: str,
         email: str,
         name: str | None,
+        picture_url: str | None,
         invite_token: str | None,
     ) -> tuple[UserDB, str]:
-        """Resolve a Google OAuth identity to a user.
+        """Resolve an OAuth/OIDC identity to a user.
 
         - Existing OAuth link → returns the linked user.
         - Matching user by email → creates an OAuth link.
@@ -110,8 +124,8 @@ class AuthService:
         """
         result = await self.db.execute(
             select(OAuthAccountDB).where(
-                OAuthAccountDB.provider == "google",
-                OAuthAccountDB.sub_id == google_sub,
+                OAuthAccountDB.provider == provider,
+                OAuthAccountDB.sub_id == sub_id,
             )
         )
         oauth_account = result.scalar_one_or_none()
@@ -123,6 +137,8 @@ class AuthService:
             user = result.scalar_one_or_none()
             if not user:
                 raise DomainError("Linked user not found")
+            self._refresh_picture(user, picture_url)
+            await self.db.flush()
             return self.build_jwt_for_user(user)
 
         result = await self.db.execute(select(UserDB).where(UserDB.email == email))
@@ -131,11 +147,12 @@ class AuthService:
         if user:
             self.db.add(
                 OAuthAccountDB(
-                    provider="google",
-                    sub_id=google_sub,
+                    provider=provider,
+                    sub_id=sub_id,
                     user_id=user.id,
                 )
             )
+            self._refresh_picture(user, picture_url)
             await self.db.flush()
             return self.build_jwt_for_user(user)
 
@@ -150,6 +167,7 @@ class AuthService:
         user = UserDB(
             email=email,
             name=name,
+            picture_url=picture_url,
             role=WorkspaceRole(invite.role),
             team_id=invite.team_id,
         )
@@ -158,8 +176,8 @@ class AuthService:
 
         self.db.add(
             OAuthAccountDB(
-                provider="google",
-                sub_id=google_sub,
+                provider=provider,
+                sub_id=sub_id,
                 user_id=user.id,
             )
         )

--- a/backend/app/users/models.py
+++ b/backend/app/users/models.py
@@ -17,6 +17,7 @@ class UserBase(SQLModel):
     email: str | None = Field(default=None, max_length=255, unique=True, index=True)
     password_hash: str | None = Field(default=None)
     role: WorkspaceRole = Field(default=WorkspaceRole.member, nullable=False)
+    picture_url: str | None = Field(default=None, max_length=1024)
 
 
 class UserDB(UserBase, BaseDBModel, table=True):

--- a/backend/app/users/schemas.py
+++ b/backend/app/users/schemas.py
@@ -33,6 +33,7 @@ class UserResponse(SQLModel):
     email: str | None
     role: WorkspaceRole
     team_id: UUID | None = None
+    picture_url: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -279,7 +279,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "0.4.39"
+version = "0.4.40"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -19,6 +19,7 @@ import {
 	WorkspacePage,
 	WorkspaceTopBarButton,
 } from "@/components/layout/workspace-page";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { DataTable, type DataTableColumn } from "@/components/ui/data-table";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { api } from "@/lib/api/client";
@@ -32,6 +33,7 @@ interface User {
 	email: string | null;
 	role: "member" | "editor" | "admin";
 	teamId: string | null;
+	pictureUrl: string | null;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -380,9 +382,18 @@ export default function UsersPage() {
 				const isCurrentUser = user.id === currentUser?.id;
 				return (
 					<div className="flex min-w-0 items-center gap-3">
-						<span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-ink text-[10.5px] font-bold text-white dark:bg-white/15">
-							{getInitials(user.name)}
-						</span>
+						<Avatar className="size-8 shrink-0">
+							{user.pictureUrl && (
+								<AvatarImage
+									src={user.pictureUrl}
+									alt=""
+									referrerPolicy="no-referrer"
+								/>
+							)}
+							<AvatarFallback className="bg-ink text-[10.5px] font-bold text-white dark:bg-white/15">
+								{getInitials(user.name)}
+							</AvatarFallback>
+						</Avatar>
 						<div className="min-w-0">
 							<div className="flex min-w-0 items-center gap-2">
 								<span className="truncate text-[13.5px] font-semibold text-foreground">

--- a/web/src/components/ui/avatar.tsx
+++ b/web/src/components/ui/avatar.tsx
@@ -18,6 +18,18 @@ const Avatar = React.forwardRef<
 ));
 Avatar.displayName = AvatarPrimitive.Root.displayName;
 
+const AvatarImage = React.forwardRef<
+	React.ElementRef<typeof AvatarPrimitive.Image>,
+	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+	<AvatarPrimitive.Image
+		ref={ref}
+		className={cn("aspect-square h-full w-full object-cover", className)}
+		{...props}
+	/>
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
 const AvatarFallback = React.forwardRef<
 	React.ElementRef<typeof AvatarPrimitive.Fallback>,
 	React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
@@ -33,4 +45,4 @@ const AvatarFallback = React.forwardRef<
 ));
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
-export { Avatar, AvatarFallback };
+export { Avatar, AvatarImage, AvatarFallback };

--- a/web/src/stores/user-store.ts
+++ b/web/src/stores/user-store.ts
@@ -6,6 +6,7 @@ interface User {
 	name: string | null;
 	email: string | null;
 	role: "member" | "editor" | "admin";
+	pictureUrl: string | null;
 	createdAt: string;
 	updatedAt: string;
 }


### PR DESCRIPTION
## Summary

Google sign-in now captures the standard OIDC `picture` claim and stores it on `users.picture_url`, so profile photos show up in the Users table.

- **Provider-agnostic seam**: `google_signin_or_link` is generalized into `AuthService.oauth_signin_or_link(provider, sub_id, email, name, picture_url, invite_token)`. Adding Azure/Okta/etc. later only requires a new callback that maps that provider's claims (or a Graph photo fetch) into the same call.
- **Refresh on every sign-in**: the photo URL is treated as a cache — updated on all three flow branches (existing link, link-by-email, new user from invite), and never erased when a provider omits the claim.
- **Migration**: `1d60a5dabb57` adds nullable `users.picture_url` (hand-trimmed; autogenerate produced unrelated drift including checkpoint-table drops).
- **Frontend**: adds the missing `AvatarImage` part to the shadcn Avatar; the Users table renders the photo with `referrerPolicy="no-referrer"` (needed for Google's CDN) and falls back to initials on load failure or for password-auth users. No `remotePatterns` config needed.
- Also syncs `backend/uv.lock` with the 0.4.40 version bump from the last release PR.

## Rollout

Existing users' photos populate on their next Google sign-in (or after logout/login) — no backfill is possible since the photo URL only arrives in the OAuth callback.

## Test plan

- 86 auth/user backend tests pass; ruff + eslint + tsc clean on touched files
- Manual: sign out → sign in with Google → photo appears in Users table and via `/auth/me`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores SSO profile photos and shows avatars in Users. Previously we showed initials only; now Google sign‑in captures the OIDC `picture` claim into `users.picture_url`, refreshes it on every OAuth sign‑in, and the table renders the photo with an initials fallback.

- Generalizes Google flow to `AuthService.oauth_signin_or_link(provider, sub_id, email, name, picture_url, invite_token)` so future providers reuse the same link/create logic; updates `CONVENTIONS.md` to reflect the rename.
- Never erases a stored photo if a provider omits the claim; updates the cached URL whenever one is provided.
- Adds `picture_url` to `UserResponse`; frontend uses `AvatarImage` with `referrerPolicy="no-referrer"` and falls back to initials. No `remotePatterns` changes.

**Migration and rollout**
- Apply Alembic migration `1d60a5dabb57` (adds nullable `users.picture_url` only).
- No backfill; existing users’ photos populate on their next Google sign‑in.
- Locks sync: `backend` version set to `0.4.40` in `uv.lock`.

<sup>Written for commit 530f59b72b0e9b32b8eabe2afdb9bc5e8b4abf84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

