### PR TITLE
feat(web): gate attachments per model with drag & drop hints

### DIFF
--- a/model-attachment-capabilities.md
+++ b/model-attachment-capabilities.md
@@ -1,0 +1,89 @@
+# Per-model attachment capabilities without manual maintenance
+
+**Question**: can we know which attachment types each model accepts (image/PDF/audio/video,
+and ideally which formats) without hand-maintaining a per-model list like the current
+`["deepseek", "z-ai"]` hack in the chat composer?
+
+**Answer: yes.** The LangChain partner packages we already depend on bundle per-model
+capability profiles (data sourced from [models.dev](https://models.dev), refreshed with every
+package release). Every chat model instance exposes them as `model.profile` — no new
+dependency, no network call, no manual list.
+
+## What we have today
+
+- `whitelist.yaml` carries a hand-maintained `multimodal: bool` — too coarse (image ≠ audio ≠
+  PDF) and one more thing to get wrong when adding a model.
+- The frontend hardcodes `noAttachments = ["deepseek", "z-ai"].includes(chefSlug)` — the thing
+  we want to delete.
+
+## The mechanism (verified against our installed versions)
+
+`langchain_core` 1.3.2 defines `ModelProfile` (a TypedDict) and `BaseChatModel.profile`.
+Partner packages bundle the data (`langchain_anthropic/data/_profiles.py` + a maintainer
+`profile_augmentations.toml`) and resolve it from the model name at instantiation — a real
+API key is not needed for the lookup.
+
+Relevant fields: `image_inputs`, `pdf_inputs`, `audio_inputs`, `video_inputs`,
+`image_url_inputs` (plus `tool_calling`, `structured_output`, `max_input_tokens`, … which
+could replace `supports_structured_output` in the whitelist later).
+
+Verified output on our installed packages:
+
+| Model (package) | image | pdf | audio | video |
+| --- | --- | --- | --- | --- |
+| `claude-sonnet-4-5` (langchain-anthropic 1.4.3) | ✅ | ✅ | ❌ | ❌ |
+| `gpt-5-mini` (langchain-openai 1.1.1) | ✅ | ✅ | ❌ | ❌ |
+| `gemini-2.5-flash` (langchain-google-genai 4.2.0) | ✅ | ✅ | ✅ | ✅ |
+| `deepseek-chat` (langchain-deepseek) | `profile is None` |
+| `z-ai/glm-4.6` via OpenRouter (`ChatOpenAI` + base_url) | `profile == {}` |
+
+The two gaps resolve **conservatively correct**: treating a missing/empty profile as
+"no attachments" is exactly right for DeepSeek and the OpenRouter-served GLM models — the
+models that caused the 400 in the first place. If an OpenRouter-served model ever *should*
+accept files, `ChatOpenAI(..., profile={"image_inputs": True})` overrides explicitly
+(verified working), which could be fed from an optional whitelist field for that rare case.
+
+## What about exact formats (WEBP vs JPG, MP4…)?
+
+No machine-readable source exposes MIME-level detail per model — not models.dev, not the
+provider `/models` APIs (they expose nothing about modalities at all), not OpenRouter/LiteLLM
+(modality level only). But MIME support is a property of the **provider's file-ingestion
+pipeline, not the individual model**, documented per provider and very stable:
+
+| Provider | images | pdf | audio | video |
+| --- | --- | --- | --- | --- |
+| Anthropic | jpeg, png, gif, webp | pdf | — | — |
+| OpenAI | png, jpeg, webp, non-animated gif | pdf | (speech models only) | — |
+| Google | png, jpeg, webp, heic, heif | pdf | wav, mp3, aiff, aac, ogg, flac | mp4, mpeg, mov, avi, webm, wmv, 3gpp, flv |
+
+So: **per-model modality booleans come free from `.profile`; a tiny static
+provider → modality → MIME map (one dict, ~15 lines, changes maybe once a year) turns them
+into an exact `accept` list.** The cross product never needs per-model maintenance.
+
+## Alternatives considered
+
+- **models.dev `api.json` fetched at whitelist-sync time** — same data, but adds a runtime
+  fetch + cache for something the partner packages already ship offline. Only worth it if we
+  want fresher data than package releases provide.
+- **LiteLLM `model_prices_and_context_window.json`** — similar coverage (`supports_vision`,
+  `supports_pdf_input`, …), but a third-party repo fetch and a second naming scheme to map.
+- **Provider APIs** — dead end; none of OpenAI/Anthropic/Google return input-modality info.
+
+## Recommended wiring (not implemented yet)
+
+1. **Backend** — in the `/models` list path, resolve each model's profile (instantiate via
+   `ChatModelFactory` with a dummy key, or cache per whitelist sync) and extend
+   `ModelResponse` with e.g. `inputModalities: list["image" | "pdf" | "audio" | "video"]`.
+   Missing/empty profile → `[]`.
+2. **Frontend** — delete the hardcoded `chefSlug` list; `noAttachments = inputModalities.length === 0`.
+   Map modalities × provider MIME table into the `accept` prop of `PromptInput`, and extend
+   its `matchesAccept` (currently only understands `image/*`) to validate real MIME lists so
+   a drop of an unsupported *type* is rejected client-side with a toast.
+3. **Whitelist** — drop `multimodal` once the above lands (or keep it as an override slot for
+   OpenRouter-served models with no profile data).
+4. **Backstop** — the provider 400 can still happen (stale package data); the run-error
+   surfacing work (`run-error-surfacing.md`) covers making that visible instead of silent.
+
+**Staleness caveat**: profile data updates with partner-package releases. A brand-new model
+may briefly report no capabilities until the package updates — conservative (blocks uploads
+that would work) rather than dangerous (never produces the 400).

