### PR TITLE
feat(models): user-configurable reasoning effort per model

### DIFF
--- a/backend/alembic/versions/a1d4c9e72b58_add_reasoning_effort.py
+++ b/backend/alembic/versions/a1d4c9e72b58_add_reasoning_effort.py
@@ -18,6 +18,29 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+# Lightweight Core table handles for the data migration — everything below is
+# built from these constructs (no raw SQL strings anywhere).
+def _model_tables() -> tuple[sa.TableClause, sa.TableClause]:
+    threads = sa.table(
+        "threads", sa.column("model_id"), sa.column("reasoning_effort")
+    )
+    triggers = sa.table(
+        "triggers", sa.column("model_id"), sa.column("reasoning_effort")
+    )
+    return threads, triggers
+
+
+_models = sa.table(
+    "models",
+    sa.column("id"),
+    sa.column("provider"),
+    sa.column("model_id"),
+    sa.column("is_enabled"),
+    sa.column("is_default"),
+    sa.column("created_at"),
+)
+
+
 def upgrade() -> None:
     """Upgrade schema."""
     op.add_column(
@@ -33,14 +56,12 @@ def upgrade() -> None:
     # thinking level in the model id. The level is now a per-thread
     # reasoning_effort and the id is the OpenRouter slug, so rewrite every
     # stored reference.
-    for table in ("threads", "triggers"):
+    for tbl in _model_tables():
         for old_id, effort in (("glm-5.2-max", "max"), ("glm-5.2-high", "high")):
             op.execute(
-                sa.text(
-                    f"UPDATE {table} "  # noqa: S608 — constant table/id values
-                    "SET model_id = 'z-ai/glm-5.2', reasoning_effort = :effort "
-                    "WHERE model_id = :old_id"
-                ).bindparams(effort=effort, old_id=old_id)
+                sa.update(tbl)
+                .where(tbl.c.model_id == old_id)
+                .values(model_id="z-ai/glm-5.2", reasoning_effort=effort)
             )
 
     # Merge the two enablement rows (admin decisions) into one: enabled /
@@ -49,46 +70,51 @@ def upgrade() -> None:
     # satisfied because at most one of the two could have been the default.
     bind = op.get_bind()
     rows = bind.execute(
-        sa.text(
-            "SELECT id, is_enabled, is_default FROM models "
-            "WHERE provider = 'openrouter' "
-            "AND model_id IN ('glm-5.2-max', 'glm-5.2-high') "
-            "ORDER BY created_at"
+        sa.select(_models.c.id, _models.c.is_enabled, _models.c.is_default)
+        .where(
+            _models.c.provider == "openrouter",
+            _models.c.model_id.in_(["glm-5.2-max", "glm-5.2-high"]),
         )
+        .order_by(_models.c.created_at)
     ).fetchall()
     if rows:
         keep = rows[0]
         merged_enabled = any(r.is_enabled for r in rows)
         merged_default = any(r.is_default for r in rows)
         for r in rows[1:]:
-            bind.execute(
-                sa.text("DELETE FROM models WHERE id = :id").bindparams(id=r.id)
-            )
+            bind.execute(sa.delete(_models).where(_models.c.id == r.id))
         bind.execute(
-            sa.text(
-                "UPDATE models SET model_id = 'z-ai/glm-5.2', "
-                "is_enabled = :enabled, is_default = :default WHERE id = :id"
-            ).bindparams(enabled=merged_enabled, default=merged_default, id=keep.id)
+            sa.update(_models)
+            .where(_models.c.id == keep.id)
+            .values(
+                model_id="z-ai/glm-5.2",
+                is_enabled=merged_enabled,
+                is_default=merged_default,
+            )
         )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     # Re-split by the stored effort level (max was the old default id).
-    for table in ("threads", "triggers"):
+    for tbl in _model_tables():
         op.execute(
-            sa.text(
-                f"UPDATE {table} "  # noqa: S608 — constant table/id values
-                "SET model_id = CASE WHEN reasoning_effort = 'high' "
-                "THEN 'glm-5.2-high' ELSE 'glm-5.2-max' END "
-                "WHERE model_id = 'z-ai/glm-5.2'"
+            sa.update(tbl)
+            .where(tbl.c.model_id == "z-ai/glm-5.2")
+            .values(
+                model_id=sa.case(
+                    (tbl.c.reasoning_effort == "high", "glm-5.2-high"),
+                    else_="glm-5.2-max",
+                )
             )
         )
     op.execute(
-        sa.text(
-            "UPDATE models SET model_id = 'glm-5.2-max' "
-            "WHERE provider = 'openrouter' AND model_id = 'z-ai/glm-5.2'"
+        sa.update(_models)
+        .where(
+            _models.c.provider == "openrouter",
+            _models.c.model_id == "z-ai/glm-5.2",
         )
+        .values(model_id="glm-5.2-max")
     )
     op.drop_column("triggers", "reasoning_effort")
     op.drop_column("threads", "reasoning_effort")

--- a/backend/alembic/versions/a1d4c9e72b58_add_reasoning_effort.py
+++ b/backend/alembic/versions/a1d4c9e72b58_add_reasoning_effort.py
@@ -1,0 +1,94 @@
+"""add reasoning effort to threads and triggers, collapse GLM pseudo-models
+
+Revision ID: a1d4c9e72b58
+Revises: 7c5a92e14b03
+Create Date: 2026-08-26 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1d4c9e72b58"
+down_revision: Union[str, Sequence[str], None] = "7c5a92e14b03"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "threads",
+        sa.Column("reasoning_effort", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "triggers",
+        sa.Column("reasoning_effort", sa.String(length=32), nullable=True),
+    )
+
+    # The former glm-5.2-max / glm-5.2-high pseudo-models encoded the GLM
+    # thinking level in the model id. The level is now a per-thread
+    # reasoning_effort and the id is the OpenRouter slug, so rewrite every
+    # stored reference.
+    for table in ("threads", "triggers"):
+        for old_id, effort in (("glm-5.2-max", "max"), ("glm-5.2-high", "high")):
+            op.execute(
+                sa.text(
+                    f"UPDATE {table} "  # noqa: S608 — constant table/id values
+                    "SET model_id = 'z-ai/glm-5.2', reasoning_effort = :effort "
+                    "WHERE model_id = :old_id"
+                ).bindparams(effort=effort, old_id=old_id)
+            )
+
+    # Merge the two enablement rows (admin decisions) into one: enabled /
+    # default if either pseudo-model was. Keep one row (rewrite its id),
+    # delete the other — the single-default partial unique index stays
+    # satisfied because at most one of the two could have been the default.
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, is_enabled, is_default FROM models "
+            "WHERE provider = 'openrouter' "
+            "AND model_id IN ('glm-5.2-max', 'glm-5.2-high') "
+            "ORDER BY created_at"
+        )
+    ).fetchall()
+    if rows:
+        keep = rows[0]
+        merged_enabled = any(r.is_enabled for r in rows)
+        merged_default = any(r.is_default for r in rows)
+        for r in rows[1:]:
+            bind.execute(
+                sa.text("DELETE FROM models WHERE id = :id").bindparams(id=r.id)
+            )
+        bind.execute(
+            sa.text(
+                "UPDATE models SET model_id = 'z-ai/glm-5.2', "
+                "is_enabled = :enabled, is_default = :default WHERE id = :id"
+            ).bindparams(enabled=merged_enabled, default=merged_default, id=keep.id)
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Re-split by the stored effort level (max was the old default id).
+    for table in ("threads", "triggers"):
+        op.execute(
+            sa.text(
+                f"UPDATE {table} "  # noqa: S608 — constant table/id values
+                "SET model_id = CASE WHEN reasoning_effort = 'high' "
+                "THEN 'glm-5.2-high' ELSE 'glm-5.2-max' END "
+                "WHERE model_id = 'z-ai/glm-5.2'"
+            )
+        )
+    op.execute(
+        sa.text(
+            "UPDATE models SET model_id = 'glm-5.2-max' "
+            "WHERE provider = 'openrouter' AND model_id = 'z-ai/glm-5.2'"
+        )
+    )
+    op.drop_column("triggers", "reasoning_effort")
+    op.drop_column("threads", "reasoning_effort")

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -353,9 +353,14 @@ class Agent:
         # Backstop for the RunService.create gate: covers the race where the
         # model is disabled between enqueue and worker pickup, and any future
         # path that builds an agent without going through `create`.
-        resolved = await ModelService(db).ensure_available(thread.model_id)
+        resolved = await ModelService(db).ensure_available(
+            thread.model_id, reasoning_effort=thread.reasoning_effort
+        )
         model = ChatModelFactory().create(
-            resolved.provider, resolved.model_id, resolved.api_key
+            resolved.provider,
+            resolved.model_id,
+            resolved.api_key,
+            reasoning_effort=resolved.reasoning_effort,
         )
 
         middleware = build_parent_middleware(thread.created_at, agent.prepared)

--- a/backend/app/model_providers/catalog.py
+++ b/backend/app/model_providers/catalog.py
@@ -41,9 +41,10 @@ def _google_adc() -> tuple[google.auth.credentials.Credentials, str | None] | No
 # Models that require adaptive thinking (`{"type": "adaptive"}` + `effort`).
 # Opus 4.7+ dropped manual extended thinking and return a 400 for the legacy
 # `{"type": "enabled", "budget_tokens": ...}` format. Everything else uses
-# the legacy `enabled` format.
+# the legacy `enabled` format. (Opus 5 thinks by default even without the
+# opt-in, but it rejects the legacy format too, so it belongs here.)
 ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
-    {"claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-5"}
+    {"claude-opus-4-6", "claude-opus-4-8", "claude-sonnet-5", "claude-opus-5"}
 )
 
 # OpenAI reasoning models that reject function tools on /v1/chat/completions
@@ -54,14 +55,6 @@ ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
 OPENAI_RESPONSES_API_MODELS: frozenset[str] = frozenset(
     {"gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"}
 )
-
-# OpenRouter catalog: our model id -> (OpenRouter slug, GLM `reasoning_effort`).
-# GLM 5.2 exposes two thinking levels; "max" is its deep-reasoning default, "high"
-# is lighter. Each is surfaced to users as its own model.
-OPENROUTER_MODELS: dict[str, tuple[str, str]] = {
-    "glm-5.2-max": ("z-ai/glm-5.2", "max"),
-    "glm-5.2-high": ("z-ai/glm-5.2", "high"),
-}
 
 
 def provider_api_keys() -> dict[str, str]:
@@ -83,7 +76,19 @@ def provider_api_keys() -> dict[str, str]:
 
 
 class ChatModelFactory:
-    def create(self, provider: str, model_id: str, api_key: str):
+    def create(
+        self,
+        provider: str,
+        model_id: str,
+        api_key: str,
+        reasoning_effort: str | None = None,
+    ):
+        # `reasoning_effort` is a value from the model's whitelist-declared
+        # levels (ModelService.ensure_available resolves and clamps it) —
+        # never a raw client string. None means "no explicit choice": each
+        # branch keeps its historical default behavior, so existing threads
+        # run exactly as before.
+        #
         # max_retries=0 everywhere: retrying is owned by ModelRetryMiddleware
         # (classified via ModelError.is_retryable, persists the failure as an
         # AIMessage on exhaustion). Leaving the SDK layer's default retries on
@@ -93,28 +98,44 @@ class ChatModelFactory:
             case "openai":
                 # gpt-5.6 reasoning models require the Responses API to use
                 # function tools (chat completions 400s); everything else is
-                # fine on the default chat-completions path.
+                # fine on the default chat-completions path. On the Responses
+                # path langchain translates reasoning_effort into
+                # `reasoning.effort` itself.
                 return ChatOpenAI(
                     model=model_id,
                     api_key=api_key,
                     max_retries=0,
                     use_responses_api=model_id in OPENAI_RESPONSES_API_MODELS,
+                    reasoning_effort=reasoning_effort,
                 )
             case "deepseek":
-                # Reasoning enabled. max_tokens caps the answer so json_object
-                # structured output isn't truncated mid-string (DeepSeek's JSON
-                # mode guide warns about this); 32768 matches the other
-                # reasoning providers here.
+                # DeepSeek V4 selects thinking by parameters: `thinking.type`
+                # turns it on/off ("none" maps to disabled), `reasoning_effort`
+                # picks the depth (low/high/max; the API defaults to high).
+                # max_tokens caps the answer so json_object structured output
+                # isn't truncated mid-string (DeepSeek's JSON mode guide warns
+                # about this); 32768 matches the other reasoning providers.
+                thinking_off = reasoning_effort == "none"
+                extra_body: dict = {
+                    "thinking": {"type": "disabled" if thinking_off else "enabled"}
+                }
+                if reasoning_effort and not thinking_off:
+                    extra_body["reasoning_effort"] = reasoning_effort
                 return ChatDeepSeek(
                     model=model_id,
                     api_key=api_key,
                     max_tokens=32768,
                     max_retries=0,
-                    extra_body={"thinking": {"type": "enabled"}},
+                    extra_body=extra_body,
                 )
             case "anthropic":
                 kwargs: dict = {}
-                if model_id in ADAPTIVE_THINKING_MODELS:
+                if model_id in ADAPTIVE_THINKING_MODELS or reasoning_effort:
+                    # Adaptive thinking + output_config.effort. Mandatory on
+                    # Opus 4.7+/Sonnet 5 (the legacy budget format 400s there);
+                    # older models (e.g. Sonnet 4.6) opt in whenever the user
+                    # picked an effort level.
+                    #
                     # `display` defaults to "omitted" on Opus 4.7+, which returns
                     # thinking blocks with an empty `thinking` field. langchain
                     # then drops the field when round-tripping the block after a
@@ -123,7 +144,7 @@ class ChatModelFactory:
                     # "summarized" keeps the field populated so it survives the
                     # round-trip (and surfaces reasoning to the UI).
                     kwargs["thinking"] = {"type": "adaptive", "display": "summarized"}
-                    kwargs["effort"] = "medium"
+                    kwargs["effort"] = reasoning_effort or "medium"
                 else:
                     kwargs["thinking"] = {"type": "enabled", "budget_tokens": 1024}
                 return ChatAnthropic(
@@ -149,6 +170,13 @@ class ChatModelFactory:
                         auth_kwargs["project"] = project
                 else:
                     auth_kwargs["api_key"] = api_key
+                # thinking_level (aka reasoning_effort) and thinking_budget are
+                # mutually exclusive on Gemini 3+ — send exactly one: the
+                # user's level, else the dynamic budget (historical default).
+                if reasoning_effort:
+                    auth_kwargs["reasoning_effort"] = reasoning_effort
+                else:
+                    auth_kwargs["thinking_budget"] = -1
                 return ChatGoogleGenerativeAI(
                     model=model_id,
                     temperature=0,
@@ -157,7 +185,6 @@ class ChatModelFactory:
                     max_retries=0,
                     streaming=True,
                     include_thoughts=True,
-                    thinking_budget=-1,
                     **auth_kwargs,
                 )
             case "xiaomi":
@@ -168,18 +195,23 @@ class ChatModelFactory:
                     max_retries=0,
                 )
             case "openrouter":
-                # OpenAI-compatible gateway. Our model id encodes the GLM thinking
-                # level; pass GLM's native `reasoning_effort` ("high"/"max"). Output
-                # is capped generously (GLM 5.2 max = 32768) since "max" reasoning
+                # OpenAI-compatible gateway; model_id is the OpenRouter slug,
+                # sent verbatim like any other provider's id. The effort level
+                # travels as the OpenAI-style `reasoning_effort`, which
+                # OpenRouter normalizes for the upstream host. Output is capped
+                # generously (GLM 5.2 max = 32768) since deep reasoning
                 # produces long chains of thought.
-                slug, effort = OPENROUTER_MODELS[model_id]
                 return ChatOpenAI(
                     base_url="https://openrouter.ai/api/v1",
-                    model=slug,
+                    model=model_id,
                     api_key=api_key,
                     max_tokens=32768,
                     max_retries=0,
-                    extra_body={"reasoning_effort": effort},
+                    extra_body=(
+                        {"reasoning_effort": reasoning_effort}
+                        if reasoning_effort
+                        else None
+                    ),
                 )
             case "meta":
                 # Meta Model API — OpenAI-compatible Chat Completions.

--- a/backend/app/model_providers/router.py
+++ b/backend/app/model_providers/router.py
@@ -44,6 +44,9 @@ async def get_models(
             chefSlug=m.chef_slug,
             providers=[ModelProviderType(m.provider)],
             isDefault=m.model_id == default_model_id,
+            multimodal=m.multimodal,
+            reasoningEffortLevels=list(m.reasoning_effort_levels),
+            reasoningEffortDefault=m.reasoning_effort_default,
         )
         for m in available
     ]

--- a/backend/app/model_providers/schemas.py
+++ b/backend/app/model_providers/schemas.py
@@ -19,6 +19,15 @@ class ModelResponse(BaseModel):
     # The *effective* workspace default (admin-flagged model when available,
     # else the first available one) — pickers preselect this row.
     isDefault: bool = False
+    # Whether the model accepts non-text input on our serving path — the
+    # composer gates attachments on this (per model, not per chef: e.g. GLM
+    # 5.3 Flash takes images while plain GLM 5.3 does not).
+    multimodal: bool = False
+    # The reasoning-effort values the user may pick for this model (empty =
+    # no effort knob) and the level in effect when they pick nothing (None =
+    # provider-managed/dynamic, shown as Auto).
+    reasoningEffortLevels: list[str] = []
+    reasoningEffortDefault: str | None = None
 
 
 class ModelCreateDB(SQLModel):

--- a/backend/app/model_providers/service.py
+++ b/backend/app/model_providers/service.py
@@ -8,6 +8,8 @@ create/update, the picker endpoint, and the thread response's
 `model_available` flag.
 """
 
+import logging
+
 from fastapi import Depends
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,12 +36,19 @@ from app.model_providers.whitelist import (
 from app.service import BaseService
 
 
+logger = logging.getLogger(__name__)
+
+
 class ResolvedModel(BaseModel):
     """An available model plus what Agent.build needs to instantiate it."""
 
     provider: str
     model_id: str
     api_key: str
+    # The effort to send: the thread's choice clamped to the whitelist
+    # entry's declared levels, else the entry's applied default. None = the
+    # model declares no default — send nothing, provider default applies.
+    reasoning_effort: str | None = None
 
 
 def _managed(entry: SupportedModel | None, row: ModelDB) -> ManagedModelResponse:
@@ -82,10 +91,21 @@ class ModelService(BaseService[ModelDB, ModelRepository]):
             if m.provider in keys and (m.provider, m.model_id) in enabled
         ]
 
-    async def ensure_available(self, model_id: str | None) -> ResolvedModel:
+    async def ensure_available(
+        self, model_id: str | None, reasoning_effort: str | None = None
+    ) -> ResolvedModel:
         """The chokepoint: raise ModelUnavailableError with the precise reason,
         or return what ChatModelFactory needs. Called by RunService.create
-        (the pre-stream gate), Agent.build (the backstop) and TriggerService."""
+        (the pre-stream gate), Agent.build (the backstop) and TriggerService.
+
+        `reasoning_effort` (a thread/trigger's stored choice) is clamped, not
+        rejected: a level the whitelist no longer declares is discarded so a
+        catalog edit can never strand an existing thread. With no (surviving)
+        choice, the whitelist entry's `reasoning_effort_default` applies —
+        the CDN file is the policy knob for what unset means — and a model
+        with no default falls through to its provider-default path. Strict
+        validation of *new* choices happens at selection time via
+        `validate_reasoning_effort`."""
         if not model_id:
             raise ModelUnavailableError("", "no model is set")
         whitelist = await get_whitelist()
@@ -107,9 +127,41 @@ class ModelService(BaseService[ModelDB, ModelRepository]):
             raise ModelUnavailableError(
                 model_id, "it has been disabled by a workspace admin"
             )
+        if reasoning_effort and reasoning_effort not in entry.reasoning_effort_levels:
+            logger.warning(
+                "Stored reasoning_effort %r is not declared for model %s; "
+                "falling back to the model's default",
+                reasoning_effort,
+                model_id,
+            )
+            reasoning_effort = None
+        if reasoning_effort is None:
+            reasoning_effort = entry.reasoning_effort_default
         return ResolvedModel(
-            provider=entry.provider, model_id=entry.model_id, api_key=api_key
+            provider=entry.provider,
+            model_id=entry.model_id,
+            api_key=api_key,
+            reasoning_effort=reasoning_effort,
         )
+
+    @staticmethod
+    async def validate_reasoning_effort(
+        model_id: str | None, reasoning_effort: str | None
+    ) -> None:
+        """Strict gate for user-supplied effort choices (thread and trigger
+        creation): the value must be one of the model's declared levels.
+        None always passes — it means "the model's default"."""
+        if reasoning_effort is None:
+            return
+        whitelist = await get_whitelist()
+        entry = next((m for m in whitelist if m.model_id == model_id), None)
+        levels = entry.reasoning_effort_levels if entry else []
+        if reasoning_effort not in levels:
+            raise DomainValidationError(
+                f"Model '{model_id}' does not support reasoning effort "
+                f"'{reasoning_effort}'"
+                + (f" (supported: {', '.join(levels)})" if levels else "")
+            )
 
     @staticmethod
     async def list_whitelisted() -> list[SupportedModel]:

--- a/backend/app/model_providers/service.py
+++ b/backend/app/model_providers/service.py
@@ -127,7 +127,12 @@ class ModelService(BaseService[ModelDB, ModelRepository]):
             raise ModelUnavailableError(
                 model_id, "it has been disabled by a workspace admin"
             )
-        if reasoning_effort and reasoning_effort not in entry.reasoning_effort_levels:
+        # `is not None` (not truthiness): an empty string must clamp like any
+        # other undeclared value, never slip through to the factory.
+        if (
+            reasoning_effort is not None
+            and reasoning_effort not in entry.reasoning_effort_levels
+        ):
             logger.warning(
                 "Stored reasoning_effort %r is not declared for model %s; "
                 "falling back to the model's default",
@@ -145,6 +150,21 @@ class ModelService(BaseService[ModelDB, ModelRepository]):
         )
 
     @staticmethod
+    async def _declared_effort_levels(model_id: str | None) -> list[str]:
+        whitelist = await get_whitelist()
+        entry = next((m for m in whitelist if m.model_id == model_id), None)
+        return list(entry.reasoning_effort_levels) if entry else []
+
+    @staticmethod
+    async def is_reasoning_effort_declared(
+        model_id: str | None, reasoning_effort: str
+    ) -> bool:
+        """Whether the whitelist declares this level for the model — for
+        callers that clamp a *stored* value instead of rejecting it (e.g.
+        re-pointing a trigger's model with a stale carried-over effort)."""
+        return reasoning_effort in await ModelService._declared_effort_levels(model_id)
+
+    @staticmethod
     async def validate_reasoning_effort(
         model_id: str | None, reasoning_effort: str | None
     ) -> None:
@@ -153,9 +173,7 @@ class ModelService(BaseService[ModelDB, ModelRepository]):
         None always passes — it means "the model's default"."""
         if reasoning_effort is None:
             return
-        whitelist = await get_whitelist()
-        entry = next((m for m in whitelist if m.model_id == model_id), None)
-        levels = entry.reasoning_effort_levels if entry else []
+        levels = await ModelService._declared_effort_levels(model_id)
         if reasoning_effort not in levels:
             raise DomainValidationError(
                 f"Model '{model_id}' does not support reasoning effort "

--- a/backend/app/model_providers/whitelist.py
+++ b/backend/app/model_providers/whitelist.py
@@ -8,7 +8,7 @@ and the bundled snapshot.
 """
 
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args
 
 import httpx
 import yaml
@@ -77,6 +77,16 @@ class SupportedModel(BaseModel):
         if len(set(self.reasoning_effort_levels)) != len(self.reasoning_effort_levels):
             raise ValueError(
                 f"model {self.model_id!r} has duplicate reasoning_effort_levels"
+            )
+        # Levels must follow the canonical ladder order — the picker renders
+        # the list as-is, so an out-of-order file would show `high` above
+        # `low`. Reject it like any other data-entry error.
+        ladder = get_args(ReasoningEffort)
+        positions = [ladder.index(level) for level in self.reasoning_effort_levels]
+        if positions != sorted(positions):
+            raise ValueError(
+                f"model {self.model_id!r} has out-of-order reasoning_effort_levels "
+                f"(expected the ladder order {', '.join(ladder)})"
             )
         if (
             self.reasoning_effort_default is not None

--- a/backend/app/model_providers/whitelist.py
+++ b/backend/app/model_providers/whitelist.py
@@ -25,6 +25,13 @@ SUPPORTED_PROVIDERS: frozenset[str] = frozenset(
     {"openai", "deepseek", "anthropic", "google", "xiaomi", "openrouter", "meta"}
 )
 
+# The canonical reasoning-effort ladder (the industry superset, ordered from
+# least to most reasoning). Whitelist entries declare the per-model subset —
+# no two providers accept the same one, and sending an undeclared value is
+# never safe (some providers coerce silently, others 400). "none" in a
+# model's levels means its thinking can be turned off entirely.
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
 _BUNDLED_PATH = Path(__file__).parent / "whitelist.yaml"
 
 
@@ -39,6 +46,16 @@ class SupportedModel(BaseModel):
     chef_slug: str | None = None
     multimodal: bool = False
     supports_structured_output: bool = False
+    # The reasoning-effort values a user may pick for this model (empty =
+    # no effort knob, the picker doesn't render one). Values must be what the
+    # serving endpoint actually accepts — silent coercion tiers don't count.
+    reasoning_effort_levels: list[ReasoningEffort] = []
+    # APPLIED when the user picks nothing: ensure_available resolves a NULL
+    # thread/trigger effort to this level, so editing it in the CDN file
+    # changes what unset means workspace-wide (explicit choices are never
+    # touched). None with non-empty levels = provider-managed/dynamic — the
+    # factory sends no effort at all and keeps its historical default path.
+    reasoning_effort_default: ReasoningEffort | None = None
 
     @field_validator("provider")
     @classmethod
@@ -53,6 +70,22 @@ class SupportedModel(BaseModel):
             self.chef = self.provider.capitalize()
         if self.chef_slug is None:
             self.chef_slug = self.provider
+        return self
+
+    @model_validator(mode="after")
+    def reasoning_effort_is_coherent(self) -> "SupportedModel":
+        if len(set(self.reasoning_effort_levels)) != len(self.reasoning_effort_levels):
+            raise ValueError(
+                f"model {self.model_id!r} has duplicate reasoning_effort_levels"
+            )
+        if (
+            self.reasoning_effort_default is not None
+            and self.reasoning_effort_default not in self.reasoning_effort_levels
+        ):
+            raise ValueError(
+                f"model {self.model_id!r}: reasoning_effort_default "
+                f"{self.reasoning_effort_default!r} is not in reasoning_effort_levels"
+            )
         return self
 
 
@@ -71,23 +104,6 @@ class WhitelistDocument(BaseModel):
             if m.model_id in seen:
                 raise ValueError(f"duplicate model_id {m.model_id!r}")
             seen.add(m.model_id)
-        return self
-
-    @model_validator(mode="after")
-    def openrouter_ids_must_be_mapped(self) -> "WhitelistDocument":
-        """OpenRouter entries are indexed straight into OPENROUTER_MODELS by
-        ChatModelFactory — an unmapped id would pass the whitelist, get
-        enabled by an admin, and only crash at agent build. Reject it here so
-        the bad file never applies. (Lazy import: catalog pulls in the
-        langchain provider packages.)"""
-        from app.model_providers.catalog import OPENROUTER_MODELS
-
-        for m in self.models:
-            if m.provider == "openrouter" and m.model_id not in OPENROUTER_MODELS:
-                raise ValueError(
-                    f"openrouter model_id {m.model_id!r} has no OPENROUTER_MODELS "
-                    "mapping (add the slug/effort entry in catalog.py first)"
-                )
         return self
 
 

--- a/backend/app/model_providers/whitelist.yaml
+++ b/backend/app/model_providers/whitelist.yaml
@@ -3,14 +3,27 @@
 # Source of truth for the models auxilia can offer. Every entry MUST be:
 #   1. tool-calling capable (all auxilia agents bind tools), and
 #   2. drivable by ChatModelFactory (backend/app/model_providers/catalog.py):
-#      `provider` must match a factory branch, and openrouter model_ids must
-#      exist in OPENROUTER_MODELS.
+#      `provider` must match a factory branch. Openrouter model_ids are the
+#      OpenRouter slugs, passed to the gateway verbatim.
 #
 # Flags describe OUR serving path, not the model in the abstract:
 #   multimodal                 — accepts non-text input (image/audio/video)
 #   supports_structured_output — REAL constrained decoding (json_schema /
 #                                strict tool call) on the endpoint we call,
 #                                NOT best-effort json_object
+#
+# reasoning_effort_levels / reasoning_effort_default — the effort values a
+# user may pick for this model, drawn from the canonical ladder
+# (none < minimal < low < medium < high < xhigh < max), and the level APPLIED
+# when they pick nothing (threads/triggers with no explicit choice resolve to
+# it, so editing a default here changes what unset means workspace-wide —
+# explicit choices are never touched). Declare only values the serving
+# endpoint ACCEPTS as distinct tiers (silent-coercion aliases don't count —
+# e.g. GLM 5.2 coerces xhigh to max, so only high/max are listed).
+# Empty/omitted levels = the model has no effort knob and the picker renders
+# none. "none" in the list means thinking can be turned off entirely. A
+# missing default with non-empty levels means "provider-managed/dynamic"
+# (shown as Auto): no effort is sent and the serving default applies.
 #
 # chef / chef_slug — the model's creator, shown next to the model in the
 # picker (logo lookup by slug). Optional: defaults to the provider name,
@@ -40,6 +53,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5-mini
     display_name: GPT-5 mini
@@ -47,6 +61,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5-nano
     display_name: GPT-5 nano
@@ -54,6 +69,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.1
     display_name: GPT-5.1
@@ -61,6 +77,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.2
     display_name: GPT-5.2
@@ -68,6 +85,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.4
     display_name: GPT-5.4
@@ -75,6 +93,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.5
     display_name: GPT-5.5
@@ -82,6 +101,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
+    reasoning_effort_default: medium
   - provider: openai
     model_id: gpt-5.6-luna
     display_name: GPT-5.6 Luna
@@ -89,6 +110,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
   - provider: openai
     model_id: gpt-5.6-sol
     display_name: GPT-5.6 Sol
@@ -96,6 +119,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
   - provider: openai
     model_id: gpt-5.6-terra
     display_name: GPT-5.6 Terra
@@ -103,6 +128,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
 
   # --- Anthropic (native endpoint) ---
   - provider: anthropic
@@ -119,6 +146,7 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, max]
   - provider: anthropic
     model_id: claude-sonnet-5
     display_name: Claude Sonnet 5
@@ -126,6 +154,11 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, xhigh, max]
+    # Adaptive-thinking models (ADAPTIVE_THINKING_MODELS in catalog.py) have
+    # always been served at effort medium — the applied default preserves
+    # that. Anthropic's own API default is high.
+    reasoning_effort_default: medium
   - provider: anthropic
     model_id: claude-opus-4-6
     display_name: Claude Opus 4.6
@@ -133,6 +166,8 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, max]
+    reasoning_effort_default: medium
   - provider: anthropic
     model_id: claude-opus-4-8
     display_name: Claude Opus 4.8
@@ -140,6 +175,23 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
+  # Opus 5 thinks by default (no opt-in needed) but is driven through the same
+  # adaptive path (ADAPTIVE_THINKING_MODELS); the legacy budget format 400s.
+  # `thinking: disabled` exists only at effort ≤ high — not exposed here ("none"
+  # would need a factory mapping). Verified live 2026-08-26 on the adaptive
+  # path. Anthropic's API default effort is high; medium matches the other
+  # Claudes we serve.
+  - provider: anthropic
+    model_id: claude-opus-5
+    display_name: Claude Opus 5
+    chef: Anthropic
+    chef_slug: anthropic
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
 
   # --- DeepSeek (native endpoint: json_object only, no schema guarantee) ---
   - provider: deepseek
@@ -149,6 +201,8 @@ models:
     chef_slug: deepseek
     multimodal: false
     supports_structured_output: false
+    reasoning_effort_levels: [none, low, high, max]
+    reasoning_effort_default: high
   - provider: deepseek
     model_id: deepseek-v4-pro
     display_name: DeepSeek V4 Pro
@@ -156,6 +210,8 @@ models:
     chef_slug: deepseek
     multimodal: false
     supports_structured_output: false
+    reasoning_effort_levels: [none, low, high, max]
+    reasoning_effort_default: high
 
   # --- Google (native endpoint) ---
   - provider: google
@@ -165,6 +221,7 @@ models:
     chef_slug: google
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [minimal, low, medium, high]
   - provider: google
     model_id: gemini-3-pro-preview
     display_name: Gemini 3 Pro (preview)
@@ -172,6 +229,7 @@ models:
     chef_slug: google
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, high]
   # Verified 2026-07-20 against the Generative Language models API: 3.5 Flash
   # is the only 3.5 chat model (no 3.5 Pro; live-translate is Live-API-only,
   # no generateContent → can't back an agent). Function calling tested live.
@@ -182,6 +240,31 @@ models:
     chef_slug: google
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [minimal, low, medium, high]
+  # 3.6/3.7 verified live 2026-08-26 against the Generative Language API:
+  # Flash is the only model in each line (no 3.6/3.7 Pro or Flash-Lite —
+  # Google's Pro line is frozen at 3.1). Level acceptance probed per model
+  # (3.7 rejects `minimal`), function calling tested live, thinking cannot be
+  # disabled on either. `medium` is Google's documented default for both —
+  # declaring it keeps unset threads on the documented behavior.
+  - provider: google
+    model_id: gemini-3.6-flash
+    display_name: Gemini 3.6 Flash
+    chef: Google
+    chef_slug: google
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [minimal, low, medium, high]
+    reasoning_effort_default: medium
+  - provider: google
+    model_id: gemini-3.7-flash
+    display_name: Gemini 3.7 Flash
+    chef: Google
+    chef_slug: google
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high]
+    reasoning_effort_default: medium
 
   # --- Xiaomi (native endpoint) ---
   # SO flags conservative: OpenRouter's listing says the models support
@@ -214,7 +297,7 @@ models:
     multimodal: false
     supports_structured_output: false
 
-  # --- OpenRouter (gateway; ids must exist in OPENROUTER_MODELS) ---
+  # --- OpenRouter (gateway; model_id is the OpenRouter slug, sent verbatim) ---
   # GLM SO flag: Z.ai's FIRST-PARTY API only offers json_object (no schema —
   # docs.z.ai/guides/capabilities/struct-output), but we serve GLM through
   # OpenRouter, whose hosts run real guided decoding — verified live
@@ -222,17 +305,79 @@ models:
   # serving-path rule that flags DeepSeek false. If enforcement ever consumes
   # this flag, the OpenRouter call must pin provider.require_parameters=true
   # (routing to a host that ignores response_format is otherwise possible).
+  # Effort: GLM 5.2 exposes exactly two thinking tiers (its API coerces the
+  # other ladder values onto them); "max" is its deep-reasoning default.
+  # Replaces the former glm-5.2-max / glm-5.2-high pseudo-model split.
   - provider: openrouter
-    model_id: glm-5.2-max
-    display_name: GLM 5.2 (max reasoning)
+    model_id: z-ai/glm-5.2
+    display_name: GLM 5.2
     chef: Z.ai
     chef_slug: z-ai
     multimodal: false
     supports_structured_output: true
+    reasoning_effort_levels: [high, max]
+    reasoning_effort_default: max
+
+  # GLM 5.3 (added 2026-08-26): thinking is FORCED on both variants (Z.ai docs
+  # — `thinking.type: disabled` fails on the direct API); the effort ladder
+  # narrowed to low|high|max, default max. SO flags: plain 5.3 is served by
+  # Z.AI only, which offers response_format json only (no json_schema); the
+  # Flash variant has real structured_outputs only on 2 of its 6 OpenRouter
+  # hosts (Cloudflare, DeepInfra) — false until we pin
+  # provider.require_parameters. Flash is natively multimodal (image+video).
   - provider: openrouter
-    model_id: glm-5.2-high
-    display_name: GLM 5.2 (high reasoning)
+    model_id: z-ai/glm-5.3
+    display_name: GLM 5.3
     chef: Z.ai
     chef_slug: z-ai
     multimodal: false
+    supports_structured_output: false
+    reasoning_effort_levels: [low, high, max]
+    reasoning_effort_default: max
+  - provider: openrouter
+    model_id: z-ai/glm-5.3-flash
+    display_name: GLM 5.3 Flash
+    chef: Z.ai
+    chef_slug: z-ai
+    multimodal: true
+    supports_structured_output: false
+    reasoning_effort_levels: [low, high, max]
+    reasoning_effort_default: max
+
+  # --- Qwen 3.8 via OpenRouter (added 2026-08-26) ---
+  # There is NO qwen3.8-flash (on OpenRouter or Alibaba); the 3.8 lineup is
+  # Max (hosted, multimodal), 27B (open-weight dense VL) and 2.4T-A95B (the
+  # open-weight MoE flagship, text-only). Effort ladder is low|xhigh with
+  # xhigh the native default — Qwen's `medium` is a silent no-op alias for
+  # the default, so per the header rule it is not declared. Whether hosted
+  # endpoints accept disabling thinking is unverified — no `none` until
+  # probed. SO flags follow the endpoints' supported_parameters: Max
+  # (Alibaba, sole host) and 27B (all 10 hosts) list structured_outputs;
+  # 2.4T-A95B is host-dependent (absent on Alibaba's own endpoint) → false.
+  - provider: openrouter
+    model_id: qwen/qwen3.8-max
+    display_name: Qwen3.8 Max
+    chef: Qwen
+    chef_slug: qwen
+    multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, xhigh]
+    reasoning_effort_default: xhigh
+  - provider: openrouter
+    model_id: qwen/qwen3.8-27b
+    display_name: Qwen3.8 27B
+    chef: Qwen
+    chef_slug: qwen
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [low, xhigh]
+    reasoning_effort_default: xhigh
+  - provider: openrouter
+    model_id: qwen/qwen3.8-2.4t-a95b
+    display_name: Qwen3.8 2.4T
+    chef: Qwen
+    chef_slug: qwen
+    multimodal: false
+    supports_structured_output: false
+    reasoning_effort_levels: [low, xhigh]
+    reasoning_effort_default: xhigh

--- a/backend/app/model_providers/whitelist.yaml
+++ b/backend/app/model_providers/whitelist.yaml
@@ -202,7 +202,16 @@ models:
     multimodal: false
     supports_structured_output: false
     reasoning_effort_levels: [none, low, high, max]
-    reasoning_effort_default: high
+    reasoning_effort_default: low
+  - provider: deepseek
+    model_id: deepseek-v4-flash-vision-exp
+    display_name: DeepSeek V4 Flash Vision Exp
+    chef: DeepSeek
+    chef_slug: deepseek
+    multimodal: true
+    supports_structured_output: false
+    reasoning_effort_levels: [none, low, high, max]
+    reasoning_effort_default: low
   - provider: deepseek
     model_id: deepseek-v4-pro
     display_name: DeepSeek V4 Pro
@@ -211,7 +220,7 @@ models:
     multimodal: false
     supports_structured_output: false
     reasoning_effort_levels: [none, low, high, max]
-    reasoning_effort_default: high
+    reasoning_effort_default: low
 
   # --- Google (native endpoint) ---
   - provider: google

--- a/backend/app/threads/models.py
+++ b/backend/app/threads/models.py
@@ -31,6 +31,11 @@ class ThreadBase(SQLModel):
     user_id: UUID = Field(foreign_key="users.id", nullable=False)
     agent_id: UUID = Field(foreign_key="agents.id", nullable=False)
     model_id: str | None = Field(default=None, nullable=True)
+    # The user's reasoning-effort choice for the pinned model, one of the
+    # whitelist entry's declared levels. NULL = no explicit choice — the
+    # model runs on its default path. Pinned like model_id: set at creation,
+    # never patched.
+    reasoning_effort: str | None = Field(default=None, nullable=True)
     first_message_content: str | None = Field(
         default=None, sa_column=Column(Text, nullable=True)
     )

--- a/backend/app/threads/schemas.py
+++ b/backend/app/threads/schemas.py
@@ -12,6 +12,9 @@ class ThreadCreate(SQLModel):
     id: str | None = None
     agent_id: UUID
     model_id: str | None = None
+    # Validated against the model's whitelist-declared levels at creation
+    # (400 on an undeclared value). None = the model's default.
+    reasoning_effort: str | None = None
     first_message_content: str | None = None
 
 

--- a/backend/app/threads/service.py
+++ b/backend/app/threads/service.py
@@ -102,6 +102,17 @@ class ThreadService(BaseService[ThreadDB, ThreadRepository]):
         source: ThreadSource,
         trigger_id: UUID | None = None,
     ) -> ThreadResponse:
