### PR TITLE
fix(backend): linearize sandbox migrations onto the picture_url head

### DIFF
--- a/backend/alembic/versions/3e9d41c7a802_add_sandboxes_table.py
+++ b/backend/alembic/versions/3e9d41c7a802_add_sandboxes_table.py
@@ -1,7 +1,7 @@
 """add sandboxes table
 
 Revision ID: 3e9d41c7a802
-Revises: d7b3f1c05a92
+Revises: 1d60a5dabb57
 Create Date: 2026-08-22 10:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 # revision identifiers, used by Alembic.
 revision: str = '3e9d41c7a802'
-down_revision: Union[str, Sequence[str], None] = 'd7b3f1c05a92'
+down_revision: Union[str, Sequence[str], None] = '1d60a5dabb57'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

Production deploys fail with `Multiple head revisions are present for given argument 'head'` because main carries two alembic heads:

- `1d60a5dabb57` — add_picture_url_to_users (#278), revises `d7b3f1c05a92`
- `7c5a92e14b03` — sandbox chain (#284), whose first migration `3e9d41c7a802` **also** revises `d7b3f1c05a92`

One-line fix: re-parent `3e9d41c7a802` onto `1d60a5dabb57`, restoring a single linear head:

```
d7b3f1c05a92 → 1d60a5dabb57 → 3e9d41c7a802 → 7c5a92e14b03 (head)
```

Production is stamped `1d60a5dabb57` (the avatars release), so on the next deploy it upgrades cleanly through the two sandbox migrations — including the env→registry conversion, which needs the `SANDBOX_*`/`CLOUD_RUN_SANDBOX_*` env vars still present. No migration content changes; `alembic heads` verified single.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linearizes Alembic history by re-parenting the sandbox chain onto the add_picture_url_to_users migration. Before: two heads off d7b3f1c05a92 blocked deploys; now: d7b3f1c05a92 → 1d60a5dabb57 → 3e9d41c7a802 → 7c5a92e14b03, with no migration content changes.

- Review and rollout
  - Confirm only the down_revision of 3e9d41c7a802 changed to 1d60a5dabb57.
  - Production is stamped at 1d60a5dabb57; next deploy will upgrade through the sandbox migrations. Keep SANDBOX_* and CLOUD_RUN_SANDBOX_* env vars available during rollout.

<sup>Written for commit 8d87af04fafdee0cce1f2d95f512b9416817216e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

