### PR TITLE
fix: render user profile pictures everywhere a person is shown

### DIFF
--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -118,7 +118,12 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                     else None
                 ),
                 owner=(
-                    AgentOwnerInfo(id=owner.id, name=owner.name, email=owner.email)
+                    AgentOwnerInfo(
+                        id=owner.id,
+                        name=owner.name,
+                        email=owner.email,
+                        picture_url=owner.picture_url,
+                    )
                     if (owner := owners_by_id.get(agent.owner_id)) is not None
                     else None
                 ),

--- a/backend/app/agents/schemas.py
+++ b/backend/app/agents/schemas.py
@@ -177,6 +177,7 @@ class AgentOwnerInfo(SQLModel):
     id: UUID
     name: str | None = None
     email: str | None = None
+    picture_url: str | None = None
 
 
 class AgentListResponse(SQLModel):

--- a/backend/app/mcp/servers/schemas.py
+++ b/backend/app/mcp/servers/schemas.py
@@ -101,6 +101,7 @@ class MCPServerConnectionResponse(SQLModel):
     user_id: UUID
     name: str | None = None
     email: str | None = None
+    picture_url: str | None = None
     status: Literal["active", "expired"] = "active"
 
 

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -240,6 +240,7 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
                     user_id=user_id,
                     name=user.name if user else None,
                     email=user.email if user else None,
+                    picture_url=user.picture_url if user else None,
                     status="expired" if expired else "active",
                 )
             )

--- a/web/src/app/(protected)/agents/components/agent-permissions-panel.tsx
+++ b/web/src/app/(protected)/agents/components/agent-permissions-panel.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { SearchBar } from "@/components/ui/search-bar";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { UnderlineTabs } from "@/components/ui/underline-tabs";
+import { UserAvatar } from "@/components/ui/user-avatar";
 
 type PermissionLevel = "member" | "editor" | "admin";
 