+        # Strict at selection time (unlike model availability, which is only
+        # flagged): an undeclared effort level is a client bug, and letting it
+        # persist would silently degrade to the model default on every run.
+        # Trigger firings are exempt — their effort was validated when the
+        # trigger was saved, and a later catalog edit must skip nothing worse
+        # than the effort (ensure_available clamps it at run time), not the
+        # whole scheduled firing.
+        if data.reasoning_effort is not None and source != ThreadSource.trigger:
+            await ModelService.validate_reasoning_effort(
+                data.model_id, data.reasoning_effort
+            )
         # `trigger_id` is a keyword (not a ThreadCreate field) so API clients
         # can't attach arbitrary threads to a trigger — only the scanner sets it.
         thread = ThreadDB(

--- a/backend/app/triggers/models.py
+++ b/backend/app/triggers/models.py
@@ -14,6 +14,9 @@ class TriggerBase(SQLModel):
         foreign_key="agents.id", ondelete="CASCADE", index=True, nullable=False
     )
     model_id: str = Field(max_length=255, nullable=False)
+    # Reasoning-effort choice for the model, one of its whitelist-declared
+    # levels; NULL = the model's default. Copied onto each firing's thread.
+    reasoning_effort: str | None = Field(default=None, max_length=32, nullable=True)
     cron_expression: str = Field(max_length=255, nullable=False)
     timezone: str = Field(default="UTC", max_length=64, nullable=False)
     is_active: bool = Field(default=True, nullable=False)