--- a/model-attachment-capabilities.md
+++ b/model-attachment-capabilities.md
@@ -32,8 +32,8 @@ Verified output on our installed packages:
 | Model (package) | image | pdf | audio | video |
 | --- | --- | --- | --- | --- |
 | `claude-sonnet-4-5` (langchain-anthropic 1.4.3) | ✅ | ✅ | ❌ | ❌ |
-| `gpt-5-mini` (langchain-openai 1.1.1) | ✅ | ✅ | ❌ | ❌ |
-| `gemini-2.5-flash` (langchain-google-genai 4.2.0) | ✅ | ✅ | ✅ | ✅ |
+| `gpt-5-mini` (langchain-openai 1.1.9) | ✅ | ✅ | ❌ | ❌ |
+| `gemini-2.5-flash` (langchain-google-genai 4.2.2) | ✅ | ✅ | ✅ | ✅ |
 | `deepseek-chat` (langchain-deepseek) | `profile is None` |
 | `z-ai/glm-4.6` via OpenRouter (`ChatOpenAI` + base_url) | `profile == {}` |
 
@@ -81,8 +81,8 @@ into an exact `accept` list.** The cross product never needs per-model maintenan
    a drop of an unsupported *type* is rejected client-side with a toast.
 3. **Whitelist** — drop `multimodal` once the above lands (or keep it as an override slot for
    OpenRouter-served models with no profile data).