@@ -14,6 +15,7 @@ interface User {
 	id: string;
 	name: string | null;
 	email: string | null;
+	pictureUrl: string | null;
 }
 
 interface Team {
@@ -37,16 +39,6 @@ const PERMISSION_LABELS: Record<PermissionLevel, string> = {
 	editor: "Editor",
 	member: "Member",
 };
-
-function getInitials(name: string | null): string {
-	if (!name) return "?";
-	return name
-		.split(" ")
-		.map((w) => w[0])
-		.join("")
-		.slice(0, 2)
-		.toUpperCase();
-}
 
 /**
  * The Permissions editor tab: who can use/edit this agent, plus team grants.
@@ -211,9 +203,12 @@ export default function AgentPermissionsPanel({
 										className="flex w-full cursor-pointer items-center gap-3 border-b border-hover px-4 py-2.5 text-left transition-colors last:border-b-0 hover:bg-sidebar dark:border-white/5"
 										onClick={() => { addUser(user.id); }}
 									>
-										<span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
-											{getInitials(user.name)}
-										</span>
+										<UserAvatar
+											name={user.name}
+											pictureUrl={user.pictureUrl}
+											className="size-7 shrink-0"
+											fallbackClassName="bg-primary text-[10px] text-primary-foreground dark:bg-primary"
+										/>
 										<span className="min-w-0 flex-1">
 											<span className="block truncate text-[13.5px] font-semibold text-foreground">
 												{user.name || "Unnamed"}
@@ -237,9 +232,12 @@ export default function AgentPermissionsPanel({
 					<div className="overflow-hidden rounded-[10px] border border-border bg-card">
 						{owner && (
 							<div className="flex items-center gap-3 border-b border-hover px-4 py-3 last:border-b-0 dark:border-white/5">
-								<span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
-									{getInitials(owner.name)}
-								</span>
+								<UserAvatar
+									name={owner.name}
+									pictureUrl={owner.pictureUrl}
+									className="size-7 shrink-0"
+									fallbackClassName="bg-primary text-[10px] text-primary-foreground dark:bg-primary"
+								/>
 								<span className="min-w-0 flex-1">
 									<span className="block truncate text-[13.5px] font-semibold text-foreground">
 										{owner.name || "Unnamed"}
@@ -259,9 +257,12 @@ export default function AgentPermissionsPanel({
 								key={user.id}
 								className="group flex items-center gap-3 border-b border-hover px-4 py-2.5 last:border-b-0 dark:border-white/5"
 							>
-								<span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
-									{getInitials(user.name)}
-								</span>
+								<UserAvatar
+									name={user.name}
+									pictureUrl={user.pictureUrl}
+									className="size-7 shrink-0"
+									fallbackClassName="bg-primary text-[10px] text-primary-foreground dark:bg-primary"
+								/>
 								<span className="min-w-0 flex-1">
 									<span className="block truncate text-[13.5px] font-semibold text-foreground">
 										{user.name || "Unnamed"}

--- a/web/src/app/(protected)/agents/components/agent-table.tsx
+++ b/web/src/app/(protected)/agents/components/agent-table.tsx
@@ -9,6 +9,7 @@ import { useMcpServersStore } from "@/stores/mcp-servers-store";
 import ArchivedAgentDialog from "@/app/(protected)/agents/components/archived-agent-dialog";
 import ForbiddenErrorDialog from "@/components/forbidden-error-dialog";
 import { DataTable, type DataTableColumn } from "@/components/ui/data-table";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 
 const MAX_INLINE_AVATARS = 3;
@@ -31,14 +32,6 @@ const NO_ACCESS_BADGE = {
 	label: "NO ACCESS",
 	className: "bg-[#FBEFED] text-[#B04A3A] dark:bg-[#B04A3A]/10",
 };
-
-function ownerInitials(name: string): string {
-	const parts = name.trim().split(/\s+/);
-	if (parts.length >= 2) {
-		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-	}
-	return name.slice(0, 2).toUpperCase();
-}
 
 interface AgentTableProps {
 	agents: Agent[];
@@ -234,9 +227,12 @@ export default function AgentTable({
 				const ownerName = agent.owner?.name || agent.owner?.email || "Unknown";
 				return (
 					<span className="flex min-w-0 items-center gap-2">
-						<span className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-primary text-[8.5px] font-bold text-primary-foreground">
-							{ownerInitials(ownerName)}
-						</span>
+						<UserAvatar
+							name={ownerName}
+							pictureUrl={agent.owner?.pictureUrl}
+							className="size-[22px] shrink-0"
+							fallbackClassName="bg-primary text-[8.5px] text-primary-foreground dark:bg-primary"
+						/>
 						<span className="truncate text-[12.5px] text-body dark:text-panel-body">
 							{ownerName}
 						</span>

--- a/web/src/app/(protected)/mcp-servers/components/connected-users-panel.tsx
+++ b/web/src/app/(protected)/mcp-servers/components/connected-users-panel.tsx
@@ -4,16 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import { KeyRound, Unplug } from "lucide-react";
 import { api } from "@/lib/api/client";
 import { getApiErrorMessage } from "@/lib/api/errors";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { MCPAuthType, MCPServerConnection } from "@/types/mcp-servers";
-
-function getInitials(name: string | null | undefined): string {
-	if (!name) return "?";
-	const parts = name.trim().split(" ");
-	if (parts.length >= 2) {
-		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-	}
-	return name.substring(0, 2).toUpperCase();
-}
 
 function StatusBadge({ status }: { status: MCPServerConnection["status"] }) {
 	const active = status === "active";
@@ -205,9 +197,11 @@ export function ConnectedUsersPanel({
 							key={connection.userId}
 							className="flex items-center gap-3 border-b border-hairline px-4 py-[11px] transition-colors last:border-b-0 hover:bg-sidebar dark:border-white/5 dark:hover:bg-white/5"
 						>
-							<span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-ink text-[10.5px] font-bold text-white dark:bg-white/15">
-								{getInitials(connection.name)}
-							</span>
+							<UserAvatar
+								name={connection.name}
+								pictureUrl={connection.pictureUrl}
+								className="shrink-0"
+							/>
 							<span className="min-w-0 flex-1">
 								<span className="block truncate text-[13.5px] font-semibold text-foreground">
 									{connection.name || "Unknown user"}

--- a/web/src/app/(protected)/users/page.tsx
+++ b/web/src/app/(protected)/users/page.tsx
@@ -19,7 +19,7 @@ import {
 	WorkspacePage,
 	WorkspaceTopBarButton,
 } from "@/components/layout/workspace-page";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { DataTable, type DataTableColumn } from "@/components/ui/data-table";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { api } from "@/lib/api/client";
@@ -81,15 +81,6 @@ const ROLE_FILTERS: { key: "all" | Role; label: string }[] = [
 	{ key: "editor", label: "Editors" },
 	{ key: "member", label: "Members" },
 ];
-
-function getInitials(name: string | null | undefined): string {
-	if (!name) return "U";
-	const parts = name.trim().split(" ");
-	if (parts.length >= 2) {
-		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-	}
-	return name.substring(0, 2).toUpperCase();
-}
 
 function timeAgo(dateStr: string): string {
 	const diff = Date.now() - new Date(dateStr).getTime();
@@ -382,18 +373,11 @@ export default function UsersPage() {
 				const isCurrentUser = user.id === currentUser?.id;
 				return (
 					<div className="flex min-w-0 items-center gap-3">
-						<Avatar className="size-8 shrink-0">
-							{user.pictureUrl && (
-								<AvatarImage
-									src={user.pictureUrl}
-									alt=""
-									referrerPolicy="no-referrer"
-								/>
-							)}
-							<AvatarFallback className="bg-ink text-[10.5px] font-bold text-white dark:bg-white/15">
-								{getInitials(user.name)}
-							</AvatarFallback>
-						</Avatar>
+						<UserAvatar
+							name={user.name}
+							pictureUrl={user.pictureUrl}
+							className="shrink-0"
+						/>
 						<div className="min-w-0">
 							<div className="flex min-w-0 items-center gap-2">
 								<span className="truncate text-[13.5px] font-semibold text-foreground">

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -50,6 +50,7 @@ import { api } from "@/lib/api/client";
 import { formatRunAt } from "@/lib/triggers/schedule";
 import { useActiveRunThreadIds } from "@/hooks/use-active-runs";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { RenameThreadDialog } from "@/components/layout/app-sidebar/rename-thread-dialog";
 import { Thread } from "@/types/threads";
 import { useTheme } from "next-themes";
@@ -82,15 +83,6 @@ const navItems: {
 		icon: Users,
 	},
 ];
-
-function getInitials(name: string | undefined): string {
-	if (!name) return "U";
-	const parts = name.trim().split(" ");
-	if (parts.length >= 2) {
-		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-	}
-	return name.substring(0, 2).toUpperCase();
-}
 
 /** Compact relative time for thread rows: now, 5m, 2h, 3d, 4w */
 function shortTimeAgo(dateStr: string): string {
@@ -479,9 +471,12 @@ export function AppSidebar() {
 										tooltip={user?.name || "User"}
 										className="h-11 cursor-pointer rounded-lg pl-[5px] pr-2 hover:bg-sidebar-hover data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:h-11! group-data-[collapsible=icon]:w-[38px]! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:pl-[5px]!"
 									>
-										<span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
-											{getInitials(user?.name ?? undefined)}
-										</span>
+										<UserAvatar
+											name={user?.name}
+											pictureUrl={user?.pictureUrl}
+											className="size-7 shrink-0"
+											fallbackClassName="bg-primary text-[10px] text-primary-foreground dark:bg-primary"
+										/>
 										<div className="grid flex-1 text-left leading-tight min-w-0 group-data-[collapsible=icon]:hidden">
 											<span className="truncate text-[12.5px] font-semibold text-sidebar-foreground">
 												{user?.name || "User"}

--- a/web/src/components/layout/app-sidebar/index.tsx
+++ b/web/src/components/layout/app-sidebar/index.tsx
@@ -469,6 +469,12 @@ export function AppSidebar() {
 									<SidebarMenuButton
 										size="lg"
 										tooltip={user?.name || "User"}
+										// Collapsed, the avatar is the button's only visible
+										// content and the name column is hidden — without this
+										// the trigger has no accessible name (the tooltip is
+										// aria-describedby, and the initials chip disappears
+										// the moment the profile picture loads).
+										aria-label={user?.name || "User"}
 										className="h-11 cursor-pointer rounded-lg pl-[5px] pr-2 hover:bg-sidebar-hover data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:h-11! group-data-[collapsible=icon]:w-[38px]! group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:pl-[5px]!"
 									>
 										<UserAvatar

--- a/web/src/components/ui/user-avatar.tsx
+++ b/web/src/components/ui/user-avatar.tsx
@@ -24,6 +24,11 @@ interface UserAvatarProps {
  *
  * `referrerPolicy="no-referrer"` is required: Google serves the OAuth picture
  * from lh3.googleusercontent.com and 403s requests that carry a referrer.
+ *
+ * `alt=""` is deliberate — every call site renders the person's name next to
+ * the avatar, so a real alt would just double it up for screen readers. A
+ * caller that shows the avatar *alone* inside a control (the collapsed
+ * sidebar account button) must label the control itself.
  */
 export function UserAvatar({
 	name,

--- a/web/src/components/ui/user-avatar.tsx
+++ b/web/src/components/ui/user-avatar.tsx
@@ -1,0 +1,49 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+export function getInitials(name: string | null | undefined): string {
+	if (!name?.trim()) return "?";
+	const parts = name.trim().split(/\s+/);
+	if (parts.length >= 2) {
+		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+	}
+	return name.trim().substring(0, 2).toUpperCase();
+}
+
+interface UserAvatarProps {
+	name: string | null | undefined;
+	pictureUrl: string | null | undefined;
+	/** Sizing/shape for the avatar root (e.g. `size-7`). */
+	className?: string;
+	/** Overrides the initials chip styling (colors, font size). */
+	fallbackClassName?: string;
+}
+
+/**
+ * A person's profile picture, falling back to their initials.
+ *
+ * `referrerPolicy="no-referrer"` is required: Google serves the OAuth picture
+ * from lh3.googleusercontent.com and 403s requests that carry a referrer.
+ */
+export function UserAvatar({
+	name,
+	pictureUrl,
+	className,
+	fallbackClassName,
+}: UserAvatarProps) {
+	return (
+		<Avatar className={cn("size-8", className)}>
+			{pictureUrl && (
+				<AvatarImage src={pictureUrl} alt="" referrerPolicy="no-referrer" />
+			)}
+			<AvatarFallback
+				className={cn(
+					"bg-ink text-[10.5px] font-bold text-white dark:bg-white/15",
+					fallbackClassName,
+				)}
+			>
+				{getInitials(name)}
+			</AvatarFallback>
+		</Avatar>
+	);
+}

--- a/web/src/types/agents.ts
+++ b/web/src/types/agents.ts
@@ -51,6 +51,7 @@ export interface AgentOwner {
 	id: string;
 	name?: string | null;
 	email?: string | null;
+	pictureUrl?: string | null;
 }
 
 export interface Agent {

--- a/web/src/types/mcp-servers.ts
+++ b/web/src/types/mcp-servers.ts
@@ -72,6 +72,7 @@ export interface MCPServerConnection {
 	userId: string;
 	name?: string | null;
 	email?: string | null;
+	pictureUrl?: string | null;
 	status: "active" | "expired";
 }
 


### PR DESCRIPTION
## Problem

Profile pictures only showed on the **Users** settings page. Everywhere else a person is rendered, the UI drew an initials-only `<span>` and never looked at `pictureUrl` — and two of the payloads involved didn't carry the field at all.

## Fix

New shared `web/src/components/ui/user-avatar.tsx` — `<UserAvatar name pictureUrl className fallbackClassName />` wrapping the Radix `Avatar`, with initials as fallback. It also owns the single `getInitials` (first + last initial), replacing four near-duplicate local copies.

One gotcha it encapsulates: `referrerPolicy="no-referrer"` is what keeps Google's `lh3.googleusercontent.com` URLs from 403ing.

**Sites converted**

| Site | File |
| --- | --- |
| Sidebar footer (current user) | `components/layout/app-sidebar/index.tsx` |
| Agent permissions panel (search results, owner, permitted users) | `agents/components/agent-permissions-panel.tsx` |
| Agents table — Owner column | `agents/components/agent-table.tsx` |
| MCP connected users | `mcp-servers/components/connected-users-panel.tsx` |
| Users table (already worked) | `users/page.tsx` |

**Backend fields that were missing**

- `MCPServerConnectionResponse.picture_url` — `app/mcp/servers/schemas.py`, populated in `service.py`
- `AgentOwnerInfo.picture_url` — `app/agents/schemas.py`, populated in `agents/core/service.py`

Matching TS types updated (`types/mcp-servers.ts`, `types/agents.ts`).

No migration — `users.picture_url` already exists and is populated by the Google OAuth flow.

## Verification

- `tsc --noEmit` clean for `src/` (the 3 remaining errors are pre-existing, in `node_modules/@vitejs/plugin-react`)
- `eslint --config eslint.precommit.mjs` clean on all touched web files
- `ruff check` + `ruff format --check` clean on the backend
- Not exercised in a running browser — worth a glance at the sidebar and agents table to confirm the sizing reads right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user profile pictures only rendering on the Users settings page — they now display everywhere a person is shown, falling back to initials when no picture exists.

- Adds the shared `UserAvatar` component with the single `getInitials` helper, replacing four near-duplicate local copies.
- `referrerPolicy="no-referrer"` in `UserAvatar` keeps Google-hosted OAuth pictures from 403ing.
- Adds `picture_url` to `AgentOwnerInfo` and `MCPServerConnectionResponse`, which previously didn't expose it.
- Converts the sidebar footer, agent permissions panel, agents table, and MCP connected-users panel; the Users table now uses the shared component too.
- Labels the collapsed sidebar account button so it keeps an accessible name once the initials fallback unmounts.
- No migration needed — `users.picture_url` already exists and is populated by Google OAuth.

<sup>Written for commit c838a3db9c2eb2b33aaf7df2d785adb994a9cb08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