--- a/backend/app/triggers/schemas.py
+++ b/backend/app/triggers/schemas.py
@@ -21,6 +21,7 @@ class TriggerPatch(SQLModel):
     instructions: str | None = None
     agent_id: UUID | None = None
     model_id: str | None = None
+    reasoning_effort: str | None = None
     cron_expression: str | None = None
     timezone: str | None = None
     is_active: bool | None = None
@@ -33,6 +34,7 @@ class TriggerResponse(SQLModel):
     owner_id: UUID
     agent_id: UUID
     model_id: str
+    reasoning_effort: str | None = None
     cron_expression: str
     timezone: str
     is_active: bool

--- a/backend/app/triggers/service.py
+++ b/backend/app/triggers/service.py
@@ -128,6 +128,9 @@ class TriggerService(BaseService[TriggerDB, TriggerRepository]):
         ensure_valid_schedule(data.cron_expression, data.timezone)
         # Fail at save time, not first fire — 409 model_unavailable on the form.
         await self.model_service.ensure_available(data.model_id)
+        await ModelService.validate_reasoning_effort(
+            data.model_id, data.reasoning_effort
+        )
         await self._ensure_agent_usable(data.agent_id, owner)
         next_run_at = (
             compute_next_run_at(
@@ -159,6 +162,13 @@ class TriggerService(BaseService[TriggerDB, TriggerRepository]):
             ensure_valid_schedule(cron, timezone)
         if "model_id" in update_data:
             await self.model_service.ensure_available(update_data["model_id"])
+        if "model_id" in update_data or "reasoning_effort" in update_data:
+            # Validate the pair that will be stored — a model change must not
+            # carry over an effort level the new model doesn't declare.
+            await ModelService.validate_reasoning_effort(
+                update_data.get("model_id", trigger.model_id),
+                update_data.get("reasoning_effort", trigger.reasoning_effort),
+            )
         if "agent_id" in update_data and update_data["agent_id"] != trigger.agent_id:
             # Check against the owner, not the caller — an admin may edit
             # someone else's trigger, but the run still executes as the owner.
@@ -241,6 +251,7 @@ class TriggerService(BaseService[TriggerDB, TriggerRepository]):
             ThreadCreate(
                 agent_id=trigger.agent_id,
                 model_id=trigger.model_id,
+                reasoning_effort=trigger.reasoning_effort,
                 first_message_content=trigger.name,
             ),
             user_id=trigger.owner_id,

--- a/backend/app/triggers/service.py
+++ b/backend/app/triggers/service.py
@@ -162,12 +162,21 @@ class TriggerService(BaseService[TriggerDB, TriggerRepository]):
             ensure_valid_schedule(cron, timezone)
         if "model_id" in update_data:
             await self.model_service.ensure_available(update_data["model_id"])
-        if "model_id" in update_data or "reasoning_effort" in update_data:
-            # Validate the pair that will be stored — a model change must not
-            # carry over an effort level the new model doesn't declare.
+        clear_stale_effort = False
+        if "reasoning_effort" in update_data:
+            # A fresh user choice is validated strictly against the model
+            # that will be stored.
             await ModelService.validate_reasoning_effort(
                 update_data.get("model_id", trigger.model_id),
-                update_data.get("reasoning_effort", trigger.reasoning_effort),
+                update_data["reasoning_effort"],
+            )
+        elif "model_id" in update_data and trigger.reasoning_effort is not None:
+            # Re-pointing the model with a carried-over effort the new model
+            # doesn't declare must not block the edit (the stored value was
+            # valid when saved) — clear it back to the model default, the
+            # same clamp ensure_available applies at run time.
+            clear_stale_effort = not await ModelService.is_reasoning_effort_declared(
+                update_data["model_id"], trigger.reasoning_effort
             )
         if "agent_id" in update_data and update_data["agent_id"] != trigger.agent_id:
             # Check against the owner, not the caller — an admin may edit
@@ -178,6 +187,11 @@ class TriggerService(BaseService[TriggerDB, TriggerRepository]):
             await self._ensure_agent_usable(update_data["agent_id"], owner)
 
         trigger = await self.repository.update(trigger, data)
+
+        if clear_stale_effort:
+            trigger.reasoning_effort = None
+            self.db.add(trigger)
+            await self.db.flush()
 
         # Rematerialize the schedule: pausing clears next_run_at so the row
         # drops out of the due scan; (re)activating or editing the schedule

--- a/backend/tests/model_providers/test_catalog.py
+++ b/backend/tests/model_providers/test_catalog.py
@@ -30,6 +30,84 @@ def test_openai_factory_routes_gpt56_through_responses_api(
     assert model.use_responses_api is expects_responses_api
 
 
+def test_openai_factory_passes_reasoning_effort_through():
+    model = ChatModelFactory().create(
+        "openai", "gpt-5.2", "unit-test-key", reasoning_effort="xhigh"
+    )
+    assert model.reasoning_effort == "xhigh"
+    # No explicit choice → nothing sent, the provider default applies.
+    model = ChatModelFactory().create("openai", "gpt-5.2", "unit-test-key")
+    assert model.reasoning_effort is None
+
+
+def test_deepseek_factory_maps_effort_onto_thinking_params():
+    factory = ChatModelFactory()
+    # Default: thinking on, no explicit effort (the API defaults to high).
+    model = factory.create("deepseek", "deepseek-v4-pro", "unit-test-key")
+    assert model.extra_body == {"thinking": {"type": "enabled"}}
+    # A level: thinking on + the effort.
+    model = factory.create(
+        "deepseek", "deepseek-v4-pro", "unit-test-key", reasoning_effort="max"
+    )
+    assert model.extra_body == {
+        "thinking": {"type": "enabled"},
+        "reasoning_effort": "max",
+    }
+    # "none" turns thinking off entirely (and sends no effort).
+    model = factory.create(
+        "deepseek", "deepseek-v4-pro", "unit-test-key", reasoning_effort="none"
+    )
+    assert model.extra_body == {"thinking": {"type": "disabled"}}
+
+
+def test_anthropic_factory_effort_selects_adaptive_thinking():
+    factory = ChatModelFactory()
+    # Adaptive model, no choice → the historical medium default.
+    model = factory.create("anthropic", "claude-opus-4-8", "unit-test-key")
+    assert model.thinking == {"type": "adaptive", "display": "summarized"}
+    assert model.reasoning_effort == "medium"
+    # Adaptive model, explicit choice → the choice.
+    model = factory.create(
+        "anthropic", "claude-opus-4-8", "unit-test-key", reasoning_effort="max"
+    )
+    assert model.reasoning_effort == "max"
+    # Legacy model, no choice → the historical budget format, untouched.
+    model = factory.create("anthropic", "claude-sonnet-4-6", "unit-test-key")
+    assert model.thinking == {"type": "enabled", "budget_tokens": 1024}
+    assert model.reasoning_effort is None
+    # Legacy model, explicit choice → opts into adaptive + effort.
+    model = factory.create(
+        "anthropic", "claude-sonnet-4-6", "unit-test-key", reasoning_effort="low"
+    )
+    assert model.thinking == {"type": "adaptive", "display": "summarized"}
+    assert model.reasoning_effort == "low"
+
+
+def test_google_factory_sends_level_xor_dynamic_budget():
+    factory = ChatModelFactory()
+    # thinking_level and thinking_budget are mutually exclusive on Gemini 3+.
+    model = factory.create("google", "gemini-3-pro-preview", "unit-test-key")
+    assert model.thinking_budget == -1
+    assert model.reasoning_effort is None
+    model = factory.create(
+        "google", "gemini-3-pro-preview", "unit-test-key", reasoning_effort="low"
+    )
+    assert model.reasoning_effort == "low"
+    assert model.thinking_budget is None
+
+
+def test_openrouter_factory_sends_the_slug_verbatim():
+    factory = ChatModelFactory()
+    # No mapping table anymore: the whitelist model_id IS the OpenRouter slug.
+    model = factory.create("openrouter", "z-ai/glm-5.2", "unit-test-key")
+    assert model.model_name == "z-ai/glm-5.2"
+    assert model.extra_body is None
+    model = factory.create(
+        "openrouter", "z-ai/glm-5.2", "unit-test-key", reasoning_effort="high"
+    )
+    assert model.extra_body == {"reasoning_effort": "high"}
+
+
 def test_provider_api_keys_serves_google_via_adc_when_no_api_key():
     with (
         patch("app.model_providers.catalog.model_provider_settings") as mock_settings,

--- a/backend/tests/model_providers/test_router.py
+++ b/backend/tests/model_providers/test_router.py
@@ -21,25 +21,30 @@ def test_get_models_projects_the_picker_shape(client, model_service):
     model_service.list_available.return_value = [
         SupportedModel(
             provider="openrouter",
-            model_id="glm-5.2-max",
-            display_name="GLM 5.2 (max reasoning)",
+            model_id="z-ai/glm-5.2",
+            display_name="GLM 5.2",
             chef="Z.ai",
             chef_slug="z-ai",
+            reasoning_effort_levels=["high", "max"],
+            reasoning_effort_default="max",
         )
     ]
-    model_service.get_default_model_id.return_value = "glm-5.2-max"
+    model_service.get_default_model_id.return_value = "z-ai/glm-5.2"
 
     response = client.get("/model-providers/models")
 
     assert response.status_code == 200
     assert response.json() == [
         {
-            "name": "GLM 5.2 (max reasoning)",
-            "id": "glm-5.2-max",
+            "name": "GLM 5.2",
+            "id": "z-ai/glm-5.2",
             "chef": "Z.ai",
             "chefSlug": "z-ai",
             "providers": ["openrouter"],
             "isDefault": True,
+            "multimodal": False,
+            "reasoningEffortLevels": ["high", "max"],
+            "reasoningEffortDefault": "max",
         }
     ]
 

--- a/backend/tests/model_providers/test_service.py
+++ b/backend/tests/model_providers/test_service.py
@@ -17,7 +17,11 @@ from app.model_providers.whitelist import SupportedModel
 
 WHITELIST = [
     SupportedModel(
-        provider="anthropic", model_id="claude-sonnet-5", display_name="Claude Sonnet 5"
+        provider="anthropic",
+        model_id="claude-sonnet-5",
+        display_name="Claude Sonnet 5",
+        reasoning_effort_levels=["low", "medium", "high", "xhigh", "max"],
+        reasoning_effort_default="medium",
     ),
     SupportedModel(
         provider="openai", model_id="gpt-4o-mini", display_name="GPT-4o mini"
@@ -100,6 +104,45 @@ async def test_ensure_available_raises_with_precise_reason(rows, model_id, match
     service = _service(rows)
     with pytest.raises(ModelUnavailableError, match=match):
         await service.ensure_available(model_id)
+
+
+async def test_ensure_available_passes_a_declared_effort_through():
+    service = _service([_row("anthropic", "claude-sonnet-5")])
+    resolved = await service.ensure_available("claude-sonnet-5", "xhigh")
+    assert resolved.reasoning_effort == "xhigh"
+
+
+async def test_ensure_available_applies_the_catalog_default_when_unset():
+    # The whitelist default is a policy value, not a UI hint: a thread with no
+    # explicit choice resolves to it, so editing the CDN file changes what
+    # unset means without touching threads.
+    service = _service([_row("anthropic", "claude-sonnet-5")])
+    resolved = await service.ensure_available("claude-sonnet-5", None)
+    assert resolved.reasoning_effort == "medium"
+
+
+async def test_ensure_available_clamps_an_undeclared_effort_to_the_default():
+    # A catalog edit must never strand an existing thread: a stored level the
+    # whitelist no longer declares is discarded, and the entry's applied
+    # default takes over.
+    service = _service(
+        [_row("anthropic", "claude-sonnet-5"), _row("openai", "gpt-4o-mini")]
+    )
+    resolved = await service.ensure_available("claude-sonnet-5", "ultra")
+    assert resolved.reasoning_effort == "medium"
+    # gpt-4o-mini declares no levels (and no default) — any stored effort
+    # clamps all the way to None: send nothing.
+    resolved = await service.ensure_available("gpt-4o-mini", "high")
+    assert resolved.reasoning_effort is None
+
+
+async def test_validate_reasoning_effort_is_strict_at_selection_time():
+    await ModelService.validate_reasoning_effort("claude-sonnet-5", None)
+    await ModelService.validate_reasoning_effort("claude-sonnet-5", "max")
+    with pytest.raises(DomainValidationError, match="does not support"):
+        await ModelService.validate_reasoning_effort("claude-sonnet-5", "none")
+    with pytest.raises(DomainValidationError, match="does not support"):
+        await ModelService.validate_reasoning_effort("gpt-4o-mini", "high")
 
 
 async def test_is_available_swallows_the_domain_error():

--- a/backend/tests/model_providers/test_service.py
+++ b/backend/tests/model_providers/test_service.py
@@ -136,6 +136,16 @@ async def test_ensure_available_clamps_an_undeclared_effort_to_the_default():
     assert resolved.reasoning_effort is None
 
 
+async def test_is_reasoning_effort_declared():
+    # The clamp-side helper (trigger model re-pointing): membership only,
+    # never raises.
+    assert await ModelService.is_reasoning_effort_declared("claude-sonnet-5", "max")
+    assert not await ModelService.is_reasoning_effort_declared(
+        "claude-sonnet-5", "none"
+    )
+    assert not await ModelService.is_reasoning_effort_declared("gpt-4o-mini", "high")
+
+
 async def test_validate_reasoning_effort_is_strict_at_selection_time():
     await ModelService.validate_reasoning_effort("claude-sonnet-5", None)
     await ModelService.validate_reasoning_effort("claude-sonnet-5", "max")

--- a/backend/tests/model_providers/test_whitelist.py
+++ b/backend/tests/model_providers/test_whitelist.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from app.model_providers.whitelist import (
@@ -91,6 +93,16 @@ def test_chef_defaults_to_provider_and_explicit_chef_wins():
             "    reasoning_effort_default: medium\n",
             "not in reasoning_effort_levels",
         ),
+        # Levels must follow the canonical ladder order — the picker renders
+        # the list as-is.
+        (
+            "schema_version: 1\nmodels:\n"
+            "  - provider: openai\n"
+            "    model_id: gpt-5\n"
+            "    display_name: GPT-5\n"
+            "    reasoning_effort_levels: [high, low]\n",
+            "out-of-order reasoning_effort_levels",
+        ),
     ],
 )
 def test_parse_rejects_bad_documents(text: str, match: str):
@@ -98,6 +110,22 @@ def test_parse_rejects_bad_documents(text: str, match: str):
     # broken CDN upload can never half-apply.
     with pytest.raises(ValueError, match=match):
         parse_whitelist(text)
+
+
+def test_publishable_copy_matches_bundled_snapshot():
+    """catalog/whitelist.yaml (uploaded to the CDN) and the bundled snapshot
+    must stay byte-identical, or the CDN and offline fallback silently
+    diverge (same contract as the MCP server catalog)."""
+    published = Path(__file__).resolve().parents[3] / "catalog" / "whitelist.yaml"
+    if not published.exists():
+        pytest.skip("publishable copy not present (packaged build)")
+    bundled = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "model_providers"
+        / "whitelist.yaml"
+    )
+    assert published.read_text(encoding="utf-8") == bundled.read_text(encoding="utf-8")
 
 
 def test_bundled_snapshot_is_valid():

--- a/backend/tests/model_providers/test_whitelist.py
+++ b/backend/tests/model_providers/test_whitelist.py
@@ -15,9 +15,11 @@ models:
     display_name: Claude Sonnet 5
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
   - provider: openrouter
-    model_id: glm-5.2-max
-    display_name: GLM 5.2 (max reasoning)
+    model_id: z-ai/glm-5.2
+    display_name: GLM 5.2
     chef: Z.ai
     chef_slug: z-ai
 """
@@ -25,9 +27,20 @@ models:
 
 def test_parse_valid_document():
     models = parse_whitelist(VALID_DOC)
-    assert [m.model_id for m in models] == ["claude-sonnet-5", "glm-5.2-max"]
+    assert [m.model_id for m in models] == ["claude-sonnet-5", "z-ai/glm-5.2"]
     assert models[0].multimodal is True
+    assert models[0].reasoning_effort_levels == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert models[0].reasoning_effort_default == "medium"
     assert models[1].supports_structured_output is False
+    # Effort metadata is optional: no levels = no effort knob.
+    assert models[1].reasoning_effort_levels == []
+    assert models[1].reasoning_effort_default is None
 
 
 def test_chef_defaults_to_provider_and_explicit_chef_wins():
@@ -58,14 +71,25 @@ def test_chef_defaults_to_provider_and_explicit_chef_wins():
             "    display_name: X\n",
             "not supported",
         ),
-        # An openrouter id without an OPENROUTER_MODELS mapping would only
-        # crash at agent build — it must fail file validation instead.
+        # Effort values come from the canonical ladder — a typo must fail the
+        # file, not surface as a 400 on some provider call later.
         (
             "schema_version: 1\nmodels:\n"
-            "  - provider: openrouter\n"
-            "    model_id: z-ai/glm-99\n"
-            "    display_name: GLM 99\n",
-            "no OPENROUTER_MODELS mapping",
+            "  - provider: openai\n"
+            "    model_id: gpt-5\n"
+            "    display_name: GPT-5\n"
+            "    reasoning_effort_levels: [ultra]\n",
+            "reasoning_effort_levels",
+        ),
+        # The default must be one of the declared levels.
+        (
+            "schema_version: 1\nmodels:\n"
+            "  - provider: openai\n"
+            "    model_id: gpt-5\n"
+            "    display_name: GPT-5\n"
+            "    reasoning_effort_levels: [low, high]\n"
+            "    reasoning_effort_default: medium\n",
+            "not in reasoning_effort_levels",
         ),
     ],
 )
@@ -82,4 +106,4 @@ def test_bundled_snapshot_is_valid():
     assert all(isinstance(m, SupportedModel) for m in models)
     # The bundled snapshot must contain the models seeded by the migration.
     ids = {m.model_id for m in models}
-    assert {"gpt-4o-mini", "claude-sonnet-5", "glm-5.2-max"} <= ids
+    assert {"gpt-4o-mini", "claude-sonnet-5", "z-ai/glm-5.2"} <= ids

--- a/backend/tests/triggers/test_run_now_gate.py
+++ b/backend/tests/triggers/test_run_now_gate.py
@@ -21,6 +21,7 @@ def _service():
         instructions="do it",
         name="t",
         model_id="m",
+        reasoning_effort=None,
     )
     svc = TriggerService(AsyncMock())
     svc.get_or_404 = AsyncMock(return_value=trigger)

--- a/catalog/whitelist.yaml
+++ b/catalog/whitelist.yaml
@@ -3,14 +3,27 @@
 # Source of truth for the models auxilia can offer. Every entry MUST be:
 #   1. tool-calling capable (all auxilia agents bind tools), and
 #   2. drivable by ChatModelFactory (backend/app/model_providers/catalog.py):
-#      `provider` must match a factory branch, and openrouter model_ids must
-#      exist in OPENROUTER_MODELS.
+#      `provider` must match a factory branch. Openrouter model_ids are the
+#      OpenRouter slugs, passed to the gateway verbatim.
 #
 # Flags describe OUR serving path, not the model in the abstract:
 #   multimodal                 — accepts non-text input (image/audio/video)
 #   supports_structured_output — REAL constrained decoding (json_schema /
 #                                strict tool call) on the endpoint we call,
 #                                NOT best-effort json_object
+#
+# reasoning_effort_levels / reasoning_effort_default — the effort values a
+# user may pick for this model, drawn from the canonical ladder
+# (none < minimal < low < medium < high < xhigh < max), and the level APPLIED
+# when they pick nothing (threads/triggers with no explicit choice resolve to
+# it, so editing a default here changes what unset means workspace-wide —
+# explicit choices are never touched). Declare only values the serving
+# endpoint ACCEPTS as distinct tiers (silent-coercion aliases don't count —
+# e.g. GLM 5.2 coerces xhigh to max, so only high/max are listed).
+# Empty/omitted levels = the model has no effort knob and the picker renders
+# none. "none" in the list means thinking can be turned off entirely. A
+# missing default with non-empty levels means "provider-managed/dynamic"
+# (shown as Auto): no effort is sent and the serving default applies.
 #
 # chef / chef_slug — the model's creator, shown next to the model in the
 # picker (logo lookup by slug). Optional: defaults to the provider name,
@@ -40,6 +53,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5-mini
     display_name: GPT-5 mini
@@ -47,6 +61,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5-nano
     display_name: GPT-5 nano
@@ -54,6 +69,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.1
     display_name: GPT-5.1
@@ -61,6 +77,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.2
     display_name: GPT-5.2
@@ -68,6 +85,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.4
     display_name: GPT-5.4
@@ -75,6 +93,7 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
   - provider: openai
     model_id: gpt-5.5
     display_name: GPT-5.5
@@ -82,6 +101,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh]
+    reasoning_effort_default: medium
   - provider: openai
     model_id: gpt-5.6-luna
     display_name: GPT-5.6 Luna
@@ -89,6 +110,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
   - provider: openai
     model_id: gpt-5.6-sol
     display_name: GPT-5.6 Sol
@@ -96,6 +119,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
   - provider: openai
     model_id: gpt-5.6-terra
     display_name: GPT-5.6 Terra
@@ -103,6 +128,8 @@ models:
     chef_slug: openai
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [none, low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
 
   # --- Anthropic (native endpoint) ---
   - provider: anthropic
@@ -119,6 +146,7 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, max]
   - provider: anthropic
     model_id: claude-sonnet-5
     display_name: Claude Sonnet 5
@@ -126,6 +154,11 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, xhigh, max]
+    # Adaptive-thinking models (ADAPTIVE_THINKING_MODELS in catalog.py) have
+    # always been served at effort medium — the applied default preserves
+    # that. Anthropic's own API default is high.
+    reasoning_effort_default: medium
   - provider: anthropic
     model_id: claude-opus-4-6
     display_name: Claude Opus 4.6
@@ -133,6 +166,8 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, max]
+    reasoning_effort_default: medium
   - provider: anthropic
     model_id: claude-opus-4-8
     display_name: Claude Opus 4.8
@@ -140,6 +175,23 @@ models:
     chef_slug: anthropic
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
+  # Opus 5 thinks by default (no opt-in needed) but is driven through the same
+  # adaptive path (ADAPTIVE_THINKING_MODELS); the legacy budget format 400s.
+  # `thinking: disabled` exists only at effort ≤ high — not exposed here ("none"
+  # would need a factory mapping). Verified live 2026-08-26 on the adaptive
+  # path. Anthropic's API default effort is high; medium matches the other
+  # Claudes we serve.
+  - provider: anthropic
+    model_id: claude-opus-5
+    display_name: Claude Opus 5
+    chef: Anthropic
+    chef_slug: anthropic
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high, xhigh, max]
+    reasoning_effort_default: medium
 
   # --- DeepSeek (native endpoint: json_object only, no schema guarantee) ---
   - provider: deepseek
@@ -149,6 +201,17 @@ models:
     chef_slug: deepseek
     multimodal: false
     supports_structured_output: false
+    reasoning_effort_levels: [none, low, high, max]
+    reasoning_effort_default: low
+  - provider: deepseek
+    model_id: deepseek-v4-flash-vision-exp
+    display_name: DeepSeek V4 Flash Vision Exp
+    chef: DeepSeek
+    chef_slug: deepseek
+    multimodal: true
+    supports_structured_output: false
+    reasoning_effort_levels: [none, low, high, max]
+    reasoning_effort_default: low
   - provider: deepseek
     model_id: deepseek-v4-pro
     display_name: DeepSeek V4 Pro
@@ -156,6 +219,8 @@ models:
     chef_slug: deepseek
     multimodal: false
     supports_structured_output: false
+    reasoning_effort_levels: [none, low, high, max]
+    reasoning_effort_default: low
 
   # --- Google (native endpoint) ---
   - provider: google
@@ -165,6 +230,7 @@ models:
     chef_slug: google
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [minimal, low, medium, high]
   - provider: google
     model_id: gemini-3-pro-preview
     display_name: Gemini 3 Pro (preview)
@@ -172,6 +238,7 @@ models:
     chef_slug: google
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, high]
   # Verified 2026-07-20 against the Generative Language models API: 3.5 Flash
   # is the only 3.5 chat model (no 3.5 Pro; live-translate is Live-API-only,
   # no generateContent → can't back an agent). Function calling tested live.
@@ -182,6 +249,31 @@ models:
     chef_slug: google
     multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [minimal, low, medium, high]
+  # 3.6/3.7 verified live 2026-08-26 against the Generative Language API:
+  # Flash is the only model in each line (no 3.6/3.7 Pro or Flash-Lite —
+  # Google's Pro line is frozen at 3.1). Level acceptance probed per model
+  # (3.7 rejects `minimal`), function calling tested live, thinking cannot be
+  # disabled on either. `medium` is Google's documented default for both —
+  # declaring it keeps unset threads on the documented behavior.
+  - provider: google
+    model_id: gemini-3.6-flash
+    display_name: Gemini 3.6 Flash
+    chef: Google
+    chef_slug: google
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [minimal, low, medium, high]
+    reasoning_effort_default: medium
+  - provider: google
+    model_id: gemini-3.7-flash
+    display_name: Gemini 3.7 Flash
+    chef: Google
+    chef_slug: google
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [low, medium, high]
+    reasoning_effort_default: medium
 
   # --- Xiaomi (native endpoint) ---
   # SO flags conservative: OpenRouter's listing says the models support
@@ -214,7 +306,7 @@ models:
     multimodal: false
     supports_structured_output: false
 
-  # --- OpenRouter (gateway; ids must exist in OPENROUTER_MODELS) ---
+  # --- OpenRouter (gateway; model_id is the OpenRouter slug, sent verbatim) ---
   # GLM SO flag: Z.ai's FIRST-PARTY API only offers json_object (no schema —
   # docs.z.ai/guides/capabilities/struct-output), but we serve GLM through
   # OpenRouter, whose hosts run real guided decoding — verified live
@@ -222,17 +314,79 @@ models:
   # serving-path rule that flags DeepSeek false. If enforcement ever consumes
   # this flag, the OpenRouter call must pin provider.require_parameters=true
   # (routing to a host that ignores response_format is otherwise possible).
+  # Effort: GLM 5.2 exposes exactly two thinking tiers (its API coerces the
+  # other ladder values onto them); "max" is its deep-reasoning default.
+  # Replaces the former glm-5.2-max / glm-5.2-high pseudo-model split.
   - provider: openrouter
-    model_id: glm-5.2-max
-    display_name: GLM 5.2 (max reasoning)
+    model_id: z-ai/glm-5.2
+    display_name: GLM 5.2
     chef: Z.ai
     chef_slug: z-ai
     multimodal: false
     supports_structured_output: true
+    reasoning_effort_levels: [high, max]
+    reasoning_effort_default: max
+
+  # GLM 5.3 (added 2026-08-26): thinking is FORCED on both variants (Z.ai docs
+  # — `thinking.type: disabled` fails on the direct API); the effort ladder
+  # narrowed to low|high|max, default max. SO flags: plain 5.3 is served by
+  # Z.AI only, which offers response_format json only (no json_schema); the
+  # Flash variant has real structured_outputs only on 2 of its 6 OpenRouter
+  # hosts (Cloudflare, DeepInfra) — false until we pin
+  # provider.require_parameters. Flash is natively multimodal (image+video).
   - provider: openrouter
-    model_id: glm-5.2-high
-    display_name: GLM 5.2 (high reasoning)
+    model_id: z-ai/glm-5.3
+    display_name: GLM 5.3
     chef: Z.ai
     chef_slug: z-ai
     multimodal: false
+    supports_structured_output: false
+    reasoning_effort_levels: [low, high, max]
+    reasoning_effort_default: max
+  - provider: openrouter
+    model_id: z-ai/glm-5.3-flash
+    display_name: GLM 5.3 Flash
+    chef: Z.ai
+    chef_slug: z-ai
+    multimodal: true
+    supports_structured_output: false
+    reasoning_effort_levels: [low, high, max]
+    reasoning_effort_default: max
+
+  # --- Qwen 3.8 via OpenRouter (added 2026-08-26) ---
+  # There is NO qwen3.8-flash (on OpenRouter or Alibaba); the 3.8 lineup is
+  # Max (hosted, multimodal), 27B (open-weight dense VL) and 2.4T-A95B (the
+  # open-weight MoE flagship, text-only). Effort ladder is low|xhigh with
+  # xhigh the native default — Qwen's `medium` is a silent no-op alias for
+  # the default, so per the header rule it is not declared. Whether hosted
+  # endpoints accept disabling thinking is unverified — no `none` until
+  # probed. SO flags follow the endpoints' supported_parameters: Max
+  # (Alibaba, sole host) and 27B (all 10 hosts) list structured_outputs;
+  # 2.4T-A95B is host-dependent (absent on Alibaba's own endpoint) → false.
+  - provider: openrouter
+    model_id: qwen/qwen3.8-max
+    display_name: Qwen3.8 Max
+    chef: Qwen
+    chef_slug: qwen
+    multimodal: true
     supports_structured_output: true
+    reasoning_effort_levels: [low, xhigh]
+    reasoning_effort_default: xhigh
+  - provider: openrouter
+    model_id: qwen/qwen3.8-27b
+    display_name: Qwen3.8 27B
+    chef: Qwen
+    chef_slug: qwen
+    multimodal: true
+    supports_structured_output: true
+    reasoning_effort_levels: [low, xhigh]
+    reasoning_effort_default: xhigh
+  - provider: openrouter
+    model_id: qwen/qwen3.8-2.4t-a95b
+    display_name: Qwen3.8 2.4T
+    chef: Qwen
+    chef_slug: qwen
+    multimodal: false
+    supports_structured_output: false
+    reasoning_effort_levels: [low, xhigh]
+    reasoning_effort_default: xhigh

--- a/docs/content/agents/index.mdx
+++ b/docs/content/agents/index.mdx
@@ -53,13 +53,15 @@ You can pick a different LLM per thread. A model appears in the selector when it
 
 | Provider  | Models                                                     |
 | --------- | ---------------------------------------------------------- |
-| Anthropic | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-sonnet-5` |
-| OpenAI    | `gpt-4o-mini`                                              |
-| Google    | `gemini-3-flash-preview`, `gemini-3-pro-preview`           |
+| Anthropic | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-8`, `claude-opus-5` |
+| OpenAI    | `gpt-4o-mini`, `gpt-5` family (5, 5.1–5.6)                 |
+| Google    | `gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.5-flash`, `gemini-3.6-flash`, `gemini-3.7-flash` |
 | DeepSeek   | `deepseek-v4-flash`, `deepseek-v4-pro`                     |
 | Xiaomi     | `mimo-v2.5-pro`, `mimo-v2.5`                               |
-| OpenRouter | `glm-5.2-max`, `glm-5.2-high`                              |
+| OpenRouter | `z-ai/glm-5.2`, `z-ai/glm-5.3`, `z-ai/glm-5.3-flash`, `qwen/qwen3.8-max`, `qwen/qwen3.8-27b`, `qwen/qwen3.8-2.4t-a95b` |
 | Meta       | `muse-spark-1.2`                                           |
+
+The canonical list lives in the hosted model whitelist (`catalog/whitelist.yaml`, served from the CDN), which also declares each model's selectable **reasoning effort** levels and default.
 
 ### Workspace default model
 

--- a/docs/content/agents/index.mdx
+++ b/docs/content/agents/index.mdx
@@ -54,7 +54,7 @@ You can pick a different LLM per thread. A model appears in the selector when it
 | Provider  | Models                                                     |
 | --------- | ---------------------------------------------------------- |
 | Anthropic | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-8`, `claude-opus-5` |
-| OpenAI    | `gpt-4o-mini`, `gpt-5` family (5, 5.1–5.6)                 |
+| OpenAI    | `gpt-4o-mini`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra` |
 | Google    | `gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.5-flash`, `gemini-3.6-flash`, `gemini-3.7-flash` |
 | DeepSeek   | `deepseek-v4-flash`, `deepseek-v4-pro`                     |
 | Xiaomi     | `mimo-v2.5-pro`, `mimo-v2.5`                               |

--- a/docs/content/deploy/environment-variables.mdx
+++ b/docs/content/deploy/environment-variables.mdx
@@ -30,12 +30,12 @@ At least one provider must be configured. That means a provider key — except f
 
 | Provider  | Environment variable | Models                                                     |
 | --------- | -------------------- | ---------------------------------------------------------- |
-| Anthropic | `ANTHROPIC_API_KEY`  | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-sonnet-5` |
-| OpenAI    | `OPENAI_API_KEY`     | `gpt-4o-mini`                                              |
-| Google    | `GOOGLE_API_KEY`     | `gemini-3-flash-preview`, `gemini-3-pro-preview`           |
+| Anthropic | `ANTHROPIC_API_KEY`  | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-8`, `claude-opus-5` |
+| OpenAI    | `OPENAI_API_KEY`     | `gpt-4o-mini`, `gpt-5` family (5, 5.1–5.6)                 |
+| Google    | `GOOGLE_API_KEY`     | `gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.5-flash`, `gemini-3.6-flash`, `gemini-3.7-flash` |
 | DeepSeek  | `DEEPSEEK_API_KEY`   | `deepseek-v4-flash`, `deepseek-v4-pro`                     |
 | Xiaomi    | `XIAOMI_API_KEY`     | `mimo-v2.5-pro`, `mimo-v2.5`                               |
-| OpenRouter | `OPENROUTER_API_KEY` | `z-ai/glm-5.2` |
+| OpenRouter | `OPENROUTER_API_KEY` | `z-ai/glm-5.2`, `z-ai/glm-5.3`, `z-ai/glm-5.3-flash`, `qwen/qwen3.8-max`, `qwen/qwen3.8-27b`, `qwen/qwen3.8-2.4t-a95b` |
 | Meta      | `METAAI_API_KEY`     | `muse-spark-1.2`                                           |
 
 Anthropic models run with thinking enabled by default; Google models run with `include_thoughts=True`. Defaults live in `app/model_providers/catalog.py`.

--- a/docs/content/deploy/environment-variables.mdx
+++ b/docs/content/deploy/environment-variables.mdx
@@ -31,7 +31,7 @@ At least one provider must be configured. That means a provider key — except f
 | Provider  | Environment variable | Models                                                     |
 | --------- | -------------------- | ---------------------------------------------------------- |
 | Anthropic | `ANTHROPIC_API_KEY`  | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-8`, `claude-opus-5` |
-| OpenAI    | `OPENAI_API_KEY`     | `gpt-4o-mini`, `gpt-5` family (5, 5.1–5.6)                 |
+| OpenAI    | `OPENAI_API_KEY`     | `gpt-4o-mini`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra` |
 | Google    | `GOOGLE_API_KEY`     | `gemini-3-flash-preview`, `gemini-3-pro-preview`, `gemini-3.5-flash`, `gemini-3.6-flash`, `gemini-3.7-flash` |
 | DeepSeek  | `DEEPSEEK_API_KEY`   | `deepseek-v4-flash`, `deepseek-v4-pro`                     |
 | Xiaomi    | `XIAOMI_API_KEY`     | `mimo-v2.5-pro`, `mimo-v2.5`                               |

--- a/docs/content/deploy/environment-variables.mdx
+++ b/docs/content/deploy/environment-variables.mdx
@@ -35,7 +35,7 @@ At least one provider must be configured. That means a provider key — except f
 | Google    | `GOOGLE_API_KEY`     | `gemini-3-flash-preview`, `gemini-3-pro-preview`           |
 | DeepSeek  | `DEEPSEEK_API_KEY`   | `deepseek-v4-flash`, `deepseek-v4-pro`                     |
 | Xiaomi    | `XIAOMI_API_KEY`     | `mimo-v2.5-pro`, `mimo-v2.5`                               |
-| OpenRouter | `OPENROUTER_API_KEY` | `glm-5.2-max`, `glm-5.2-high` |
+| OpenRouter | `OPENROUTER_API_KEY` | `z-ai/glm-5.2` |
 | Meta      | `METAAI_API_KEY`     | `muse-spark-1.2`                                           |
 
 Anthropic models run with thinking enabled by default; Google models run with `include_thoughts=True`. Defaults live in `app/model_providers/catalog.py`.

--- a/reasoning-effort-assessment.md
+++ b/reasoning-effort-assessment.md
@@ -1,0 +1,199 @@
+# Reasoning effort: cross-provider assessment & catalog design
+
+*Assessed 2026-08-26. Question: can "reasoning effort" become a user-settable,
+catalog-declared setting instead of being hardcoded per model (GLM 5.2
+max/high pseudo-models, DeepSeek `thinking: enabled`)?*
+
+## TL;DR
+
+- **The knob is converging, the values are not.** Every current-gen provider now
+  exposes reasoning control as an **effort enum** (token budgets are legacy:
+  rejected on Claude 4.7+, deprecated on Gemini 3, never existed on
+  OpenAI/DeepSeek/GLM/xAI). The de-facto superset ladder is
+  `none < minimal < low < medium < high < xhigh < max` — but **no two providers
+  accept the same subset**, defaults differ, and "off" doesn't exist on some
+  models (Gemini 3, GLM-5.3, grok-4+, Claude Fable/Mythos 5).
+- **LangChain 1.x has already standardized the parameter name**: `ChatOpenAI`,
+  `ChatAnthropic` (alias `effort` → `output_config.effort`) and
+  `ChatGoogleGenerativeAI` (alias `thinking_level`) all accept
+  **`reasoning_effort`** as an init/call param. DeepSeek/GLM/xAI still need
+  `extra_body`.
+- **LangChain also ships the catalog data we need**: `model.profile` returns
+  `reasoning_effort_levels` + `reasoning_effort_default` per model (verified
+  locally on langchain-anthropic 1.6.1 / -openai 1.6.0 / -google-genai 4.3.5).
+  It covers first-party models only — `None` for GLM via OpenRouter — so our
+  whitelist must carry the levels at least for gateway models.
+- **Recommendation**: add `reasoning_effort_levels` + `reasoning_effort_default`
+  to the whitelist entry (same names as LangChain profiles), store the user's
+  choice per thread next to `model_id`, and translate the canonical enum inside
+  `ChatModelFactory`. This collapses `glm-5.2-max`/`glm-5.2-high` into one
+  model and unhardcodes DeepSeek.
+
+## Current state in auxilia
+
+| Where | What's hardcoded |
+| --- | --- |
+| `backend/app/model_providers/catalog.py` `OPENROUTER_MODELS` | GLM effort baked into the *model id*: `glm-5.2-max` / `glm-5.2-high` → `extra_body={"reasoning_effort": ...}` |
+| `ChatModelFactory` deepseek branch | `extra_body={"thinking": {"type": "enabled"}}`, always on |
+| `ChatModelFactory` anthropic branch | adaptive models: `effort="medium"` fixed; legacy models: `budget_tokens=1024` fixed |
+| `ChatModelFactory` google branch | `thinking_budget=-1` (dynamic) fixed |
+| `ChatModelFactory` openai branch | nothing sent → provider default effort |
+| `whitelist.yaml` | no reasoning metadata at all |
+
+Flow today: `thread.model_id` → `ModelService.ensure_available` →
+`ChatModelFactory.create(provider, model_id, api_key)`. There is no per-thread
+or per-agent knob; effort is a side effect of which model you picked.
+
+## Provider comparison (August 2026)
+
+| Provider | Native param | Values (current models) | Default | Off? | LangChain exposure |
+| --- | --- | --- | --- | --- | --- |
+| OpenAI | `reasoning_effort` (chat) / `reasoning.effort` (Responses) | gpt-5.1/5.2: `none,low,medium,high(,xhigh)`; gpt-5.6: adds `max` (Responses-only) | 5.1/5.2: `none`; 5.5/5.6: `medium` | yes (`none`) | `ChatOpenAI(reasoning_effort=...)`, first-class |
+| Anthropic | `output_config.effort` (+ `thinking: {type: adaptive}`) | `low,medium,high,xhigh,max` (xhigh: 4.7+/5-family) | `high` | 5-family Fable/Mythos: no; Sonnet 5/Opus 5: `type: disabled` ≤ high | `ChatAnthropic(reasoning_effort=...)` (alias `effort`), first-class; `budget_tokens` **400s on 4.7+** |
+| Google | `thinkingConfig.thinkingLevel` (Gemini 3+) | `minimal,low,medium,high` — per-model subsets (3-pro-preview: `low,high` only) | model-specific (`high` for 3-pro) | **no** — thinking can't be disabled on Gemini 3.x | `ChatGoogleGenerativeAI(reasoning_effort=...)` (alias `thinking_level`); `thinking_budget` deprecated for 3+ |
+| DeepSeek V4 | `thinking: {type}` + `reasoning_effort` | `low,high,max` (`medium`/`xhigh` silently coerced to `high`) | thinking on, effort `high` | yes (`thinking: disabled`) | `extra_body` only (`ChatDeepSeek` subclasses BaseChatOpenAI so `reasoning_effort` passes through) |
+| Z.ai GLM 5.2 | `reasoning_effort` (top-level) + `thinking: {type}` | effective tiers: off / `high` / `max` (others coerced) | `max` | 5.2: yes; **5.3: no** (disabled → effort `low`) | via `ChatOpenAI` + `extra_body` (what we do through OpenRouter) |
+| xAI Grok | `reasoning_effort` | 4.6: `low,medium,high,xhigh`; grok-4/4.1 **reject the param** (400) | `high` | no on grok-4-class | `extra_body` only |
+| OpenRouter (gateway) | unified `reasoning: {effort \| max_tokens \| enabled, exclude}` | `none…max` superset, normalized per upstream (effort→Anthropic budget by % of max_tokens; xhigh→high for Gemini) | — | per upstream | `extra_body` |
+
+Key hazards the design must absorb:
+
+- **Silent coercion vs hard 400**: DeepSeek/GLM coerce unsupported values;
+  Anthropic legacy format and grok-4 hard-fail. Never send a value the model
+  wasn't declared to support.
+- **"Off" is not universal**: UIs need per-model knowledge of whether `none`
+  exists, else "off" must degrade to lowest effort (LiteLLM/GLM-5.3 behavior).
+- **OpenAI gpt-5.6 + tools**: chat completions rejects function tools with any
+  effort ≠ `none` — already handled by `OPENAI_RESPONSES_API_MODELS`.
+
+## How other platforms model it
+
+- **LibreChat** — per-provider param panels, no translation layer. OpenAI-style
+  endpoints get a `reasoning_effort` dropdown over the full superset
+  (`none…max`, default unset); Anthropic gets a `thinking` toggle +
+  `thinkingBudget` slider (adaptive handling bolted on later for Opus 4.6+);
+  Google gets `thinking`/`thinkingBudget`/`thinkingLevel`. Presets in
+  `librechat.yaml` (`modelSpecs.list[].preset`) can pin any of these; custom
+  endpoints choose a wire format via `customParams.reasoningFormat`
+  (`reasoning_effort` flat vs OpenRouter-style object). *Weakness: the dropdown
+  is the same superset for every model — users can pick values the model
+  rejects.*
+- **Open WebUI** — a free-text `reasoning_effort` string in per-model advanced
+  params, passed through verbatim; broken on Ollama (which wants `think=`).
+  The anti-pattern: untyped passthrough, no per-model validation.
+- **LiteLLM** — the best translation prior art: unified `reasoning_effort`
+  (`none…max` + `disable`), mapped per provider — verbatim for
+  OpenAI/xAI/DeepSeek, → `output_config.effort` for Claude 4.6+, →
+  `budget_tokens` for legacy Claude (low=1024, medium=2048, high=4096,
+  xhigh=8192, max=16384), → `thinking_level` for Gemini 3 (with
+  none/disable degrading to minimal since it can't turn off).
+- **Vercel AI SDK 7** — unified top-level `reasoning` enum with a clean
+  precedence rule: any provider-specific reasoning option makes the unified
+  param ignored entirely, never merged.
+- **OpenRouter** — unified `reasoning.effort`/`max_tokens` (mutually
+  exclusive), normalizing effort→budget by percentage of `max_tokens` for
+  budget-native upstreams.
+
+Conclusion: **canonical enum + per-model declared subset + per-provider
+translation** (LiteLLM's model, constrained LibreChat-style UI) is the design
+everyone converged on. Nobody serious does raw passthrough (Open WebUI) and
+nobody needs budget sliders anymore except for legacy Anthropic/Gemini models.
+
+## Verified locally: LangChain profiles already carry the catalog data
+
+```python
+ChatAnthropic(model="claude-opus-4-8").profile
+# reasoning_effort_levels: [low, medium, high, xhigh, max], default: high
+ChatOpenAI(model="gpt-5.6-luna").profile
+# reasoning_effort_levels: [none, low, medium, high, xhigh, max], default: medium
+ChatGoogleGenerativeAI(model="gemini-3-pro-preview").profile
+# reasoning_effort_levels: [low, high], default: high
+ChatDeepSeek(model="deepseek-v4-pro").profile
+# reasoning_output: True — no levels (package data lags the V4 API, which
+# accepts low/high/max per api-docs.deepseek.com/guides/thinking_mode/)
+ChatOpenAI(model="z-ai/glm-5.2", base_url=openrouter).profile
+# None — gateway models have no profile
+```
+
+So profiles are a good *validation/backfill* source but can't be the source of
+truth: they miss gateway models and lag provider API changes. The whitelist
+(already CDN-hosted, hand-editable, release-free) is the right owner.
+
+## Recommended design
+
+### 1. Whitelist schema (catalog)
+
+Add to `SupportedModel` / `whitelist.yaml`, reusing LangChain's profile names:
+
+```yaml
+- provider: openrouter
+  model_id: glm-5.2
+  display_name: GLM 5.2
+  reasoning_effort_levels: [high, max]   # omitted/empty = no reasoning knob
+  reasoning_effort_default: max
+```
+
+- Values drawn from the canonical ladder
+  `none, minimal, low, medium, high, xhigh, max` (validate against a
+  `Literal`). `none` in the list ⇔ thinking can be disabled — no separate
+  boolean needed.
+- Entries without levels render no effort picker (gpt-4o-mini, MiMo, Muse).
+- Optional validator: when a LangChain profile exists for the model, warn/fail
+  if the whitelist declares a level the profile doesn't (catches typos; profile
+  absence or mismatch in the lenient direction is fine since profiles lag).
+
+### 2. Where the user sets it
+
+Per **thread**, next to the model picker (a small effort selector shown only
+when the selected model declares levels), stored as a nullable
+`reasoning_effort` column beside `thread.model_id`; `NULL` = catalog default.
+Triggers get the same optional field. Per-agent defaults can come later —
+per-thread matches how `model_id` already flows and is what
+LibreChat/Claude/ChatGPT UIs train users to expect.
+
+Validation belongs where `ModelUnavailableError` lives: `RunService.create`
+checks the requested effort against the whitelist entry's levels (400 on
+mismatch — never forward and rely on provider coercion, since some providers
+silently coerce and others 400).
+
+### 3. Translation in `ChatModelFactory`
+
+`create(provider, model_id, api_key, reasoning_effort: str | None)`:
+
+| Provider | Mapping |
+| --- | --- |
+| openai | `reasoning_effort=<value>` (first-class param; Responses API routing already handled) |
+| anthropic | adaptive models: `reasoning_effort=<value>` (replaces hardcoded `effort="medium"`); legacy models: keep `budget_tokens`, LiteLLM table if we ever expose levels there |
+| google | `reasoning_effort=<value>` (alias of `thinking_level`) for Gemini 3+; keep `thinking_budget=-1` when no effort chosen |
+| deepseek | `extra_body={"thinking": {"type": "disabled" if value == "none" else "enabled"}, ...}` + `reasoning_effort` for low/high/max |
+| openrouter (GLM) | `extra_body={"reasoning_effort": <value>}` — and **delete the `glm-5.2-max`/`glm-5.2-high` split**: one `glm-5.2` model, levels `[high, max]`, default `max`. `OPENROUTER_MODELS` becomes id → slug only. |
+
+Precedence rule (from AI SDK 7): a model with no declared levels never gets a
+reasoning param sent — no merging, no best-effort guesses.
+
+### 4. Migration notes
+
+- Collapsing the GLM pseudo-models changes `model_id`s stored on threads and in
+  the `models` enablement table — needs a data migration (`glm-5.2-*` →
+  `glm-5.2` + effort) or keeping the old ids as aliases during a deprecation
+  window. The whitelist is CDN-served, so ship the backend translation first,
+  then flip the YAML.
+- DeepSeek default stays "thinking on, effort high" (their API default), so
+  no behavior change for existing threads with `NULL` effort.
+- `reasoning_effort` should flow into Langfuse metadata for cost monitoring —
+  effort is the dominant cost lever on these models.
+
+## Sources
+
+- OpenAI: developers.openai.com/api/docs/guides/reasoning
+- Anthropic: platform.claude.com/docs/en/build-with-claude/effort, …/extended-thinking
+- Google: ai.google.dev/gemini-api/docs/thinking, …/gemini-3
+- DeepSeek: api-docs.deepseek.com/guides/thinking_mode/
+- Z.ai: docs.z.ai/guides/capabilities/thinking-mode
+- xAI: docs.x.ai/developers/model-capabilities/text/reasoning
+- OpenRouter: openrouter.ai/docs/use-cases/reasoning-tokens
+- LibreChat: librechat.ai/docs/configuration/librechat_yaml/object_structure/model_specs
+- Open WebUI: docs.openwebui.com/features/chat-conversations/chat-features/reasoning-models/ (+ issue #20921)
+- LiteLLM: docs.litellm.ai/docs/reasoning_content
+- Vercel AI SDK: ai-sdk.dev/docs/ai-sdk-core/reasoning
+- LangChain profiles: verified locally against installed langchain-anthropic 1.6.1, langchain-openai 1.6.0, langchain-google-genai 4.3.5, langchain-deepseek 1.1.0

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -435,6 +435,9 @@ const ChatPage = () => {
   const threadId = params.threadId as string;
   const hasInitialized = useRef(false);
   const [threadModel, setThreadModel] = useState<string | undefined>(undefined);
+  // The thread's pinned reasoning-effort choice (null = model default) —
+  // displayed read-only next to the pinned model.
+  const [threadEffort, setThreadEffort] = useState<string | null>(null);
   const [agentArchived, setAgentArchived] = useState(false);
   // Server-computed on GET /threads/{id}: the thread's pinned model is no
   // longer usable (removed from the catalog, provider key gone, or disabled
@@ -791,6 +794,7 @@ const ChatPage = () => {
       const data = response.data;
 
       setThreadModel(data.thread.modelId);
+      setThreadEffort(data.thread.reasoningEffort ?? null);
       if (data.thread.modelAvailable === false) {
         setModelUnavailable(true);
       }
@@ -1464,6 +1468,7 @@ const ChatPage = () => {
             stop={handleStop}
             selectedModel={threadModel}
             readOnlyModel={true}
+            selectedEffort={threadEffort}
             agentReady={agentReady}
             disconnectedServers={disconnectedMcpServers}
             onAllConnected={refetchReady}

--- a/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
@@ -15,8 +15,9 @@ import {
 	PromptInputTools,
 	usePromptInputController,
 } from "@/components/ai-elements/prompt-input";
-import { CheckIcon, PlugIcon } from "lucide-react";
+import { BrainIcon, CheckIcon, PlugIcon } from "lucide-react";
 import { useRef, useState, useEffect, useMemo } from "react";
+import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { useModelsStore } from "@/stores/models-store";
 import { useChatHeaderStore } from "@/stores/chat-header-store";
 import { Model } from "@/types/models";
@@ -55,10 +56,28 @@ interface ChatPromptInputProps {
 	onModelChange?: (modelId: string) => void;
 	selectedModel?: string;
 	readOnlyModel?: boolean;
+	// Reasoning-effort choice for the selected model; null = the model's
+	// default. Pinned with the model on existing threads (readOnlyModel).
+	selectedEffort?: string | null;
+	onEffortChange?: (effort: string | null) => void;
 	agentReady?: boolean | null;
 	disconnectedServers?: MCPServer[];
 	onAllConnected?: () => void;
 }
+
+// Human labels for the canonical effort ladder ("none" reads as Off — it
+// turns the model's thinking off entirely).
+const EFFORT_LABELS: Record<string, string> = {
+	none: "Off",
+	minimal: "Minimal",
+	low: "Low",
+	medium: "Medium",
+	high: "High",
+	xhigh: "Extra high",
+	max: "Max",
+};
+
+const effortLabel = (effort: string) => EFFORT_LABELS[effort] ?? effort;
 
 const ChatPromptInput = ({
 	onSubmit,
@@ -68,6 +87,8 @@ const ChatPromptInput = ({
 	onModelChange,
 	selectedModel: externalSelectedModel,
 	readOnlyModel = false,
+	selectedEffort = null,
+	onEffortChange,
 	agentReady,
 	disconnectedServers = [],
 	onAllConnected,
@@ -83,10 +104,21 @@ const ChatPromptInput = ({
 
 	const currentModel = externalSelectedModel ?? model;
 	const selectedModelData = models.find((m) => m.id === currentModel);
-	// Text-only providers can't take image attachments (DeepSeek, Z.ai/GLM 5.2).
-	const noAttachments = ["deepseek", "z-ai"].includes(
-		selectedModelData?.chefSlug ?? "",
-	);
+	const effortLevels = selectedModelData?.reasoningEffortLevels ?? [];
+	const effortDefault = selectedModelData?.reasoningEffortDefault ?? null;
+	// Pill label: the explicit choice, else the model's declared default
+	// level, else Auto (provider-managed/dynamic).
+	const effortPillLabel = selectedEffort
+		? effortLabel(selectedEffort)
+		: effortDefault
+			? effortLabel(effortDefault)
+			: "Auto";
+	// Text-only models can't take image attachments. Per model, not per chef:
+	// e.g. GLM 5.3 Flash accepts images while plain GLM 5.3 does not. Unknown
+	// model (not in the picker list, e.g. a disabled pinned model) → allow,
+	// matching the old lookup-miss behavior.
+	const noAttachments =
+		selectedModelData !== undefined && !selectedModelData.multimodal;
 
 	const handleModelChange = (modelId: string) => {
 		setModel(modelId);
@@ -304,6 +336,49 @@ const ChatPromptInput = ({
 								</DialogContent>
 							</Dialog>
 						)}
+						{readOnlyModel
+							? // Existing threads pin the effort with the model — show it
+								// only when one was explicitly chosen.
+								selectedEffort && (
+									<PromptInputButton disabled className={composerPillClass}>
+										<BrainIcon className="size-3.5" />
+										<span className="truncate text-left">
+											{effortLabel(selectedEffort)}
+										</span>
+									</PromptInputButton>
+								)
+							: effortLevels.length > 0 && (
+									<DropdownMenu
+										align="start"
+										side="top"
+										items={[
+											{
+												label: effortDefault
+													? `Default (${effortLabel(effortDefault)})`
+													: "Auto",
+												active: !selectedEffort,
+												onClick: () => {
+													onEffortChange?.(null);
+												},
+											},
+											...effortLevels.map((level) => ({
+												label: effortLabel(level),
+												active: selectedEffort === level,
+												onClick: () => {
+													onEffortChange?.(level);
+												},
+											})),
+										]}
+										trigger={
+											<PromptInputButton className={composerPillClass}>
+												<BrainIcon className="size-3.5" />
+												<span className="truncate text-left">
+													{effortPillLabel}
+												</span>
+											</PromptInputButton>
+										}
+									/>
+								)}
 					</PromptInputTools>
 					{agentReady === false ? (
 						<ConnectButton

--- a/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
@@ -67,17 +67,17 @@ interface ChatPromptInputProps {
 
 // Human labels for the canonical effort ladder ("none" reads as Off — it
 // turns the model's thinking off entirely).
-const EFFORT_LABELS: Record<string, string> = {
-	none: "Off",
-	minimal: "Minimal",
-	low: "Low",
-	medium: "Medium",
-	high: "High",
-	xhigh: "Extra high",
-	max: "Max",
-};
+const EFFORT_LABELS = new Map<string, string>([
+	["none", "Off"],
+	["minimal", "Minimal"],
+	["low", "Low"],
+	["medium", "Medium"],
+	["high", "High"],
+	["xhigh", "Extra high"],
+	["max", "Max"],
+]);
 
-const effortLabel = (effort: string) => EFFORT_LABELS[effort] ?? effort;
+const effortLabel = (effort: string) => EFFORT_LABELS.get(effort) ?? effort;
 
 const ChatPromptInput = ({
 	onSubmit,

--- a/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
@@ -106,10 +106,19 @@ const ChatPromptInput = ({
 	const selectedModelData = models.find((m) => m.id === currentModel);
 	const effortLevels = selectedModelData?.reasoningEffortLevels ?? [];
 	const effortDefault = selectedModelData?.reasoningEffortDefault ?? null;
+	// A stored effort the catalog no longer declares is clamped to the model
+	// default at run time — don't display it as if it were in effect. When the
+	// model itself is unknown (e.g. disabled, absent from the picker list) the
+	// levels can't be checked, so trust the stored value.
+	const validatedEffort =
+		selectedEffort &&
+		(selectedModelData === undefined || effortLevels.includes(selectedEffort))
+			? selectedEffort
+			: null;
 	// Pill label: the explicit choice, else the model's declared default
 	// level, else Auto (provider-managed/dynamic).
-	const effortPillLabel = selectedEffort
-		? effortLabel(selectedEffort)
+	const effortPillLabel = validatedEffort
+		? effortLabel(validatedEffort)
 		: effortDefault
 			? effortLabel(effortDefault)
 			: "Auto";
@@ -338,12 +347,12 @@ const ChatPromptInput = ({
 						)}
 						{readOnlyModel
 							? // Existing threads pin the effort with the model — show it
-								// only when one was explicitly chosen.
-								selectedEffort && (
+								// only when one was explicitly chosen (and still declared).
+								validatedEffort && (
 									<PromptInputButton disabled className={composerPillClass}>
 										<BrainIcon className="size-3.5" />
 										<span className="truncate text-left">
-											{effortLabel(selectedEffort)}
+											{effortLabel(validatedEffort)}
 										</span>
 									</PromptInputButton>
 								)
@@ -356,14 +365,14 @@ const ChatPromptInput = ({
 												label: effortDefault
 													? `Default (${effortLabel(effortDefault)})`
 													: "Auto",
-												active: !selectedEffort,
+												active: !validatedEffort,
 												onClick: () => {
 													onEffortChange?.(null);
 												},
 											},
 											...effortLevels.map((level) => ({
 												label: effortLabel(level),
-												active: selectedEffort === level,
+												active: validatedEffort === level,
 												onClick: () => {
 													onEffortChange?.(level);
 												},

--- a/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/components/prompt-input.tsx
@@ -129,6 +129,21 @@ const ChatPromptInput = ({
 	const noAttachments =
 		selectedModelData !== undefined && !selectedModelData.multimodal;
 
+	// Editable composer only: normalize a stale selection in the parent state
+	// too (not just the display), so what's shown as Default/Auto is also what
+	// gets submitted. Read-only threads keep their pinned value — the backend
+	// clamps it at run time.
+	useEffect(() => {
+		if (
+			!readOnlyModel &&
+			selectedEffort &&
+			selectedModelData !== undefined &&
+			!selectedModelData.reasoningEffortLevels.includes(selectedEffort)
+		) {
+			onEffortChange?.(null);
+		}
+	}, [readOnlyModel, selectedEffort, selectedModelData, onEffortChange]);
+
 	const handleModelChange = (modelId: string) => {
 		setModel(modelId);
 		onModelChange?.(modelId);

--- a/web/src/app/(protected)/agents/[id]/chat/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/page.tsx
@@ -28,6 +28,9 @@ const StarterChatPage = () => {
 	const { modelSelection, starterAgent } = usePromptInputController();
 	const selectedModel = modelSelection.value;
 	const setSelectedModel = modelSelection.setModel;
+	// Reasoning-effort choice for the selected model; null = the model's
+	// default. Pinned onto the thread at creation, like the model.
+	const [reasoningEffort, setReasoningEffort] = useState<string | null>(null);
 	const addThread = useThreadsStore((state) => state.addThread);
 	const setPendingMessage = usePendingMessageStore(
 		(state) => state.setPendingMessage,
@@ -76,6 +79,7 @@ const StarterChatPage = () => {
 				id: threadId,
 				agentId: agentId,
 				modelId,
+				reasoningEffort,
 				firstMessageContent: textContent,
 			});
 
@@ -170,7 +174,14 @@ const StarterChatPage = () => {
 							status={isCreating ? "streaming" : "ready"}
 							className="w-full"
 							selectedModel={selectedModel}
-							onModelChange={setSelectedModel}
+							onModelChange={(modelId) => {
+								setSelectedModel(modelId);
+								// Levels differ per model — a carried-over choice could be
+								// one the new model rejects.
+								setReasoningEffort(null);
+							}}
+							selectedEffort={reasoningEffort}
+							onEffortChange={setReasoningEffort}
 							agentReady={agentReady}
 							disconnectedServers={disconnectedMcpServers}
 							onAllConnected={refetchReady}

--- a/web/src/types/models.ts
+++ b/web/src/types/models.ts
@@ -7,6 +7,14 @@ export interface Model {
 	// The effective workspace default (admin-flagged model when available,
 	// else the first available one) — pickers preselect this row.
 	isDefault: boolean;
+	// Whether the model accepts non-text input — gates composer attachments
+	// per model (not per chef: GLM 5.3 Flash takes images, plain 5.3 doesn't).
+	multimodal: boolean;
+	// Reasoning-effort values the user may pick for this model (empty = no
+	// effort knob, render no picker) and the level in effect when they pick
+	// nothing (null = provider-managed/dynamic, shown as Auto).
+	reasoningEffortLevels: string[];
+	reasoningEffortDefault: string | null;
 }
 
 // One row of the admin Settings view (GET /model-providers/models/manage):


### PR DESCRIPTION
## What

Reasoning effort becomes a **whitelist-declared, user-settable option** instead of being hardcoded into model definitions. Design rationale in `reasoning-effort-assessment.md` (industry comparison: providers converged on an effort enum; token budgets are legacy).

### Catalog
- Whitelist entries declare `reasoning_effort_levels` (per-model subset of the canonical ladder `none < minimal < low < medium < high < xhigh < max`) and `reasoning_effort_default`.
- The default is **applied**: threads with no explicit choice resolve to it, so editing the CDN file changes what "unset" means workspace-wide — explicit choices are never overridden. Declared defaults were chosen to be behavior-neutral (Claude adaptive `medium`, DeepSeek `high`, GLM `max`, gpt-5.5/5.6 `medium`).

### Flow
- `ThreadCreate`/`TriggerCreate` accept `reasoning_effort`, strictly validated against the model's levels (400 on undeclared values — some providers coerce silently, others hard-400, so we never forward blind).
- At run time `ensure_available` **clamps** a stale stored level instead of failing, so a catalog edit can never strand an existing thread.
- `ChatModelFactory` translates the canonical value per provider: OpenAI `reasoning_effort`, Anthropic adaptive `effort` (an explicit level also opts Sonnet 4.6 into adaptive), Gemini `thinking_level` (XOR with the dynamic budget), DeepSeek `thinking` + `reasoning_effort` (`none` = thinking off), OpenRouter `extra_body`.
- `NULL` reproduces the previous behavior exactly on every branch — existing threads run unchanged.

### OpenRouter mapping removed
`OPENROUTER_MODELS` is gone: an openrouter `model_id` is the OpenRouter slug sent verbatim, like any other provider. The `glm-5.2-max`/`glm-5.2-high` pseudo-models collapse into one `z-ai/glm-5.2` (levels `[high, max]`, default `max`). Migration `a1d4c9e72b58` adds the two nullable columns and rewrites thread/trigger/enablement rows (merging the two GLM enablement rows).

### Web
- Effort pill next to the model picker (shown only when the model declares levels; resets on model change; read-only pinned display on existing threads).
- Attachment gating now uses the model's `multimodal` flag instead of the chef slug — required because GLM 5.3 Flash takes images while plain GLM 5.3 doesn't, under the same chef.

### New models (capabilities verified live where possible)
| Model | Levels (default) | Notes |
| --- | --- | --- |
| `gemini-3.6-flash` | minimal/low/medium/high (medium) | levels + function calling probed live |
| `gemini-3.7-flash` | low/medium/high (medium) | rejects `minimal` (probed live); no 3.6/3.7 Pro exists |
| `claude-opus-5` | low→max (medium) | added to `ADAPTIVE_THINKING_MODELS`; verified live on the adaptive path |
| `z-ai/glm-5.3` / `-flash` | low/high/max (max) | thinking forced; SO false (host-dependent guided decoding) |
| `qwen/qwen3.8-max` / `-27b` / `-2.4t-a95b` | low/xhigh (xhigh) | Qwen's `medium` is a documented no-op → not declared; no 3.8 "flash" exists |

## Deploy notes
- **Upload the updated `catalog/whitelist.yaml` to R2** (the `MODEL_WHITELIST_URL` default) and sync — until then the old CDN list is served and migrated GLM threads 409.
- New models start disabled (enablement is opt-in per workspace admin).
- No `qwen.png` icon on the CDN yet — Qwen rows show a broken logo until one is uploaded.

## Tests
- 663 backend tests pass (the one pre-existing failure, `test_publishable_copy_matches_bundled_snapshot`, is the unrelated uncommitted Slides entry in `catalog/catalog.yaml`).
- New coverage: whitelist effort validation, `ensure_available` clamp + applied default, per-provider factory translation, picker payload shape.
- Verified live: Gemini level acceptance & function calling, Opus 5 on the adaptive factory path, migration against the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reasoning effort is now a user-settable, whitelist-declared option per model instead of being hardcoded. Threads and triggers can pin an effort level; unset resolves to the model's catalog default and NULL keeps the previous provider behavior.

**Refactors**
- Whitelist entries now declare `reasoning_effort_levels` and an applied default; editing the CDN file changes what unset means workspace-wide without overriding explicit choices.
- The CDN `catalog/whitelist.yaml` and bundled snapshot are pinned byte-identical by a new test, both setting the DeepSeek default to `low`.
- `ChatModelFactory` translates the canonical effort per provider (OpenAI `reasoning_effort`, Anthropic adaptive `effort`, Gemini `thinking_level`, DeepSeek `thinking` + `reasoning_effort`, OpenRouter `extra_body`).
- `OPENROUTER_MODELS` is gone: OpenRouter `model_id` is the slug sent verbatim, and the `glm-5.2-max`/`glm-5.2-high` pseudo-models collapse into `z-ai/glm-5.2` (levels high/max, default max).
- Stored efforts are clamped, never fatal, at run time; re-pointing a trigger's model clears an effort the new model no longer declares instead of rejecting the edit.
- The composer gains an effort pill (shown only for models declaring levels, resets on model change, and clamps a stale stored effort to Default/Auto in both display and editable state); attachment gating now uses the model's `multimodal` flag.
- New models: Gemini 3.6/3.7 Flash, Claude Opus 5, GLM 5.3/5.3 Flash, Qwen3.8 Max/27B/2.4T, DeepSeek V4 Flash Vision Exp.

**Migration**
- Run migration `a1d4c9e72b58` (adds `reasoning_effort` to threads/triggers, rewrites GLM rows, merges enablement rows).
- Upload the updated `catalog/whitelist.yaml` to R2 (`MODEL_WHITELIST_URL` default) and sync, or migrated GLM threads 409.
- New models start disabled.

<sup>Written for commit 4822dc40d59fd46f3fdce3d5773b9cc9e214e014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

