### PR TITLE
fix(web): display DeepSeek reasoning content in chat

### DIFF
--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -124,6 +124,7 @@ type LCMessage = {
   // camelCase (after Axios interceptor)
   toolCalls?: LCToolCallEntry[];
   toolCallId?: string;
+  additionalKwargs?: Record<string, unknown>;
   status?: string;
   additional_kwargs?: Record<string, unknown>;
   response_metadata?: Record<string, unknown>;
@@ -143,10 +144,19 @@ function getTextContent(message: LCMessage): string {
 }
 
 function getReasoningContent(message: LCMessage): string | null {
-  if (!Array.isArray(message.content)) return null;
-  const thinking = message.content.filter((c) => c.type === "thinking");
-  if (thinking.length === 0) return null;
-  return thinking.map((c) => (c.thinking as string) || "").join("\n");
+  // Anthropic: `thinking` blocks in content.
+  if (Array.isArray(message.content)) {
+    const thinking = message.content.filter((c) => c.type === "thinking");
+    if (thinking.length > 0) {
+      return thinking.map((c) => (c.thinking as string) || "").join("\n");
+    }
+  }
+  // DeepSeek: reasoning lives in additional_kwargs.reasoning_content, not in
+  // content. Streamed messages keep snake_case (SSE bypasses the Axios
+  // interceptor); history loaded via GET /threads/{id} is camelCased.
+  const kwargs = message.additional_kwargs ?? message.additionalKwargs;
+  const reasoning = kwargs?.reasoning_content ?? kwargs?.reasoningContent;
+  return typeof reasoning === "string" && reasoning ? reasoning : null;
 }
 
 function getFileAttachments(message: LCMessage): AttachmentData[] {


### PR DESCRIPTION
## Problem

DeepSeek reasoning was not displayed in the chat UI, even though it appeared in Langfuse.

## Root cause

`langchain-deepseek` stores reasoning in `additional_kwargs["reasoning_content"]` — never in `content` blocks. The chat page's `getReasoningContent` only extracted Anthropic-style `thinking` content blocks, so DeepSeek reasoning was silently dropped.

The data was already reaching the browser: the backend stream serializer forwards `additional_kwargs` on every `messages` SSE event, and the LangGraph JS SDK's chunk merge concatenates its string values — the fully-accumulated message held the complete reasoning text, it was just never read.

## Fix

`getReasoningContent` now falls back to `additional_kwargs.reasoning_content` when there are no `thinking` blocks, checking both key spellings:
- `additional_kwargs.reasoning_content` — streamed SSE (bypasses the Axios interceptor)
- `additionalKwargs.reasoningContent` — thread history loaded via `GET /threads/{id}` (camelCased by the interceptor)

Covers both live streaming and page reload. Anthropic thinking blocks are unaffected.

Verified locally against a DeepSeek thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display DeepSeek reasoning in chat by falling back to `additional_kwargs.reasoning_content` when no Anthropic `thinking` blocks exist. Previously DeepSeek reasoning was dropped in the UI; now it appears for both live streams and thread reloads without affecting Anthropic.

- Adds `additionalKwargs` to the `LCMessage` type and reads `reasoning_content`/`reasoningContent` from `additional_kwargs`/`additionalKwargs`.
- Supports SSE streams (snake_case, bypasses Axios interceptor) and `GET /threads/{id}` history (camelCase via the interceptor).
- No backend changes; UI change is limited to showing reasoning content when available.

<sup>Written for commit 74b5b1ac2d3b295d7aa4e9d429c73e1cb89d8833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