-4. **Backstop** — the provider 400 can still happen (stale package data); the run-error
-   surfacing work (`run-error-surfacing.md`) covers making that visible instead of silent.
+4. **Backstop** — the provider 400 can still happen (stale package data); the in-progress
+   run-error surfacing work covers making such failures visible in the UI instead of silent.
 
 **Staleness caveat**: profile data updates with partner-package releases. A brand-new model
 may briefly report no capabilities until the package updates — conservative (blocks uploads

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -1409,8 +1409,8 @@ const ChatPage = () => {
           </div>
         ) : agentStatus === "not_configured" ? (
           <div className="w-full max-w-4xl mx-auto lg:px-10 sm:px-6 px-3 py-4">
-            <div className="w-full flex items-center justify-center border border-red-200 bg-red-50 rounded-lg px-4 py-8">
-              <p className="text-md text-center text-red-700">
+            <div className="w-full flex items-center justify-center border border-destructive/30 bg-destructive/10 rounded-lg px-4 py-8">
+              <p className="text-md text-center text-destructive">
                 {canConfigure
                   ? "This agent's MCP tools aren't configured yet. Configure them in the agent's settings."
                   : "Agent is not configured yet. Contact agent owner to configure it first."}

--- a/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
@@ -142,6 +142,7 @@ const ChatPromptInput = ({
 			<PromptInput
 				globalDrop
 				multiple
+				disableAttachments={noAttachments}
 				onSubmit={handleSubmit}
 				className={cn(
 					"min-h-[116px] transition-all duration-200",

--- a/web/src/components/ai-elements/error.tsx
+++ b/web/src/components/ai-elements/error.tsx
@@ -14,18 +14,18 @@ const Error = ({ children, className, onDismiss }: ErrorProps) => {
 	return (
 		<div
 			className={cn(
-				"flex items-start gap-3 p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-lg text-wrap break-all",
+				"flex items-start gap-3 p-4 bg-destructive/10 border border-destructive/30 rounded-lg text-wrap break-all",
 				className
 			)}
 		>
-			<AlertTriangle className="h-5 w-5 text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" />
+			<AlertTriangle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
 			<div className="flex-1 min-w-0">
-				<div className="text-sm text-red-700 dark:text-red-300">{children}</div>
+				<div className="text-sm text-destructive">{children}</div>
 			</div>
 			{onDismiss && (
 				<button
 					onClick={onDismiss}
-					className="flex-shrink-0 text-red-400 hover:text-red-600 dark:text-red-500 dark:hover:text-red-300 transition-colors"
+					className="flex-shrink-0 text-destructive/60 hover:text-destructive transition-colors"
 					aria-label="Dismiss error"
 				>
 					<X className="h-4 w-4" />
@@ -53,7 +53,7 @@ const ErrorDetails = ({ children, className }: ErrorDetailsProps) => {
 	return (
 		<div
 			className={cn(
-				"text-xs text-red-600 dark:text-red-400 mt-1 opacity-75",
+				"text-xs text-destructive mt-1 opacity-75",
 				className
 			)}
 		>

--- a/web/src/components/ai-elements/prompt-input.tsx
+++ b/web/src/components/ai-elements/prompt-input.tsx
@@ -119,7 +119,7 @@ export function PromptInputProvider({
 }: PromptInputProviderProps) {
 	// ----- textInput state
 	const [textInput, setTextInput] = useState(initialTextInput);
-	const clearInput = useCallback(() => setTextInput(""), []);
+	const clearInput = useCallback(() => { setTextInput(""); }, []);
 
 	// ----- model selection state
 	const [selectedModel, setSelectedModel] = useState<string | undefined>(
@@ -255,6 +255,10 @@ export function PromptInputProvider({
 // ============================================================================
 
 const LocalAttachmentsContext = createContext<AttachmentsContext | null>(null);
+
+// True when the surrounding PromptInput has attachments disabled (e.g. the
+// selected model can't take files) — lets paste/button handlers opt out too.
+const AttachmentsDisabledContext = createContext(false);
 
 const usePromptInputAttachments = () => {
 	// Dual-mode: prefer provider if present, otherwise use local
@@ -405,12 +409,18 @@ export type PromptInputAddAttachmentButtonProps = Omit<
 
 export const PromptInputAddAttachmentButton = ({
 	children,
+	disabled,
 	...props
 }: PromptInputAddAttachmentButtonProps) => {
 	const attachments = usePromptInputAttachments();
+	const attachmentsDisabled = useContext(AttachmentsDisabledContext);
 
 	return (
-		<PromptInputButton onClick={() => attachments.openFileDialog()} {...props}>
+		<PromptInputButton
+			onClick={() => { attachments.openFileDialog(); }}
+			disabled={disabled || attachmentsDisabled}
+			{...props}
+		>
 			{children ?? <PlusIcon className="size-4 cursor-pointer" />}
 		</PromptInputButton>
 	);
@@ -426,6 +436,8 @@ export type PromptInputProps = Omit<
 > & {
 	accept?: string; // e.g., "image/*" or leave undefined for any
 	multiple?: boolean;
+	// When true, blocks every attachment path (file dialog, drop, paste).
+	disableAttachments?: boolean;
 	// When true, accepts drops anywhere on document. Default false (opt-in).
 	globalDrop?: boolean;
 	// Render a hidden input with given name and keep it in sync for native form posts. Default false.
@@ -447,6 +459,7 @@ export const PromptInput = ({
 	className,
 	accept,
 	multiple,
+	disableAttachments,
 	globalDrop,
 	syncHiddenInput,
 	maxFiles,
@@ -464,6 +477,12 @@ export const PromptInput = ({
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const anchorRef = useRef<HTMLSpanElement>(null);
 	const formRef = useRef<HTMLFormElement | null>(null);
+
+	// ----- Drag & drop visual state
+	const [isDragActive, setIsDragActive] = useState(false);
+	// dragenter/dragleave fire for every child element crossed; count the depth
+	// so the overlay doesn't flicker while moving inside the drop zone.
+	const dragDepth = useRef(0);
 
 	// Find nearest form to scope drag & drop
 	useEffect(() => {
@@ -546,36 +565,46 @@ export const PromptInput = ({
 		[matchesAccept, maxFiles, maxFileSize, onError],
 	);
 
-	const add = usingProvider
-		? (files: File[] | FileList) => controller.attachments.add(files)
+	const addFiles = usingProvider
+		? (files: File[] | FileList) => { controller.attachments.add(files); }
 		: addLocal;
+	// Every ingestion path (file dialog, drop, paste) funnels through here.
+	const add = disableAttachments ? () => {} : addFiles;
 
 	const remove = usingProvider
-		? (id: string) => controller.attachments.remove(id)
+		? (id: string) => { controller.attachments.remove(id); }
 		: (id: string) =>
-				setItems((prev) => {
+				{ setItems((prev) => {
 					const found = prev.find((file) => file.id === id);
 					if (found?.url) {
 						URL.revokeObjectURL(found.url);
 					}
 					return prev.filter((file) => file.id !== id);
-				});
+				}); };
 
 	const clear = usingProvider
-		? () => controller.attachments.clear()
+		? () => { controller.attachments.clear(); }
 		: () =>
-				setItems((prev) => {
+				{ setItems((prev) => {
 					for (const file of prev) {
 						if (file.url) {
 							URL.revokeObjectURL(file.url);
 						}
 					}
 					return [];
-				});
+				}); };
 
 	const openFileDialog = usingProvider
-		? () => controller.attachments.openFileDialog()
+		? () => { controller.attachments.openFileDialog(); }
 		: openFileDialogLocal;
+
+	// Drop stale attachments if the flag flips on with files already queued
+	// (e.g. the user switches to a model that can't take them).
+	useEffect(() => {
+		if (disableAttachments && files.length > 0) {
+			clear();
+		}
+	});
 
 	// Let provider know about our hidden file input so external menus can call openFileDialog()
 	useEffect(() => {
@@ -629,6 +658,11 @@ export const PromptInput = ({
 			if (e.dataTransfer?.types?.includes("Files")) {
 				e.preventDefault();
 			}
+			// Drops on the form itself bubble here too — the form handler
+			// already added them, so skip to avoid duplicating attachments.
+			if (formRef.current?.contains(e.target as Node)) {
+				return;
+			}
 			if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
 				add(e.dataTransfer.files);
 			}
@@ -640,6 +674,50 @@ export const PromptInput = ({
 			document.removeEventListener("drop", onDrop);
 		};
 	}, [add, globalDrop]);
+
+	// Track file-drag presence to surface the drop-zone hint. Scoped to the
+	// document when globalDrop is on (any drag anywhere can land here),
+	// otherwise to the form only. Tracked even with attachments disabled —
+	// the hint then renders as a "not supported" tint instead.
+	useEffect(() => {
+		const target: EventTarget | null = globalDrop
+			? document
+			: formRef.current;
+		if (!target) {
+			return;
+		}
+
+		const hasFiles = (e: DragEvent) =>
+			Boolean(e.dataTransfer?.types?.includes("Files"));
+		const onDragEnter = (e: DragEvent) => {
+			if (!hasFiles(e)) return;
+			dragDepth.current += 1;
+			setIsDragActive(true);
+		};
+		const onDragLeave = (e: DragEvent) => {
+			if (!hasFiles(e)) return;
+			dragDepth.current = Math.max(0, dragDepth.current - 1);
+			if (dragDepth.current === 0) {
+				setIsDragActive(false);
+			}
+		};
+		const reset = () => {
+			dragDepth.current = 0;
+			setIsDragActive(false);
+		};
+
+		target.addEventListener("dragenter", onDragEnter as EventListener);
+		target.addEventListener("dragleave", onDragLeave as EventListener);
+		target.addEventListener("drop", reset);
+		// dragend fires on the source when the drag is cancelled (e.g. Esc)
+		window.addEventListener("dragend", reset);
+		return () => {
+			target.removeEventListener("dragenter", onDragEnter as EventListener);
+			target.removeEventListener("dragleave", onDragLeave as EventListener);
+			target.removeEventListener("drop", reset);
+			window.removeEventListener("dragend", reset);
+		};
+	}, [globalDrop]);
 
 	useEffect(
 		() => () => {
@@ -663,7 +741,7 @@ export const PromptInput = ({
 		const blob = await response.blob();
 		return new Promise((resolve, reject) => {
 			const reader = new FileReader();
-			reader.onloadend = () => resolve(reader.result as string);
+			reader.onloadend = () => { resolve(reader.result as string); };
 			reader.onerror = reject;
 			reader.readAsDataURL(blob);
 		});
@@ -740,7 +818,7 @@ export const PromptInput = ({
 
 	// Render with or without local provider
 	const inner = (
-		<>
+		<AttachmentsDisabledContext.Provider value={!!disableAttachments}>
 			<span aria-hidden="true" className="hidden" ref={anchorRef} />
 			<input
 				accept={accept}
@@ -757,9 +835,36 @@ export const PromptInput = ({
 				onSubmit={handleSubmit}
 				{...props}
 			>
-				<InputGroup className="overflow-hidden">{children}</InputGroup>
+				<InputGroup
+					className={cn(
+						"overflow-hidden",
+						// `!` beats consumer border overrides scoped on the form
+						// (e.g. the chat composer's [&>[data-slot=input-group]] rules).
+						isDragActive &&
+							disableAttachments &&
+							"border-destructive! dark:border-destructive!",
+					)}
+				>
+					{children}
+					{isDragActive && (
+						<div
+							className={cn(
+								"pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-[inherit] transition-colors",
+								disableAttachments
+									? "bg-destructive/8 dark:bg-destructive/15"
+									: "bg-petrol/8 dark:bg-petrol/25",
+							)}
+						>
+							{disableAttachments && (
+								<span className="rounded-full border border-destructive/30 bg-card px-3 py-1.5 text-[13px] font-medium text-destructive shadow-sm">
+									This model does not support attachments
+								</span>
+							)}
+						</div>
+					)}
+				</InputGroup>
 			</form>
-		</>
+		</AttachmentsDisabledContext.Provider>
 	);
 
 	return usingProvider ? (
@@ -792,6 +897,7 @@ export const PromptInputTextarea = ({
 }: PromptInputTextareaProps) => {
 	const controller = useOptionalPromptInputController();
 	const attachments = usePromptInputAttachments();
+	const attachmentsDisabled = useContext(AttachmentsDisabledContext);
 	const [isComposing, setIsComposing] = useState(false);
 
 	const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
@@ -833,7 +939,7 @@ export const PromptInputTextarea = ({
 	const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {
 		const items = event.clipboardData?.items;
 
-		if (!items) {
+		if (!items || attachmentsDisabled) {
 			return;
 		}
 
@@ -870,8 +976,8 @@ export const PromptInputTextarea = ({
 		<InputGroupTextarea
 			className={cn("field-sizing-content max-h-48 min-h-16", className)}
 			name="message"
-			onCompositionEnd={() => setIsComposing(false)}
-			onCompositionStart={() => setIsComposing(true)}
+			onCompositionEnd={() => { setIsComposing(false); }}
+			onCompositionStart={() => { setIsComposing(true); }}
 			onKeyDown={handleKeyDown}
 			onPaste={handlePaste}
 			placeholder={placeholder}

--- a/web/src/components/ai-elements/prompt-input.tsx
+++ b/web/src/components/ai-elements/prompt-input.tsx
@@ -688,7 +688,7 @@ export const PromptInput = ({
 		}
 
 		const hasFiles = (e: DragEvent) =>
-			Boolean(e.dataTransfer?.types?.includes("Files"));
+			Boolean(e.dataTransfer?.types.includes("Files"));
 		const onDragEnter = (e: DragEvent) => {
 			if (!hasFiles(e)) return;
 			dragDepth.current += 1;
@@ -937,15 +937,13 @@ export const PromptInputTextarea = ({
 	};
 
 	const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {
-		const items = event.clipboardData?.items;
-
-		if (!items || attachmentsDisabled) {
+		if (attachmentsDisabled) {
 			return;
 		}
 
 		const files: File[] = [];
 
-		for (const item of items) {
+		for (const item of event.clipboardData.items) {
 			if (item.kind === "file") {
 				const file = item.getAsFile();
 				if (file) {


### PR DESCRIPTION
## Problem

Users could drag & drop (or paste) files into the chat composer even when the selected model doesn't support file input (DeepSeek, Z.ai GLM). The message then failed with a raw provider error:

> Error code: 400 - This model does not support image

Only the attach *button* was gated; drop and paste bypassed it entirely.

## Changes

- **`disableAttachments` prop on `PromptInput`** — no-ops every ingestion path (file dialog, form drop, document-level `globalDrop`, clipboard paste) and clears already-queued attachments when the flag flips on (e.g. switching to a text-only model with a file pending). The chat composer wires it to the existing text-only provider check.
- **Drag & drop visual hints** — dragging files over the window tints the composer petrol when the model accepts attachments; when it doesn't, the composer shows a soft destructive tint, a solid destructive border, and a "This model does not support attachments" pill.
- **Duplicate-add fix** — with `globalDrop`, a drop landing on the form bubbled to the document handler and attached the file twice; the document handler now skips events originating inside the form.
- **Error color tokenization** — `ai-elements/error.tsx` and the thread page's "not configured" banner move from hardcoded `red-*` classes to the `destructive` token (the banner had no dark-mode variants at all and rendered a bright `red-50` panel in dark theme). All error surfaces and the new drag hint now share one definition.
- **`model-attachment-capabilities.md`** — investigation write-up: per-model attachment capabilities can come from LangChain partner-package model profiles (`model.profile`, models.dev data) instead of hand-maintained lists; recommended follow-up wiring included.

The shared `prompt-input.tsx` also picks up mechanical `--fix` changes from the stricter pre-commit eslint config (void-expression braces), since this commit is the first to touch the file under that hook.

## Test plan

- With a multimodal model: drag a file over the page → petrol tint; drop → file attaches once (not twice); paste screenshot → attaches.
- With DeepSeek/GLM: attach button disabled; drag → red tint + border + pill; drop/paste → nothing queued; switch from multimodal model with a pending attachment → attachment cleared.
- Error box and "not configured" banner render with token colors in light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks file attachments for models that don’t support them and adds drag‑over hints in the composer. Previously drag/drop and paste bypassed the attach-button gate and caused provider 400s; now those inputs no‑op, and pending files are cleared when switching to a text‑only model.

- New Features
  - Adds `disableAttachments` to `PromptInput` to gate file dialog, form/global drop, and paste.
  - Shows drag-over states: petrol when allowed; destructive tint, solid border, and a “This model does not support attachments” pill when blocked.
  - Clears queued attachments when gating turns on.
  - Adds `model-attachment-capabilities.md` describing per-model capability sourcing.

- Bug Fixes
  - Prevents duplicate adds by ignoring `globalDrop` events originating inside the form.
  - Gates paste and the add button via context so both respect `disableAttachments`.
  - Moves `ai-elements/error.tsx` and the “not configured” banner to the `destructive` token with dark-mode support.
  - Removes unnecessary optional chaining on `DataTransfer.types` and a redundant clipboard null check; corrects package versions in the capabilities doc.

<sup>Written for commit f92927c7c5fd52a4feabfb176863d138fa1f3656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

