### PR TITLE
fix(backend): Phase 1 hot path & stability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,8 @@ auxilia/
 │   │   │   └── router.py              # /triggers CRUD + /triggers/schedule/preview
 │   │   ├── users/                     # User management
 │   │   ├── utils/                     # remote_catalog.py — CDN-hosted catalogs; encryption.py — AES-GCM at rest
+│   │   ├── background.py              # PeriodicLoop + LoopHealth registry — supervised
+│   │   │                              # background loops; /health reports their liveness
 │   │   ├── database.py                # Async engine + request-scoped get_db
 │   │   ├── redis_client.py            # Shared async Redis client (durable runtime, out-of-request)
 │   │   ├── exceptions.py              # DomainError hierarchy + root_cause() ExceptionGroup unwrap

--- a/backend-cleanup-todo.md
+++ b/backend-cleanup-todo.md
@@ -6,7 +6,7 @@ just the state. Task IDs are stable — reference them in commits and PR titles.
 
 **Status legend:** `[ ]` not started · `[~]` partly done · `[x]` done · `[!]` blocked
 
-Last updated: 2026-08-28
+Last updated: 2026-08-29
 
 ---
 
@@ -60,7 +60,7 @@ Last updated: 2026-08-28
       (LLM turns are not idempotent; there is no retry, no DLQ, no backoff — a Celery
       contributor will assume otherwise) plus a Mermaid lifecycle diagram
 
-## Phase 1 — Hot path & stability
+## Phase 1 — Hot path & stability ✅ complete except P1-1 (blocked)
 
 - [!] **P1-1** PAT lookup → SHA-256 indexed digest (+ migration) — **BLOCKED**, awaiting
       an owner decision. Blocks nothing else; it is a leaf task, so the rest of Phase 1
@@ -81,31 +81,219 @@ Last updated: 2026-08-28
       `pg_dump -t personal_access_tokens` first, since migration 2 is irreversible),
       and (b) the owner to run the backfill script. The token must not be pasted into
       a session transcript.
-- [ ] **P1-2** `to_thread` around remaining Argon2 — **do this next.** It was written as
-      the stopgap for P1-1 (§3.1b), so with P1-1 parked it *is* the mitigation: it takes
-      Argon2 off the event loop for the PAT prefix scan as well as for passwords, so
-      in-flight SSE streams stop stalling. No migration, no DB access, no token handling
-      — entirely independent of P1-1's decision
-- [ ] **P1-3** `TokenStorageFactory` on the shared Redis client
-- [ ] **P1-4** `AgentRepository.get_run_spec` — *blocks P1-5, P2-6*
-- [ ] **P1-5** Consume `RunSpec` in `runtime.py` / `collect_run_bindings` (drops the triple resolution)
-- [ ] **P1-6** One memoized, concurrent, fail-open `probe_authorization`
-- [ ] **P1-7** `MCPServerRepository.list_by_ids` — no raw cross-module selects in services
-- [ ] **P1-8** Runs-runtime defects §5.1–5.4 (heartbeat, queued-run reaping, Redis restart, stream leak)
-- [ ] **P1-9** Thread delete ordering (commit before purge)
+- [x] **P1-2** `to_thread` around remaining Argon2. `verify_password` /
+      `get_password_hash` are now `async` and hand the hash to `asyncio.to_thread`, so
+      every Argon2 call in the codebase is off the event loop: password signin/signup,
+      PAT minting, and — the one that mattered — the PAT prefix scan on every Bearer
+      request, which used to block the loop once *per candidate*. Making the functions
+      async rather than adding wrappers means a missed call site is an unawaited
+      coroutine, not a silent regression; the five call sites are in `auth/service.py`
+      (3), `auth/tokens/service.py` and `auth/tokens/repository.py`.
+      Guarded by `test_hashing_does_not_block_the_event_loop`, which runs a heartbeat
+      coroutine alongside a hash and asserts it kept ticking — verified to fail
+      (`assert 0 > 1`) when the `to_thread` is removed. 703 passed, ruff and mypy clean.
+      **Still true after this:** the prefix scan is off-loop but remains sequential,
+      one Argon2 verify per prefix collision. That is the part P1-1 deletes; with
+      12-char prefixes over `secrets.token_urlsafe(32)` a collision is not a practical
+      concern, so this is a latency footnote, not a queue
+- [x] **P1-3** `TokenStorageFactory` on the shared Redis client. The factory built a
+      fresh `ConnectionPool` in its constructor and was constructed *per call* at eight
+      sites (`connectivity.py` ×3, `factory.py`, `servers/service.py` ×4), so every
+      readiness probe, is-connected poll, agent build and OAuth callback leaked a pool
+      that nothing ever closed. It now borrows `app.redis_client.get_redis()` — the
+      lifespan-managed client — with `redis` injectable for tests. `grep` confirms the
+      done-when: the only `Redis(` in `app/` is the one in `redis_client.py`.
+      Also gone: `RedisTokenStorage`'s `host="localhost", port=6379, db=0` default
+      constructor args (the deployment trap the review named — they silently ignored
+      `REDIS_PASSWORD` and pointed at the wrong host), now a required injected `redis`;
+      and its unused `aclose()`, which post-change would have closed the app-wide
+      client out from under everything else. Covered by
+      `test_factory_borrows_the_app_wide_client_instead_of_opening_a_pool`.
+      704 passed, ruff and mypy clean
+- [x] **P1-4** `AgentRepository.get_run_spec` → `RunSpec`. New leaf module
+      `app/agents/run_spec.py` (`RunSpec` / `AgentSpec` / `SandboxSpec`) carrying DB
+      rows, not response DTOs — the run path has no business depending on API response
+      assembly. `get_run_spec` fills it in **three flat queries** for a graph of any
+      width: one outer-joined select returning the parent *and* its direct subagent rows
+      (the link row's `created_at` rides along so subagent order is stable), one `IN` for
+      all `AgentMCPServerDB` bindings, one delegated to
+      `AgentSandboxRepository.list_for_agents`. `SandboxSpec` carries the joined
+      `SandboxDB` row, which is what lets P1-5 drop the re-fetch.
+      **Needed a real test lane to prove anything**: query count is the contract and a
+      mocked session cannot observe it. `tests/agents/core/conftest.py` now stands up a
+      SQLite engine with a statement counter — two accommodations make the Postgres
+      schema loadable (a `JSONB`→`JSON` DDL rendering for SQLite; tables created by
+      walking the FK closure rather than the whole metadata, which carries Postgres-only
+      columns elsewhere). 11 tests in `test_run_spec.py`, including a parametrized
+      `test_cost_is_flat_in_the_number_of_subagents` over N = 0, 1, 5
+- [x] **P1-5** Consume `RunSpec`. `Agent.build` does one `get_run_spec` for the whole
+      graph; `ResolvedAgent.resolve` now takes an `AgentSpec` instead of an agent id, so
+      resolving a subagent costs **zero** further agent queries, and `_resolve_sandbox`
+      became synchronous — it reads the row the same query already joined instead of
+      re-fetching it. `collect_run_bindings` is a projection of `RunSpec`
+      (`all_mcp_bindings`), which fixes the (1+N)×~5 on the endpoint the frontend
+      *polls*. `runtime.py` no longer imports `AgentService`, `AgentResponse` or
+      `SandboxRepository` — the review's stated done-when.
+      `Toolset.prepare` is retyped `Sequence[AgentMCPServerBase]` (the column set shared
+      by the row and its DTO — it only ever read `mcp_server_id` and `tools`), so the run
+      path passes rows and the API paths keep passing DTOs.
+      Subagent resolution stays sequential *on purpose* — one `AsyncSession` is not
+      concurrency-safe, and the review says so; what made it expensive was the per-agent
+      read, which is now gone.
+      The 8 readiness/binding tests in `tests/agents/core/test_service.py` were rebuilt
+      on real `RunSpec` dataclasses instead of duck-typed `MagicMock`s (the rules turn on
+      `tools is None` and on parent/subagent bindings staying separate — a mock satisfies
+      either reading), plus 2 new ones for the missing-agent path. 717 passed, ruff and
+      mypy clean.
+      *Not covered by this task:* `describe_readiness` still returns a constant
+      `"disconnected"` status and probes sequentially — that is P1-6
+- [x] **P1-6** One memoized, concurrent, fail-open `probe_authorization` in
+      `app/mcp/client/connectivity.py`, replacing the sequential fail-loud copy in
+      `describe_readiness` and the concurrent one in `ensure_mcp_authorized`. Also fixed
+      `describe_readiness` returning a constant `"disconnected"` status even when
+      everything was connected — it disagreed with the `ready` flag beside it.
+      **Only positives are memoized** (Redis, 30s TTL). Caching a negative would leave a
+      user who has just finished the OAuth popup reading as disconnected for the length
+      of the TTL, and a negative is already the cheap case — no stored token means the
+      probe returns without network work. The cost is the other direction: a token
+      revoked at the IdP reads as authorized for ≤30s, which the code says out loud.
+      A cache outage degrades to probing, never to failing — this is the polled endpoint.
+      8 tests in `tests/mcp/client/test_connectivity.py`, including a real concurrency
+      assertion (peak in-flight == 3, not just "gather was called").
+      **Also required**: an autouse `fake_shared_redis` fixture in `tests/conftest.py`.
+      Once readiness reaches the shared client, any test that walks that path would
+      otherwise connect to whatever sits on localhost:6379 — green on a developer's
+      machine, hanging or erroring in CI
+- [x] **P1-7** `MCPServerRepository.list_by_ids`. The review named two raw
+      `select(MCPServerDB).where(id.in_(...))` outside `app/mcp/servers/`; there were
+      **three** — `agents/core/service.py`, `agents/runs/service.py` and
+      `agents/toolset.py`. All three now call the repository, which short-circuits an
+      empty id set (`IN ()` is a round-trip for a known-empty answer, and every caller
+      reaches it that way whenever an agent binds no servers). `grep` confirms the
+      done-when: no `select(MCPServerDB)` outside `app/mcp/servers/`
+- [x] **P1-8** Runs-runtime defects §5.1–5.4. Each has a regression test that was
+      **verified to fail** with its fix reverted (the reaper had no tests at all before
+      this; `tests/agents/runs/test_reaper.py` is new).
+      - *§5.1 heartbeat* — every tick is now wrapped. One transient Redis error used to
+        kill the loop silently, after which liveness expired and the reaper finalized a
+        healthy streaming run as `error`.
+      - *§5.2 queued-run reaping* — new `DispatcherLiveness` (`run:dispatchers:alive`,
+        one shared key). Stuck-`pending` runs are reaped **only while no dispatcher in
+        the cluster is alive**. Crucially the key is stamped from an *independent* task,
+        not the claim loop: that loop blocks on `_semaphore.acquire()` when saturated,
+        i.e. it goes silent exactly in the backlog case being fixed.
+        Accepted trade-off, stated in the code and the SPEC: a dispatcher that is alive
+        but wedged leaves pending runs un-reaped. That is P1-12's problem, and failing
+        to reap is far cheaper than killing runs that were about to run.
+      - *§5.3 Redis restart* — death must be observed on two consecutive sweeps
+        (`_suspect` set). A restart drops every liveness key at once; the old
+        single-sample rule would mass-reap a whole cluster of healthy streaming runs.
+      - *§5.4 stream leak* — `_expire_ephemera` is now unconditional in `finalize`
+        (`thread_id is None` includes "the thread was deleted mid-run and CASCADEd the
+        row away", and nothing will ever finalize that run again), **plus** a safety TTL
+        stamped on the event log's first `XADD` and pushed out by the worker heartbeat,
+        so a long or uncapped run never expires its own live stream.
+      Also: `RunWorker._stop` became a module-level `_cancel` (the dispatcher needs it
+      too), and the SPEC's storage table + reaper section document the new key and both
+      new rules. 743 passed.
+      *Test-lane notes for whoever touches these next:* the SQLite lane stores
+      `DateTime(timezone=True)` as **naive UTC**, and `updated_at` carries
+      `onupdate=func.now()` so it cannot be backdated by an UPDATE. The reaper tests
+      therefore drive `now` **forward** and use a `_db_now()` helper — a plain
+      `datetime.now()` is local time and makes every young run look stale. The
+      background-task tests use a bounded `_until` helper: with a plain `while`, the
+      regression they guard (the task dying) would hang the suite instead of failing it
+- [x] **P1-9** Thread delete ordering. `DELETE /threads/{id}` purged LangGraph
+      checkpoints *first* and left the row delete to the request commit — the exact
+      reverse of `purge_checkpoints`' own documented contract, so a failed commit left a
+      thread whose entire history was irrecoverably gone. Now: delete the row, `commit`
+      (an instance of the documented third transaction regime, with the reason in a
+      comment), then purge. The other direction fails safe — a purge that errors leaves
+      orphaned checkpoints, which is invisible and reclaimable.
+      Covered by `test_delete_commits_the_row_before_purging_checkpoints` (verified to
+      fail on the old ordering) plus a 403 test; the endpoint had **no** tests before.
+      *Residual, deliberately not expanded into:* `AgentService.delete_permanently`
+      purges after all DB deletes have *flushed* but still before the request commit, so
+      it keeps a narrower version of the same window. Its ordering is asserted by an
+      existing test and fixing it means committing mid-service, which changes that
+      method's contract — worth doing under P3-5 when that method is opened anyway
 - [x] **P1-10** Slack: strong task references, Redis `SET NX EX` dedup (was per-process,
       so a retry on a second instance ran the agent twice), Optional-event guard.
       `app/integrations/slack/router.py` rewritten; 9 tests in
       `tests/integrations/slack/test_router.py` (the module had none)
-- [ ] **P1-11** Buffer run SSE chunks into pipelined `XADD`s
-- [ ] **P1-12** Background-loop supervision + liveness on `/health`
-- [ ] **P1-13** Trigger scanner pre-warms the whitelist outside the claim txn
-- [ ] **P1-14** Narrow `_open_session`'s `try` to the handshake (§5.7)
-- [ ] **P1-15** `MCPServerService.update` cleans up on auth-type/URL change (§5.8)
+- [x] **P1-11** `BufferedEventPublisher` in `app/agents/runs/events.py` coalesces SSE
+      chunks into pipelined appends. Bounded on **both** axes, and the second one is the
+      one that matters: chunks (32) caps memory and pipeline size, delay (50ms, enforced
+      by a background flusher) caps *latency*. These chunks are the tokens a user watches
+      appear, so a count-only buffer would hold the tail of a slow response until enough
+      tokens arrived — exactly backwards. Flush errors are carried, not swallowed: the
+      next `publish`/`aclose` re-raises, so a Redis that has gone away still fails the
+      run instead of silently dropping output.
+      **The first version of the test proved nothing** — it counted calls to
+      `publish_many`, which is the method under test. Replaced by a `count_appends`
+      fixture counting *client-level* `xadd` calls (buffered writes go through
+      `pipeline.xadd`, which costs nothing until `execute()`), plus a worker-level test
+      that a 50-chunk run makes exactly 1 direct append (the end sentinel). Both verified
+      to fail when the buffer is bypassed
+- [x] **P1-12** New `app/background.py`: `PeriodicLoop` (supervised tick with
+      exponential backoff, capped at 60s) + a `LoopHealth`/`LoopRegistry` pair, and a
+      **new `GET /health`** returning 503 when a loop has stopped ticking. The app had no
+      health endpoint at all.
+      `RunReaper` and `TriggerScanner` now drive their tick through `PeriodicLoop`; they
+      already caught per-tick exceptions, so what they actually gained is backoff (a
+      persistent failure used to be a tight error-logging spin) and liveness reporting.
+      `RunDispatcher` is **not** a `PeriodicLoop` and doesn't pretend to be — it blocks on
+      its semaphore, so it is not periodic. It publishes the same `LoopHealth` and got its
+      loop body wrapped, which is the actual §2.3 defect: a raise there killed it for
+      good while the instance kept serving 200s.
+      Both halves are needed and the module says why: supervision cannot save a loop from
+      a bug in the supervisor, a cancellation, or a `BaseException`, so liveness is
+      published rather than assumed. A stopped or never-started loop counts as healthy —
+      `RUN_DISPATCHER_ENABLED=false` is a supported deployment, not a degraded one.
+      15 tests; supervision ones verified to fail without it. SPEC's deployment section
+      now says to point the platform health check at `/health`.
+      **This also closes P1-8's stated trade-off** (a wedged-but-alive dispatcher leaves
+      pending runs un-reaped): a wedged dispatcher now fails `/health` and gets recycled
+- [x] **P1-13** `claim_and_enqueue` warms the model whitelist before `claim_due`, as
+      `RunService.create` already did. Sharper version of the same problem there:
+      `is_available` runs *inside* the claim transaction, which holds
+      `FOR UPDATE SKIP LOCKED` locks on every claimed trigger row, so a cold catalog cache
+      meant a multi-second CDN fetch with those locks held. `claim_and_enqueue` had no
+      tests; it has an ordering test now (verified to fail without the pre-warm)
+- [x] **P1-14** `_open_session`'s `yield` moved out of the `except Exception` wrapper.
+      Any exception raised by the *caller's* `async with` body travelled back through the
+      generator and got laundered into a `DomainError` — a 500 carrying someone else's
+      message. 4 tests pin the boundary: a caller-body `PermissionDeniedError` propagates
+      unchanged (verified to fail with the old shape), a failing `list_tools` is still
+      wrapped, and `OAuthAuthorizationRequired` still passes through unwrapped so
+      `test_connection` can turn it into an `oauth_required` result
+- [x] **P1-15** `MCPServerService.update` purges what an edit invalidates, via a new
+      `_purge_invalidated_state` and `MCPServerRepository.delete_credentials`.
+      **Two triggers with deliberately different blast radii**, which is the judgement
+      call in this task:
+      - *URL changed* → purge all per-user Redis state (tokens, DCR registration, cached
+        AS metadata — all issued for the old resource; a surviving refresh token is worse
+        than none, because `is_authorized` keeps reporting the user connected). Admin-
+        entered credential rows are **kept**: a static client id/secret is configuration
+        someone typed, and re-pointing a server at a new path of the same provider must
+        not silently discard it.
+      - *auth type changed* → the same Redis purge **plus** the credential row for the
+        scheme being left, which is dead config (`list_responses` already had to gate
+        `oauth_client_id` on the current auth type precisely because it could linger).
+      Redis purging is best-effort — a cache outage must not stop an admin fixing a
+      server; the cost of a miss is a stale token the next authorization overwrites.
+      5 tests including "renaming purges nothing"; 3 verified to fail without the fix
 - [x] **P1-16** One shared resolver behind `get_current_user` /
       `get_current_user_optional` (§5.9) — the precedence had diverged; covered by
       `test_stale_cookie_plus_valid_bearer_resolves_the_bearer_user`
-- [ ] **P1-17** Langfuse: lazy client + `flush()` on shutdown (§5.10)
+- [x] **P1-17** Langfuse client built lazily and memoized, with construction failures
+      caught: a bad base URL used to take down every import of `runtime.py` at startup,
+      for an optional integration. `flush_langfuse()` runs in the lifespan teardown (via
+      `to_thread` — the SDK's flush is blocking and this is the loop's last breath) so
+      scale-to-zero stops losing trace tails.
+      `app/integrations/langfuse/__init__.py` re-exported the old module-level constant,
+      so it had to change too — that re-export was itself part of the eager-import
+      problem. 7 new tests
 
 ## Phase 2 — Runtime unification (before the deepagents/langchain upgrades)
 

--- a/backend-cleanup-todo.md
+++ b/backend-cleanup-todo.md
@@ -348,6 +348,45 @@ Last updated: 2026-08-29
 
 ---
 
+## Review follow-ups on PR #299 (cubic)
+
+cubic found 16 issues on the Phase 1 PR, and the important ones were real —
+including two flaws inside the P1-8 fixes themselves and one self-inflicted
+outage risk. Recorded here because they are the kind of mistake that recurs:
+
+- **A fix can reintroduce the bug it was fixing.** P1-8's unconditional
+  `_expire_ephemera` (§5.4) cleared the liveness key of a run that was *still
+  running* whenever a guarded finalize lost a race with a dispatcher claim —
+  handing the reaper a fake dead worker, which is precisely what §5.3's
+  two-sample rule exists to prevent. Now gated on the row being absent or
+  terminal.
+- **A health check can be the outage.** P1-12 ticked dispatcher health from the
+  claim loop, which blocks on the semaphore for the whole length of an agent
+  turn. A fully occupied dispatcher went stale in ~63s, so `/health` 503'd and
+  the platform would recycle a healthy, busy worker mid-run. Health now rides
+  the liveness heartbeat, which runs on its own timer.
+- **The two-sample rule had to apply to both reap paths.** "No dispatcher alive"
+  is a missing Redis key too, so a restart made the reaper kill the whole
+  pending queue on one sample. Also: a sweep that raised part-way left
+  `_suspect` stale, so the *next* single sample could reap — the error path
+  quietly restored single-sample behaviour.
+- **Cancelling a task can destroy data it already took.** The event buffer's
+  `_flush_locked` empties the buffer before awaiting the write, so `aclose`
+  cancelling mid-write lost the tail of a run. The flusher is now asked to stop
+  and awaited, never cancelled.
+- **Fail-open only catches raised errors.** The `probe_authorization` cache had
+  no deadline, so a stalled Redis would hang the polled endpoint rather than
+  degrade. Every cache round trip is now bounded.
+- **A cache must live where the invalidators can find it.** The probe cache key
+  sat outside the `mcp:{user}:{server}:*` layout that `clear_server_data` scans,
+  so a revoked connection or a changed server URL left it reporting authorized.
+- **Two of my own tests proved nothing.** The dispatcher-liveness test deleted
+  the key by hand and would have passed against a `SET` with no expiry; the
+  subagent-ordering test asserted insertion order that the query never
+  guaranteed (`created_at` is the transaction timestamp, so siblings tie).
+- `/health` is unauthenticated, so it now reports an exception *type*, never a
+  repr that could carry a DSN or token.
+
 ## Process note: the mypy ratchet can hide a regression in a base class
 
 `app/repository.py` and `app/service.py` are checked, but most of their *subclasses*

--- a/backend/app/agents/core/repository.py
+++ b/backend/app/agents/core/repository.py
@@ -94,7 +94,7 @@ class AgentRepository(BaseRepository[AgentDB]):
         out of the agents list while still wired to a supervisor.
         """
         # One query for the whole first level. The outer join carries the link
-        # row's `created_at` so subagents keep a stable order; the parent matches
+        # row's `created_at` so subagents come back in a stable order; the parent matches
         # the first disjunct and joins to a NULL link, hence `nullsfirst`.
         stmt = (
             select(AgentDB, AgentSubagentDB.created_at)
@@ -109,7 +109,15 @@ class AgentRepository(BaseRepository[AgentDB]):
                     AgentSubagentDB.supervisor_id == agent_id,
                 )
             )
-            .order_by(AgentSubagentDB.created_at.asc().nullsfirst())
+            .order_by(
+                AgentSubagentDB.created_at.asc().nullsfirst(),
+                # `created_at` is the *transaction* timestamp, so subagents bound
+                # in one save all share it and would otherwise come back in
+                # whatever order the planner liked. The tie-break only buys
+                # repeatability — subagents are addressed by name, so their
+                # relative order carries no meaning.
+                AgentSubagentDB.id.asc(),
+            )
         )
         rows = (await self.db.execute(stmt)).all()
 

--- a/backend/app/agents/core/repository.py
+++ b/backend/app/agents/core/repository.py
@@ -1,14 +1,19 @@
+from collections import defaultdict
 from uuid import UUID
 
+from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.agents.models import (
     AgentDB,
     AgentMCPServerDB,
+    AgentSubagentDB,
     AgentTeamDB,
     AgentUserPermissionDB,
 )
+from app.agents.run_spec import AgentSpec, RunSpec, SandboxSpec
+from app.agents.sandboxes.repository import AgentSandboxRepository
 from app.agents.schemas import AgentPermissionCreate
 from app.repository import BaseRepository
 from app.users.models import WorkspaceRole
@@ -78,6 +83,78 @@ class AgentRepository(BaseRepository[AgentDB]):
 
         result = await self.db.execute(stmt)
         return result.all()
+
+    async def get_run_spec(self, agent_id: UUID) -> RunSpec | None:
+        """The parent agent and its direct subagents, with their MCP and sandbox
+        bindings, in three flat queries — regardless of how many subagents there
+        are (design review §2.2). Returns `None` if the agent does not exist.
+
+        Archived agents are included: a run already under way must survive its
+        agent being archived mid-flight, and a subagent is routinely archived
+        out of the agents list while still wired to a supervisor.
+        """
+        # One query for the whole first level. The outer join carries the link
+        # row's `created_at` so subagents keep a stable order; the parent matches
+        # the first disjunct and joins to a NULL link, hence `nullsfirst`.
+        stmt = (
+            select(AgentDB, AgentSubagentDB.created_at)
+            .outerjoin(
+                AgentSubagentDB,
+                (AgentSubagentDB.subagent_id == AgentDB.id)
+                & (AgentSubagentDB.supervisor_id == agent_id),
+            )
+            .where(
+                or_(
+                    AgentDB.id == agent_id,
+                    AgentSubagentDB.supervisor_id == agent_id,
+                )
+            )
+            .order_by(AgentSubagentDB.created_at.asc().nullsfirst())
+        )
+        rows = (await self.db.execute(stmt)).all()
+
+        parent: AgentDB | None = None
+        subagent_rows: list[AgentDB] = []
+        for agent, link_created_at in rows:
+            if link_created_at is None and agent.id == agent_id:
+                parent = agent
+            else:
+                subagent_rows.append(agent)
+        if parent is None:
+            return None
+
+        agent_ids = [parent.id, *(a.id for a in subagent_rows)]
+
+        bindings_by_agent: dict[UUID, list[AgentMCPServerDB]] = defaultdict(list)
+        stmt = (
+            select(AgentMCPServerDB)
+            .where(AgentMCPServerDB.agent_id.in_(agent_ids))
+            .order_by(AgentMCPServerDB.created_at.asc())
+        )
+        for binding in (await self.db.execute(stmt)).scalars().all():
+            bindings_by_agent[binding.agent_id].append(binding)
+
+        # An agent binds at most one sandbox (uq_agent_sandbox), so last-wins is
+        # the same as only-one; the dict just avoids asserting that here.
+        sandbox_by_agent: dict[UUID, SandboxSpec] = {}
+        sandbox_repository = AgentSandboxRepository(self.db)
+        for link, sandbox in await sandbox_repository.list_for_agents(agent_ids):
+            sandbox_by_agent[link.agent_id] = SandboxSpec(row=sandbox, tools=link.tools)
+
+        def to_spec(agent: AgentDB) -> AgentSpec:
+            return AgentSpec(
+                id=agent.id,
+                name=agent.name,
+                instructions=agent.instructions,
+                description=agent.description,
+                mcp_servers=bindings_by_agent.get(agent.id, []),
+                sandbox=sandbox_by_agent.get(agent.id),
+            )
+
+        return RunSpec(
+            agent=to_spec(parent),
+            subagents=[to_spec(a) for a in subagent_rows],
+        )
 
     async def archive(self, agent: AgentDB) -> None:
         agent.is_archived = True

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -7,13 +7,13 @@ from uuid import UUID
 from fastapi import Depends
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
 from app.agents.core.repository import AgentRepository
 from app.agents.mcp_servers.repository import AgentMCPServerRepository
 from app.agents.mcp_servers.service import AgentMCPServerService
 from app.agents.models import (
     AgentDB,
+    AgentMCPServerDB,
     AgentUserPermissionDB,
 )
 from app.agents.sandboxes.repository import AgentSandboxRepository
@@ -32,8 +32,8 @@ from app.agents.schemas import (
 from app.agents.subagents.service import SubagentService
 from app.database import get_db
 from app.exceptions import NotFoundError, PermissionDeniedError
-from app.mcp.client.connectivity import is_authorized
-from app.mcp.servers.models import MCPServerDB
+from app.mcp.client.connectivity import probe_authorization
+from app.mcp.servers.repository import MCPServerRepository
 from app.service import BaseService
 from app.tags.service import TagService
 from app.threads.service import ThreadService
@@ -57,6 +57,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         self.mcp_server_service = AgentMCPServerService(db)
         self.sandbox_repository = AgentSandboxRepository(db)
         self.sandbox_service = AgentSandboxService(db)
+        self.mcp_servers = MCPServerRepository(db)
 
     @staticmethod
     def _resolve_permission(
@@ -397,23 +398,20 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     async def set_teams(self, agent_id: UUID, team_ids: list[UUID]) -> list[UUID]:
         return await self.repository.set_teams(agent_id, team_ids)
 
-    async def collect_run_bindings(
-        self, agent_id: UUID
-    ) -> list[AgentMCPServerResponse]:
+    async def collect_run_bindings(self, agent_id: UUID) -> list[AgentMCPServerDB]:
         """Every MCP binding a run of this agent touches: the agent's own plus
         each direct subagent's. One level only — matches `Agent.build`, which
         does not recurse into a subagent's own subagents.
 
-        NOT deduped: `tools` (configuration state) is per binding, so a server
-        configured on the parent but left unconfigured on a subagent must stay
-        visible to the readiness check. Callers doing per-server work (the OAuth
-        probe) dedupe by mcp_server_id themselves."""
-        agent = await self.get(agent_id, include_archived=True)
-        bindings: list[AgentMCPServerResponse] = list(agent.mcp_servers or [])
-        for sub in agent.subagents or []:
-            sub_agent = await self.get(sub.id, include_archived=True)
-            bindings.extend(sub_agent.mcp_servers or [])
-        return bindings
+        A projection of `RunSpec` — see `run_spec.all_mcp_bindings` for the
+        not-deduped contract. This used to be a full `AgentService.get` per
+        agent, i.e. (1+N)×~5 queries, and it sits on the endpoint the frontend
+        polls (design review §1.2).
+        """
+        spec = await self.repository.get_run_spec(agent_id)
+        if spec is None:
+            return []
+        return spec.all_mcp_bindings
 
     async def describe_readiness(self, agent_id: UUID, user_id: str) -> dict:
         # Includes subagents' servers: a subagent's unauthorized OAuth server
@@ -433,19 +431,20 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
                 }
 
         server_ids = {b.mcp_server_id for b in bindings}  # dedupe for the probe
-        stmt = select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
-        result = await self.db.execute(stmt)
-        servers = list(result.scalars().all())
+        servers = await self.mcp_servers.list_by_ids(server_ids)
 
-        disconnected: list[str] = []
-        for server in servers:
-            if not await is_authorized(server, user_id):
-                disconnected.append(str(server.id))
+        authorized = await probe_authorization(servers, user_id)
+        disconnected = [
+            str(server.id) for server in servers if not authorized.get(server.id, True)
+        ]
 
         return {
-            "ready": len(disconnected) == 0,
+            "ready": not disconnected,
             "disconnected_servers": disconnected,
-            "status": "disconnected",
+            # Was hardcoded to "disconnected" even when everything was connected
+            # (design review §4.1) — the frontend's own `ready` flag disagreed
+            # with the status string it was shown next to.
+            "status": "disconnected" if disconnected else "ready",
         }
 
 

--- a/backend/app/agents/run_spec.py
+++ b/backend/app/agents/run_spec.py
@@ -1,0 +1,72 @@
+"""The narrow read the run path needs — everything, and only, what it takes to
+build an agent graph.
+
+`AgentService.get` assembles an `AgentResponse`: owner names, tag names,
+permission resolution, sandbox display fields, `is_subagent` flags. That is the
+right shape for the API and the wrong shape for a run, which needs
+`instructions` + MCP bindings + subagents and nothing else. Resolving a graph
+through `get` cost one full assembly *per agent* — and the same graph was
+resolved three times per send (readiness poll, run preflight, worker build), so
+the waste multiplied by three (design review §1.2 / §2.2).
+
+`RunSpec` is that narrow read, filled by `AgentRepository.get_run_spec` in three
+flat queries for a graph of any width. It carries DB rows rather than response
+DTOs on purpose: the runtime should not depend on API response assembly, and a
+row already holds every field the runtime touches.
+"""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from app.agents.models import AgentMCPServerDB, ToolStatus
+from app.sandbox.models import SandboxDB
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """A resolved agent↔sandbox binding: the sandbox row plus the binding's
+    per-tool map. Carrying `row` is what lets the runtime skip the re-fetch it
+    used to do for a row the same read had already joined."""
+
+    row: SandboxDB
+    tools: dict[str, ToolStatus] | None
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """One agent's run-relevant state. Used for both the parent and subagents —
+    `Agent.build` treats them identically apart from `apply_ui`."""
+
+    id: UUID
+    name: str
+    instructions: str
+    description: str | None
+    mcp_servers: list[AgentMCPServerDB]
+    sandbox: SandboxSpec | None
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    """A parent agent and its direct subagents.
+
+    One level only, matching `Agent.build`, which does not recurse into a
+    subagent's own subagents.
+    """
+
+    agent: AgentSpec
+    subagents: list[AgentSpec]
+
+    @property
+    def all_mcp_bindings(self) -> list[AgentMCPServerDB]:
+        """Every MCP binding a run of this agent touches: the agent's own plus
+        each direct subagent's.
+
+        NOT deduped: `tools` (configuration state) is per binding, so a server
+        configured on the parent but left unconfigured on a subagent must stay
+        visible to the readiness check. Callers doing per-server work (the OAuth
+        probe) dedupe by `mcp_server_id` themselves.
+        """
+        bindings = list(self.agent.mcp_servers)
+        for sub in self.subagents:
+            bindings.extend(sub.mcp_servers)
+        return bindings

--- a/backend/app/agents/runs/SPEC.md
+++ b/backend/app/agents/runs/SPEC.md
@@ -41,6 +41,7 @@ Storage is split by **data lifetime**, not by module:
 | SSE event log (stream/reattach) | **Redis Stream** | per-token appends; TTL'd — it's a replay window, not a record |
 | Cancel signal | **Redis list** | transient coordination |
 | Worker liveness | **Redis key** (`SET … EX`) | a heartbeat every 5s would be MVCC dead-tuple churn in Postgres; a self-expiring key makes "silent = dead" free |
+| Dispatcher liveness | **Redis key** (`run:dispatchers:alive`) | one shared key, refreshed by every live dispatcher, so the reaper can tell "nothing is dispatching" from "dispatchers are busy" |
 
 On a terminal transition, `RunService.finalize` updates the run row **and**
 stamps `threads.last_run_status` in one transaction — the run outcome and the
@@ -248,10 +249,20 @@ copy).
 
 - `running` whose liveness key is gone AND whose last transition is older than
   `RUN_HEARTBEAT_TIMEOUT_SECONDS` (grace for the claim → first-stamp gap) →
-  `error` via `finalize` (sentinel + thread stamp included).
+  `error` via `finalize` (sentinel + thread stamp included). **Death must be
+  observed on two consecutive sweeps.** The liveness key is the only evidence,
+  and a Redis restart makes every key missing at once; a single-sample rule
+  would mass-reap a whole cluster of healthy streaming runs. Confirming costs
+  one reaper interval of extra latency on a genuinely dead run.
 - `pending` older than `RUN_PENDING_TIMEOUT_SECONDS` **whose thread isn't
-  busy** → `error` (queued zombie). A pending run behind a running one is a
-  legitimate `enqueue` waiter, however old.
+  busy**, and **only while no dispatcher in the cluster is alive** → `error`
+  (queued zombie). A pending run behind a running one is a legitimate `enqueue`
+  waiter, however old — and so is every run queued behind a saturated worker
+  pool, which has exactly the same shape (a burst of trigger firings, each on a
+  fresh thread, produces it). The `run:dispatchers:alive` key is what separates
+  the two. Deliberate trade-off: a dispatcher that is alive but wedged leaves
+  pending runs un-reaped — a supervision problem, and much cheaper than killing
+  runs that were about to run.
 - `interrupted` is never reaped.
 - Daily retention pass: DELETE terminal rows older than `RUN_RETENTION_DAYS`.
   Safe by construction — `threads.last_run_status` is denormalized, so pruning
@@ -286,6 +297,18 @@ not serving requests:
 `RUN_DISPATCHER_ENABLED=false` lets you split a dedicated worker deployment from
 request-serving instances later (run the dispatcher only on the worker pool)
 without code changes.
+
+**Point the platform's health check at `GET /health`.** The dispatcher, reaper
+and scanner publish liveness through `app/background.py`, and `/health` returns
+**503** when one of them has stopped ticking. Without that, a dead loop leaves
+an instance answering 200s while nothing executes runs ever again — so nothing
+recycles it and the deployment looks healthy while being entirely broken. An
+instance with `RUN_DISPATCHER_ENABLED=false` registers no loops and is simply
+healthy; request-only instances are a supported deployment, not a degraded one.
+
+A raising tick is logged and retried with exponential backoff (capped at 60s)
+rather than ending its loop, so a Postgres failover or a Redis blip costs a
+retry instead of the loop.
 
 Rollout from the Redis-records version: no data migration — the old Redis
 record keys were 1h-TTL ephemeral and simply expire; in-flight runs at deploy

--- a/backend/app/agents/runs/events.py
+++ b/backend/app/agents/runs/events.py
@@ -20,6 +20,7 @@ from app.redis_client import get_redis
 
 # Stream entry fields.
 _DATA = "data"  # the raw SSE chunk
+_MIN_FLUSH_DELAY_SECONDS = 0.001
 _END = "end"  # present ("1") only on the terminal sentinel
 
 
@@ -186,14 +187,20 @@ class BufferedEventPublisher:
     ):
         self._events = events
         self._max_chunks = max_chunks or run_settings.event_buffer_max_chunks
-        self._max_delay = (
+        delay = (
             max_delay_seconds
             if max_delay_seconds is not None
             else run_settings.event_buffer_max_delay_ms / 1000
         )
+        # A non-positive delay would make the flusher's wait return instantly
+        # and spin a CPU for the length of the run. Zero plainly means "ship
+        # immediately", so honour that intent at the smallest delay that still
+        # yields, rather than rejecting the configuration.
+        self._max_delay = max(delay, _MIN_FLUSH_DELAY_SECONDS)
         self._buffer: list[str] = []
         self._lock = asyncio.Lock()
         self._flusher: asyncio.Task | None = None
+        self._stopping = asyncio.Event()
         self._error: BaseException | None = None
 
     async def __aenter__(self) -> "BufferedEventPublisher":
@@ -211,11 +218,17 @@ class BufferedEventPublisher:
                 await self._flush_locked()
 
     async def aclose(self) -> None:
-        """Stop the flusher and drain whatever is left."""
+        """Stop the flusher and drain whatever is left.
+
+        The flusher is *asked* to stop and awaited, never cancelled.
+        `_flush_locked` takes the buffer before awaiting the write, so
+        cancelling mid-write would destroy chunks that are no longer in the
+        buffer for the drain below to pick up — losing the tail of a run, or
+        landing it after the end sentinel.
+        """
+        self._stopping.set()
         if self._flusher is not None:
-            self._flusher.cancel()
-            with suppress(asyncio.CancelledError):
-                await self._flusher
+            await self._flusher
             self._flusher = None
         async with self._lock:
             await self._flush_locked()
@@ -233,8 +246,11 @@ class BufferedEventPublisher:
         await self._events.publish_many(chunks)
 
     async def _flush_periodically(self) -> None:
-        while True:
-            await asyncio.sleep(self._max_delay)
+        while not self._stopping.is_set():
+            with suppress(TimeoutError):
+                await asyncio.wait_for(self._stopping.wait(), timeout=self._max_delay)
+            if self._stopping.is_set():
+                return  # `aclose` owns the final drain
             try:
                 async with self._lock:
                     await self._flush_locked()

--- a/backend/app/agents/runs/events.py
+++ b/backend/app/agents/runs/events.py
@@ -5,8 +5,10 @@ from a cursor and relay the raw strings to their HTTP response. Stream entry ids
 *are* the resume cursor, so reattach replays only what a client missed.
 """
 
+import asyncio
 import json
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 
 from redis.asyncio import Redis
 
@@ -34,15 +36,68 @@ class RunEventStream:
         self.run_id = run_id
         self.redis: Redis = redis or get_redis()
         self._key = keys.run_events_key(run_id)
+        self._ttl_stamped = False
 
     async def publish(self, sse: str) -> str:
-        """Append an SSE chunk; returns its stream entry id."""
+        """Append an SSE chunk; returns its stream entry id.
+
+        The first append also stamps a safety TTL, so a stream can never
+        outlive its run permanently. `RunService.finalize` normally sets that
+        TTL, but it is skipped when the run row has vanished — a thread deleted
+        mid-run CASCADEs the run away — and the log would then sit in Redis for
+        ever. The worker's heartbeat pushes this TTL out every few seconds, so
+        a long (or uncapped) run never expires its own live stream.
+        """
         # ponytail: approximate MAXLEN keeps only the recent tail — a slow reattacher
         # on a trimmed cursor misses intermediate live chunks, but final state is
         # reconstructable from the checkpoint, so it's safe.
-        return await self.redis.xadd(
-            self._key, {_DATA: sse}, maxlen=run_settings.max_events, approximate=True
-        )
+        if self._ttl_stamped:
+            return await self.redis.xadd(
+                self._key,
+                {_DATA: sse},
+                maxlen=run_settings.max_events,
+                approximate=True,
+            )
+        async with self.redis.pipeline(transaction=False) as pipe:
+            pipe.xadd(
+                self._key,
+                {_DATA: sse},
+                maxlen=run_settings.max_events,
+                approximate=True,
+            )
+            pipe.expire(self._key, run_settings.ttl_seconds)
+            entry_id, _ = await pipe.execute()
+        self._ttl_stamped = True
+        return entry_id
+
+    async def publish_many(self, chunks: list[str]) -> None:
+        """Append several SSE chunks in one round trip.
+
+        The whole point of `BufferedEventPublisher`: an awaited `XADD` per chunk
+        means one Redis RTT per token, serialized with the agent stream, so a
+        3,000-chunk run on managed Redis spends seconds of wall clock just
+        waiting on the network (design review §3.4).
+        """
+        if not chunks:
+            return
+        async with self.redis.pipeline(transaction=False) as pipe:
+            for sse in chunks:
+                pipe.xadd(
+                    self._key,
+                    {_DATA: sse},
+                    maxlen=run_settings.max_events,
+                    approximate=True,
+                )
+            if not self._ttl_stamped:
+                pipe.expire(self._key, run_settings.ttl_seconds)
+            await pipe.execute()
+        self._ttl_stamped = True
+
+    async def touch_ttl(self) -> None:
+        """Push the safety TTL out. Called from the worker's heartbeat so an
+        in-flight run keeps its live stream however long it takes. A no-op
+        while the log is still empty — EXPIRE on a missing key does nothing."""
+        await self.redis.expire(self._key, run_settings.ttl_seconds)
 
     async def publish_end(self, status: RunStatus) -> str:
         """Append the terminal sentinel. Subscribers stop after reading it."""
@@ -98,4 +153,91 @@ class RunEventStream:
             for chunk in chunks:
                 yield chunk
             if ended:
+                return
+
+
+class BufferedEventPublisher:
+    """Coalesces SSE chunks into pipelined appends.
+
+    Bounded on both axes, because each bound fixes a different failure:
+
+    * **chunks** caps memory and keeps one pipeline small.
+    * **delay** caps *latency*. This is the one that matters for behaviour —
+      these chunks are the tokens a user is watching appear. A count-only buffer
+      would hold the tail of a slow response until enough tokens arrived, which
+      is exactly backwards.
+
+    A background flusher enforces the delay bound, so a run that goes quiet
+    mid-stream (a long tool call) still ships what it has. Flush errors are not
+    swallowed: the flusher records them and the next `publish`/`aclose` re-raises,
+    so a Redis that has gone away still fails the run rather than silently
+    dropping its output.
+
+    Use as an async context manager — exiting drains the buffer, which is what
+    orders the last chunks before `finalize`'s end sentinel.
+    """
+
+    def __init__(
+        self,
+        events: RunEventStream,
+        *,
+        max_chunks: int | None = None,
+        max_delay_seconds: float | None = None,
+    ):
+        self._events = events
+        self._max_chunks = max_chunks or run_settings.event_buffer_max_chunks
+        self._max_delay = (
+            max_delay_seconds
+            if max_delay_seconds is not None
+            else run_settings.event_buffer_max_delay_ms / 1000
+        )
+        self._buffer: list[str] = []
+        self._lock = asyncio.Lock()
+        self._flusher: asyncio.Task | None = None
+        self._error: BaseException | None = None
+
+    async def __aenter__(self) -> "BufferedEventPublisher":
+        self._flusher = asyncio.create_task(self._flush_periodically())
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        await self.aclose()
+
+    async def publish(self, sse: str) -> None:
+        self._raise_pending()
+        async with self._lock:
+            self._buffer.append(sse)
+            if len(self._buffer) >= self._max_chunks:
+                await self._flush_locked()
+
+    async def aclose(self) -> None:
+        """Stop the flusher and drain whatever is left."""
+        if self._flusher is not None:
+            self._flusher.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._flusher
+            self._flusher = None
+        async with self._lock:
+            await self._flush_locked()
+        self._raise_pending()
+
+    def _raise_pending(self) -> None:
+        if self._error is not None:
+            error, self._error = self._error, None
+            raise error
+
+    async def _flush_locked(self) -> None:
+        if not self._buffer:
+            return
+        chunks, self._buffer = self._buffer, []
+        await self._events.publish_many(chunks)
+
+    async def _flush_periodically(self) -> None:
+        while True:
+            await asyncio.sleep(self._max_delay)
+            try:
+                async with self._lock:
+                    await self._flush_locked()
+            except Exception as exc:  # noqa: BLE001 — re-raised on the next publish/aclose
+                self._error = exc
                 return

--- a/backend/app/agents/runs/keys.py
+++ b/backend/app/agents/runs/keys.py
@@ -20,3 +20,14 @@ def run_alive_key(run_id: str) -> str:
     """Self-expiring worker heartbeat; a missing key on a `running` run means
     its worker died (the reaper's signal)."""
     return f"run:{run_id}:alive"
+
+
+def dispatchers_alive_key() -> str:
+    """Self-expiring key stamped by every live `RunDispatcher` in the cluster.
+
+    Answers exactly one question for the reaper: is anything out there able to
+    claim runs? Deliberately one shared key rather than one per instance — the
+    reaper never needs to know *which* dispatcher is alive, and a shared key
+    means the check is one EXISTS instead of a SCAN.
+    """
+    return "run:dispatchers:alive"

--- a/backend/app/agents/runs/liveness.py
+++ b/backend/app/agents/runs/liveness.py
@@ -32,3 +32,23 @@ class RunLiveness:
         """Drop the key on clean finish so the reaper never has to wait out
         the TTL for a run that already finalized."""
         await self.redis.delete(self._key)
+
+
+class DispatcherLiveness:
+    """Cluster-wide "is any dispatcher able to claim runs?" signal.
+
+    Separate from `RunLiveness`, which is per run. Every dispatcher refreshes
+    the same key on its own timer — not from the claim loop, which blocks on a
+    saturated semaphore and would therefore go silent exactly when the answer
+    matters most (see `RunReaper`).
+    """
+
+    def __init__(self, redis: Redis | None = None):
+        self.redis: Redis = redis or get_redis()
+        self._key = keys.dispatchers_alive_key()
+
+    async def stamp(self, *, ttl: int) -> None:
+        await self.redis.set(self._key, "1", ex=ttl)
+
+    async def any_alive(self) -> bool:
+        return bool(await self.redis.exists(self._key))

--- a/backend/app/agents/runs/reaper.py
+++ b/backend/app/agents/runs/reaper.py
@@ -8,16 +8,15 @@ and still stamps `threads.last_run_status`. It also owns the daily retention
 prune of terminal run rows.
 """
 
-import asyncio
 import logging
 import time
-from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 
-from app.agents.runs.liveness import RunLiveness
+from app.agents.runs.liveness import DispatcherLiveness, RunLiveness
 from app.agents.runs.service import RunService
 from app.agents.runs.settings import run_settings
 from app.agents.runs.state import RunStatus
+from app.background import PeriodicLoop
 
 
 logger = logging.getLogger(__name__)
@@ -28,42 +27,76 @@ _PRUNE_INTERVAL_SECONDS = 24 * 3600
 class RunReaper:
     def __init__(self, redis=None):
         self.service = RunService(redis)
-        self._stopping = asyncio.Event()
+        self.dispatchers = DispatcherLiveness(self.service.redis)
         self._last_prune: float | None = None
+        # Run ids that looked dead on the previous sweep — see `_reap_dead_running`.
+        self._suspect: set[str] = set()
+        self._loop = PeriodicLoop(
+            "run-reaper", run_settings.reaper_interval_seconds, self._sweep
+        )
 
     async def run(self) -> None:
-        logger.info(
-            "run reaper started: interval=%ss retention=%sd",
-            run_settings.reaper_interval_seconds,
-            run_settings.retention_days,
-        )
-        while not self._stopping.is_set():
-            try:
-                await self._sweep()
-            except Exception:
-                logger.exception("Reaper sweep failed")
-            await self._sleep(run_settings.reaper_interval_seconds)
+        logger.info("run reaper retention=%sd", run_settings.retention_days)
+        await self._loop.run()
 
     async def _sweep(self) -> None:
         now = datetime.now(UTC)
-        # Dead workers: a running run whose liveness key is gone. The
-        # updated_at grace window covers the claim → first-stamp gap (and any
-        # Redis hiccup shorter than the heartbeat timeout).
+        await self._reap_dead_running(now)
+        await self._reap_undispatched_pending(now)
+        await self._maybe_prune(now)
+
+    async def _reap_dead_running(self, now: datetime) -> None:
+        """Finalize `running` runs whose worker is gone.
+
+        The updated_at grace window covers the claim → first-stamp gap (and any
+        Redis hiccup shorter than the heartbeat timeout).
+
+        Death then has to be observed **twice in a row**. The liveness key is
+        the only evidence, and a Redis restart makes every key missing at once —
+        a single-sample rule would mass-reap a whole cluster of healthy
+        streaming runs. Confirming costs one reaper interval of extra latency on
+        a genuinely dead run and removes that failure mode entirely.
+        """
         grace = timedelta(seconds=run_settings.heartbeat_timeout_seconds)
+        suspect_now: set[str] = set()
         for record in await self.service.list_running():
             if await RunLiveness(record.id, self.service.redis).is_alive():
                 continue
             if now - record.updated_at < grace:
                 continue
+            suspect_now.add(record.id)
+            if record.id not in self._suspect:
+                logger.info(
+                    "Run %s looks dead; waiting for a second sweep to confirm",
+                    record.id,
+                )
+                continue
             logger.warning("Reaping stale running run %s", record.id)
             await self.service.finalize(
                 record.id, RunStatus.error, error="Worker stopped responding."
             )
-        # Queued zombies: pending past the dispatch timeout with an idle
-        # thread (a pending run behind a running one is a legitimate
-        # `enqueue` waiter and is skipped by the query).
-        pending_cutoff = now - timedelta(seconds=run_settings.pending_timeout_seconds)
-        for record in await self.service.list_stuck_pending(pending_cutoff):
+        self._suspect = suspect_now
+
+    async def _reap_undispatched_pending(self, now: datetime) -> None:
+        """Finalize `pending` runs that will never be picked up.
+
+        Only when **no dispatcher in the cluster is alive**. "Pending past the
+        dispatch timeout with an idle thread" is equally the state of every run
+        legitimately queued behind a saturated worker pool — a burst of trigger
+        firings, each on its own fresh thread, produces exactly that shape and
+        used to get healthy runs killed mid-queue. A live dispatcher means the
+        backlog is being worked through; the absence of one is what makes a
+        pending run a zombie. (A pending run behind a *running* one is a
+        legitimate `enqueue` waiter and is skipped by the query itself.)
+
+        Trade-off, on purpose: a dispatcher that is alive but wedged leaves
+        pending runs un-reaped. That is a supervision problem (P1-12), and
+        failing to reap is far cheaper than killing runs that were about to run.
+        """
+        if await self.dispatchers.any_alive():
+            return
+        cutoff = now - timedelta(seconds=run_settings.pending_timeout_seconds)
+        for record in await self.service.list_stuck_pending(cutoff):
             logger.warning("Reaping stuck pending run %s", record.id)
             # expected=pending: if a dispatcher claimed it between the list
             # and this call, the guarded update is a no-op instead of marking
@@ -74,7 +107,6 @@ class RunReaper:
                 error="Run was never dispatched.",
                 expected=RunStatus.pending,
             )
-        await self._maybe_prune(now)
 
     async def _maybe_prune(self, now: datetime) -> None:
         """Daily retention pass: drop terminal run rows past `retention_days`.
@@ -93,10 +125,5 @@ class RunReaper:
         if pruned:
             logger.info("Pruned %s terminal runs older than %s", pruned, cutoff)
 
-    async def _sleep(self, seconds: float) -> None:
-        """Sleep, but wake early if asked to stop."""
-        with suppress(TimeoutError):
-            await asyncio.wait_for(self._stopping.wait(), timeout=seconds)
-
     def stop(self) -> None:
-        self._stopping.set()
+        self._loop.stop()

--- a/backend/app/agents/runs/reaper.py
+++ b/backend/app/agents/runs/reaper.py
@@ -108,25 +108,35 @@ class RunReaper:
         Redis restart makes every key missing at once. A single sample would
         turn a restart into "reap the entire queue".
         """
-        if await self.dispatchers.any_alive():
+        try:
+            if await self.dispatchers.any_alive():
+                self._saw_no_dispatcher = False
+                return
+            if not self._saw_no_dispatcher:
+                self._saw_no_dispatcher = True
+                logger.info(
+                    "No dispatcher alive; waiting for a second sweep to confirm"
+                )
+                return
+            cutoff = now - timedelta(seconds=run_settings.pending_timeout_seconds)
+            for record in await self.service.list_stuck_pending(cutoff):
+                logger.warning("Reaping stuck pending run %s", record.id)
+                # expected=pending: if a dispatcher claimed it between the list
+                # and this call, the guarded update is a no-op instead of marking
+                # a now-running run "never dispatched".
+                await self.service.finalize(
+                    record.id,
+                    RunStatus.error,
+                    error="Run was never dispatched.",
+                    expected=RunStatus.pending,
+                )
+        except Exception:
+            # A sweep that failed observed nothing reliable, so it must not leave
+            # half an observation behind: a Redis or Postgres blip could
+            # otherwise supply one of the two samples and turn the next single
+            # check into a reap. Same reasoning as `_suspect` above.
             self._saw_no_dispatcher = False
-            return
-        if not self._saw_no_dispatcher:
-            self._saw_no_dispatcher = True
-            logger.info("No dispatcher alive; waiting for a second sweep to confirm")
-            return
-        cutoff = now - timedelta(seconds=run_settings.pending_timeout_seconds)
-        for record in await self.service.list_stuck_pending(cutoff):
-            logger.warning("Reaping stuck pending run %s", record.id)
-            # expected=pending: if a dispatcher claimed it between the list
-            # and this call, the guarded update is a no-op instead of marking
-            # a now-running run "never dispatched".
-            await self.service.finalize(
-                record.id,
-                RunStatus.error,
-                error="Run was never dispatched.",
-                expected=RunStatus.pending,
-            )
+            raise
 
     async def _maybe_prune(self, now: datetime) -> None:
         """Daily retention pass: drop terminal run rows past `retention_days`.

--- a/backend/app/agents/runs/reaper.py
+++ b/backend/app/agents/runs/reaper.py
@@ -31,6 +31,9 @@ class RunReaper:
         self._last_prune: float | None = None
         # Run ids that looked dead on the previous sweep — see `_reap_dead_running`.
         self._suspect: set[str] = set()
+        # Whether the previous sweep also found no dispatcher — see
+        # `_reap_undispatched_pending`.
+        self._saw_no_dispatcher = False
         self._loop = PeriodicLoop(
             "run-reaper", run_settings.reaper_interval_seconds, self._sweep
         )
@@ -59,23 +62,30 @@ class RunReaper:
         """
         grace = timedelta(seconds=run_settings.heartbeat_timeout_seconds)
         suspect_now: set[str] = set()
-        for record in await self.service.list_running():
-            if await RunLiveness(record.id, self.service.redis).is_alive():
-                continue
-            if now - record.updated_at < grace:
-                continue
-            suspect_now.add(record.id)
-            if record.id not in self._suspect:
-                logger.info(
-                    "Run %s looks dead; waiting for a second sweep to confirm",
-                    record.id,
+        # `finally`, so a sweep that raises part-way still replaces the previous
+        # suspicions instead of carrying them into the next one — a run left in
+        # `_suspect` by an aborted sweep would be reaped on its very next
+        # missing sample, which is the single-sample rule this exists to avoid.
+        # A partial `suspect_now` errs the safe way: fewer suspects, more sweeps.
+        try:
+            for record in await self.service.list_running():
+                if await RunLiveness(record.id, self.service.redis).is_alive():
+                    continue
+                if now - record.updated_at < grace:
+                    continue
+                suspect_now.add(record.id)
+                if record.id not in self._suspect:
+                    logger.info(
+                        "Run %s looks dead; waiting for a second sweep to confirm",
+                        record.id,
+                    )
+                    continue
+                logger.warning("Reaping stale running run %s", record.id)
+                await self.service.finalize(
+                    record.id, RunStatus.error, error="Worker stopped responding."
                 )
-                continue
-            logger.warning("Reaping stale running run %s", record.id)
-            await self.service.finalize(
-                record.id, RunStatus.error, error="Worker stopped responding."
-            )
-        self._suspect = suspect_now
+        finally:
+            self._suspect = suspect_now
 
     async def _reap_undispatched_pending(self, now: datetime) -> None:
         """Finalize `pending` runs that will never be picked up.
@@ -90,10 +100,20 @@ class RunReaper:
         legitimate `enqueue` waiter and is skipped by the query itself.)
 
         Trade-off, on purpose: a dispatcher that is alive but wedged leaves
-        pending runs un-reaped. That is a supervision problem (P1-12), and
+        pending runs un-reaped. That is what `/health` is for (P1-12), and
         failing to reap is far cheaper than killing runs that were about to run.
+
+        "No dispatcher alive" also has to be seen **twice in a row**, for the
+        same reason the running path does: the evidence is a Redis key, and a
+        Redis restart makes every key missing at once. A single sample would
+        turn a restart into "reap the entire queue".
         """
         if await self.dispatchers.any_alive():
+            self._saw_no_dispatcher = False
+            return
+        if not self._saw_no_dispatcher:
+            self._saw_no_dispatcher = True
+            logger.info("No dispatcher alive; waiting for a second sweep to confirm")
             return
         cutoff = now - timedelta(seconds=run_settings.pending_timeout_seconds)
         for record in await self.service.list_stuck_pending(cutoff):

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -10,7 +10,6 @@ request (worker, reaper, Slack, trigger scanner), and even router calls must
 commit before the response starts streaming.
 """
 
-import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
@@ -141,12 +140,11 @@ class RunService:
         # Local imports avoid an import cycle (runs.service is imported early by
         # the worker/reaper; AgentService and the MCP connectivity layer pull in
         # far more).
-        from sqlmodel import select
-
         from app.agents.core.service import AgentService
-        from app.mcp.client.connectivity import initiate_oauth, is_authorized
+        from app.mcp.client.connectivity import initiate_oauth, probe_authorization
         from app.mcp.client.exceptions import OAuthAuthorizationRequired
-        from app.mcp.servers.models import MCPAuthType, MCPServerDB
+        from app.mcp.servers.models import MCPAuthType
+        from app.mcp.servers.repository import MCPServerRepository
 
         bindings = await AgentService(db).collect_run_bindings(agent_id)
         if not bindings:
@@ -155,32 +153,18 @@ class RunService:
         # Auth is per (user, server), so dedupe server ids — a server shared by
         # the agent and a subagent need only be probed once.
         server_ids = {b.mcp_server_id for b in bindings}
-        stmt = select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
-        result = await db.execute(stmt)
-        servers = [
-            s for s in result.scalars().all() if s.auth_type == MCPAuthType.oauth2
-        ]
+        rows = await MCPServerRepository(db).list_by_ids(server_ids)
+        servers = [s for s in rows if s.auth_type == MCPAuthType.oauth2]
         # DB reads done — release the pooled connection before the probes'
         # network IO (token refresh, OAuth metadata discovery can take
         # seconds). expire_on_commit=False keeps the loaded rows usable.
         await db.commit()
 
-        async def _probe(server) -> bool:
-            try:
-                return await is_authorized(server, user_id)
-            except Exception:  # noqa: BLE001 — fail-open: a probe error must not block the run
-                logger.warning(
-                    "OAuth pre-flight for MCP server %s failed; letting the run launch",
-                    server.id,
-                    exc_info=True,
-                )
-                return True  # fail open
-
-        # Probes are independent per (user, server) — run them concurrently so
-        # the pre-flight costs one round trip, not one per server.
-        results = await asyncio.gather(*(_probe(s) for s in servers))
-        for server, authorized in zip(servers, results, strict=True):
-            if authorized:
+        # Concurrent, fail-open and memoized — shared with the readiness
+        # endpoint, which used to carry a sequential fail-loud copy (§4.1).
+        authorized = await probe_authorization(servers, user_id)
+        for server in servers:
+            if authorized.get(server.id, True):
                 continue
             try:
                 # Raises OAuthAuthorizationRequired(auth_url) for the first
@@ -326,7 +310,12 @@ class RunService:
             record = await repository.get(run_id)
         if thread_id is not None:
             await RunEventStream(run_id, self.redis).publish_end(status)
-            await self._expire_ephemera(run_id)
+        # Unconditional. `thread_id is None` means the terminal UPDATE matched
+        # nothing — the run was already terminal, or its row is gone because the
+        # thread was deleted mid-run (CASCADE). In that second case the ephemera
+        # would otherwise keep no TTL at all and sit in Redis for ever; there is
+        # no second chance, because nothing will ever finalize this run again.
+        await self._expire_ephemera(run_id)
         return record
 
     # --- reaper support -----------------------------------------------------

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -310,12 +310,19 @@ class RunService:
             record = await repository.get(run_id)
         if thread_id is not None:
             await RunEventStream(run_id, self.redis).publish_end(status)
-        # Unconditional. `thread_id is None` means the terminal UPDATE matched
-        # nothing — the run was already terminal, or its row is gone because the
-        # thread was deleted mid-run (CASCADE). In that second case the ephemera
-        # would otherwise keep no TTL at all and sit in Redis for ever; there is
-        # no second chance, because nothing will ever finalize this run again.
-        await self._expire_ephemera(run_id)
+        # `thread_id is None` means the guarded UPDATE matched nothing, which
+        # covers three different situations and only two of them are finished:
+        #   1. the run was already terminal — expire, it is over;
+        #   2. its row is gone (the thread was deleted mid-run and CASCADEd) —
+        #      expire, or the ephemera keep no TTL at all and sit in Redis for
+        #      ever, with no second chance because nothing will finalize it again;
+        #   3. it moved out of `expected` and is **still running** — a pending
+        #      cancel or a reaper sweep losing a race with a dispatcher claim.
+        # Expiring in case 3 would clear a live run's liveness key and hand the
+        # reaper a false "dead worker", which is precisely the failure the
+        # two-sample rule exists to prevent.
+        if thread_id is not None or record is None or is_terminal(record.status):
+            await self._expire_ephemera(run_id)
         return record
 
     # --- reaper support -----------------------------------------------------

--- a/backend/app/agents/runs/settings.py
+++ b/backend/app/agents/runs/settings.py
@@ -1,3 +1,5 @@
+import math
+
 from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
@@ -70,6 +72,13 @@ class RunSettings(BaseSettings):
     @field_validator("claim_interval_seconds", "cancel_poll_seconds", mode="after")
     @classmethod
     def _sub_second_intervals_stay_positive(cls, value: float) -> float:
+        # `nan`/`inf` are rejected rather than clamped: `max(nan, x)` is `nan`,
+        # which then becomes a sleep timeout with undefined behaviour, and `inf`
+        # is a loop that never ticks again. Unlike 0 they express no intent
+        # worth honouring, so failing at boot with a clear error beats a
+        # dispatcher that silently stops dispatching.
+        if not math.isfinite(value):
+            raise ValueError("must be a finite number of seconds")
         return max(value, MIN_INTERVAL_SECONDS)
 
 

--- a/backend/app/agents/runs/settings.py
+++ b/backend/app/agents/runs/settings.py
@@ -1,5 +1,7 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
+from app.background import MIN_INTERVAL_SECONDS
 from app.settings import settings_config
 
 
@@ -50,6 +52,25 @@ class RunSettings(BaseSettings):
     dispatcher_enabled: bool = True
 
     model_config = settings_config(env_prefix="run_")
+
+    # Every interval below drives a `while` loop's sleep. Set to zero, each turns
+    # its loop into a busy spin that burns a core for the life of the process —
+    # and the dispatcher's and the run heartbeat's loops sleep directly, so
+    # `PeriodicLoop`'s own floor does not reach them. Clamped rather than
+    # rejected: an operator writing 0 means "as often as possible", and refusing
+    # to boot over a config typo is the worse failure.
+
+    @field_validator(
+        "heartbeat_interval_seconds", "reaper_interval_seconds", mode="after"
+    )
+    @classmethod
+    def _whole_second_intervals_stay_whole(cls, value: int) -> int:
+        return max(value, 1)
+
+    @field_validator("claim_interval_seconds", "cancel_poll_seconds", mode="after")
+    @classmethod
+    def _sub_second_intervals_stay_positive(cls, value: float) -> float:
+        return max(value, MIN_INTERVAL_SECONDS)
 
 
 run_settings: RunSettings = RunSettings()

--- a/backend/app/agents/runs/settings.py
+++ b/backend/app/agents/runs/settings.py
@@ -28,6 +28,13 @@ class RunSettings(BaseSettings):
     # the reattach/replay window. Run *records* live in Postgres and don't
     # expire; see `retention_days`.
     ttl_seconds: int = 3600
+    # SSE chunks coalesced into one pipelined append. Caps memory and pipeline
+    # size; the delay below is what caps latency.
+    event_buffer_max_chunks: int = 32
+    # Longest a chunk waits in the buffer before being shipped. These are the
+    # tokens a user watches appear, so this is a perceived-latency knob: raising
+    # it trades smoothness for fewer Redis round trips.
+    event_buffer_max_delay_ms: int = 50
     # Reattach tail: how many recent SSE chunks the event stream keeps (approx
     # MAXLEN). NOT the full run history — that lives in the LangGraph checkpoint
     # (Postgres), so trimmed chunks are recoverable and this only needs to cover

--- a/backend/app/agents/runs/worker.py
+++ b/backend/app/agents/runs/worker.py
@@ -257,13 +257,16 @@ class RunDispatcher:
         self._tasks: set[asyncio.Task] = set()
         self._heartbeat: asyncio.Task | None = None
         # Not a `PeriodicLoop`: this loop is not periodic — it blocks on the
-        # semaphore for as long as every slot is busy. It publishes the same
-        # `LoopHealth` so `/health` can see it, with an interval sized to the
-        # longest a *healthy* dispatcher can legitimately go without a pass.
+        # semaphore for as long as every slot is busy, which can be the whole
+        # length of an agent turn. Health is therefore ticked by
+        # `_announce_liveness`, not by the claim loop, and sized to that
+        # cadence. Ticking from the claim loop would make a *fully occupied*
+        # dispatcher look dead within a minute and get a healthy, busy worker
+        # recycled mid-run — worse than the failure /health exists to catch.
         self.health = registry.register(
             LoopHealth(
                 name="run-dispatcher",
-                interval=max(run_settings.claim_interval_seconds, 1.0),
+                interval=run_settings.heartbeat_interval_seconds,
             )
         )
 
@@ -276,26 +279,34 @@ class RunDispatcher:
         self.health.started = True
         self.health.mark_tick()
         self._heartbeat = asyncio.create_task(self._announce_liveness())
-        # Acquire a slot *before* claiming so at most `concurrency` runs are
-        # ever in flight; the loop blocks on `acquire` when saturated.
-        while not self._stopping.is_set():
-            try:
-                await self._claim_and_dispatch()
-            except Exception as exc:
-                # `_claim_one` already absorbs claim failures; reaching here
-                # means the loop's own machinery broke. Without this the
-                # dispatcher died for good and the instance kept serving 200s
-                # while no run ever executed again (design review §2.3).
-                self.health.mark_failure(exc)
-                logger.exception("Run dispatch loop failed; retrying")
-                await self._sleep(min(run_settings.claim_interval_seconds * 4, 5.0))
-        self.health.stopped = True
+        try:
+            # Acquire a slot *before* claiming so at most `concurrency` runs are
+            # ever in flight; the loop blocks on `acquire` when saturated.
+            while not self._stopping.is_set():
+                try:
+                    await self._claim_and_dispatch()
+                except Exception as exc:
+                    # `_claim_one` already absorbs claim failures; reaching here
+                    # means the loop's own machinery broke. Without this the
+                    # dispatcher died for good and the instance kept serving 200s
+                    # while no run ever executed again (design review §2.3).
+                    self.health.mark_failure(exc)
+                    logger.exception("Run dispatch loop failed; retrying")
+                    await self._sleep(min(run_settings.claim_interval_seconds * 4, 5.0))
+        finally:
+            # The heartbeat is what ticks health, so it must not outlive this
+            # loop: an orphaned heartbeat would keep reporting a dispatcher that
+            # is no longer dispatching. `stopped` is set only for a shutdown we
+            # asked for — leaving any other exit to go stale and fail /health.
+            if self._heartbeat is not None:
+                await _cancel(self._heartbeat)
+                self._heartbeat = None
+            self.health.stopped = self._stopping.is_set()
 
     async def _claim_and_dispatch(self) -> None:
         """One pass: take a slot, claim a run, start it."""
         await self._semaphore.acquire()
         record = None if self._stopping.is_set() else await self._claim_one()
-        self.health.mark_tick()
         if record is None:
             self._semaphore.release()
             await self._sleep(run_settings.claim_interval_seconds)
@@ -314,8 +325,13 @@ class RunDispatcher:
         while not self._stopping.is_set():
             try:
                 await self.liveness.stamp(ttl=run_settings.heartbeat_timeout_seconds)
-            except Exception:  # noqa: BLE001 — a blip must not end the heartbeat
+            except Exception as exc:  # noqa: BLE001 — a blip must not end the heartbeat
+                self.health.mark_failure(exc)
                 logger.warning("Dispatcher liveness stamp failed", exc_info=True)
+            else:
+                # This, not the claim loop, is the dispatcher's health signal —
+                # see the note on `self.health` above.
+                self.health.mark_tick()
             await self._sleep(run_settings.heartbeat_interval_seconds)
 
     async def _claim_one(self) -> RunDB | None:

--- a/backend/app/agents/runs/worker.py
+++ b/backend/app/agents/runs/worker.py
@@ -16,14 +16,15 @@ from sqlalchemy.exc import IntegrityError
 
 from app.agents.runs.control import RunControl
 from app.agents.runs.delivery import DeliveryFactory
-from app.agents.runs.events import RunEventStream
-from app.agents.runs.liveness import RunLiveness
+from app.agents.runs.events import BufferedEventPublisher, RunEventStream
+from app.agents.runs.liveness import DispatcherLiveness, RunLiveness
 from app.agents.runs.models import RunDB
 from app.agents.runs.service import RunService
 from app.agents.runs.settings import run_settings
 from app.agents.runs.state import MCP_REAUTH_ERROR, RunStatus
 from app.agents.runtime import Agent
 from app.agents.stream import decode_sse_blocks
+from app.background import LoopHealth, registry
 from app.database import AsyncSessionLocal, get_checkpointer
 from app.exceptions import root_cause
 from app.mcp.client.exceptions import OAuthAuthorizationRequired
@@ -49,6 +50,13 @@ def _error_event_message(sse: str) -> str:
                 return str(data.get("message") or "")
             return str(data or "")
     return ""
+
+
+async def _cancel(task: asyncio.Task) -> None:
+    """Cancel a background task and wait for it to unwind."""
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
 
 
 async def _mcp_unauthorized(db, thread: ThreadDB, user_id: str) -> bool:
@@ -84,7 +92,7 @@ class RunWorker:
         # Stamp before anything else: the reaper treats a running run with no
         # liveness key (past the grace window) as a dead worker.
         await liveness.stamp(ttl=run_settings.heartbeat_timeout_seconds)
-        heartbeat = asyncio.create_task(self._heartbeat(liveness))
+        heartbeat = asyncio.create_task(self._heartbeat(liveness, events))
         cancel_watch = asyncio.create_task(
             RunControl(record.id, self.redis).wait_for_cancel(
                 poll_seconds=run_settings.cancel_poll_seconds
@@ -101,8 +109,8 @@ class RunWorker:
             logger.exception("Run %s failed", record.id)
             status, error = RunStatus.error, str(root_cause(exc))
         finally:
-            await self._stop(heartbeat)
-            await self._stop(cancel_watch)
+            await _cancel(heartbeat)
+            await _cancel(cancel_watch)
         await self.service.finalize(record.id, status, error=error)
         if delivery is not None:
             await delivery  # the sentinel is published; let the consumer finish
@@ -145,7 +153,7 @@ class RunWorker:
             timeout=run_settings.max_duration_seconds or None,
         )
         if not done:  # wall-clock cap elapsed
-            await self._stop(stream_task)
+            await _cancel(stream_task)
             return RunStatus.timeout, None
 
         # A genuine cancel: the watcher completed cleanly with a signal. A failed
@@ -155,7 +163,7 @@ class RunWorker:
             and not cancel_watch.cancelled()
             and cancel_watch.exception() is None
         ):
-            await self._stop(stream_task)
+            await _cancel(stream_task)
             return RunStatus.cancelled, None
         if cancel_watch in done and cancel_watch.exception() is not None:
             logger.warning(
@@ -189,23 +197,44 @@ class RunWorker:
             if await _mcp_unauthorized(db, thread, str(record.user_id)):
                 raise RuntimeError(MCP_REAUTH_ERROR)
             agent = await Agent.build(thread=thread, db=db)
-            async for sse in agent.stream(
-                agent_input=record.input,
-                command=record.command,
-                trigger=record.trigger,
-                config_overrides=record.config_overrides,
-                output_schema=record.output_schema,
-            ):
-                if error_message is None and sse.startswith(_ERROR_EVENT_PREFIX):
-                    error_message = _error_event_message(sse)
-                await events.publish(sse)
+            # Buffered: one awaited XADD per chunk is one Redis round trip per
+            # token, serialized with the agent stream. Exiting the buffer drains
+            # it, which is what keeps the last chunks ahead of `finalize`'s end
+            # sentinel.
+            async with BufferedEventPublisher(events) as publisher:
+                async for sse in agent.stream(
+                    agent_input=record.input,
+                    command=record.command,
+                    trigger=record.trigger,
+                    config_overrides=record.config_overrides,
+                    output_schema=record.output_schema,
+                ):
+                    if error_message is None and sse.startswith(_ERROR_EVENT_PREFIX):
+                        error_message = _error_event_message(sse)
+                    await publisher.publish(sse)
         return error_message
 
-    async def _heartbeat(self, liveness: RunLiveness) -> None:
-        """Keep the liveness key fresh while the run executes."""
+    async def _heartbeat(self, liveness: RunLiveness, events: RunEventStream) -> None:
+        """Keep the liveness key fresh, and the event log's safety TTL pushed
+        out, while the run executes.
+
+        Every tick is wrapped: a single transient Redis error used to kill this
+        loop silently, after which liveness expired and the reaper finalized a
+        perfectly healthy streaming run as `error`. The cancel watcher already
+        got this treatment (`_execute` tolerates a failed watcher); the
+        heartbeat did not.
+        """
         while True:
             await asyncio.sleep(run_settings.heartbeat_interval_seconds)
-            await liveness.stamp(ttl=run_settings.heartbeat_timeout_seconds)
+            try:
+                await liveness.stamp(ttl=run_settings.heartbeat_timeout_seconds)
+                await events.touch_ttl()
+            except Exception:  # noqa: BLE001 — a blip must not end the heartbeat
+                logger.warning(
+                    "Heartbeat for run %s failed; retrying next tick",
+                    liveness.run_id,
+                    exc_info=True,
+                )
 
     async def _is_interrupted(self, thread_id: str) -> bool:
         async with get_checkpointer() as checkpointer:
@@ -213,12 +242,6 @@ class RunWorker:
                 config={"configurable": {"thread_id": thread_id}}
             )
         return checkpoint is not None and pending_interrupt(checkpoint) is not None
-
-    @staticmethod
-    async def _stop(task: asyncio.Task) -> None:
-        task.cancel()
-        with suppress(asyncio.CancelledError):
-            await task
 
 
 class RunDispatcher:
@@ -228,9 +251,21 @@ class RunDispatcher:
     def __init__(self, redis=None, delivery_factory: DeliveryFactory | None = None):
         self.worker = RunWorker(redis, delivery_factory=delivery_factory)
         self.service = self.worker.service
+        self.liveness = DispatcherLiveness(self.service.redis)
         self._semaphore = asyncio.Semaphore(run_settings.worker_concurrency)
         self._stopping = asyncio.Event()
         self._tasks: set[asyncio.Task] = set()
+        self._heartbeat: asyncio.Task | None = None
+        # Not a `PeriodicLoop`: this loop is not periodic — it blocks on the
+        # semaphore for as long as every slot is busy. It publishes the same
+        # `LoopHealth` so `/health` can see it, with an interval sized to the
+        # longest a *healthy* dispatcher can legitimately go without a pass.
+        self.health = registry.register(
+            LoopHealth(
+                name="run-dispatcher",
+                interval=max(run_settings.claim_interval_seconds, 1.0),
+            )
+        )
 
     async def run(self) -> None:
         logger.info(
@@ -238,18 +273,50 @@ class RunDispatcher:
             run_settings.worker_concurrency,
             run_settings.claim_interval_seconds,
         )
+        self.health.started = True
+        self.health.mark_tick()
+        self._heartbeat = asyncio.create_task(self._announce_liveness())
         # Acquire a slot *before* claiming so at most `concurrency` runs are
         # ever in flight; the loop blocks on `acquire` when saturated.
         while not self._stopping.is_set():
-            await self._semaphore.acquire()
-            record = None if self._stopping.is_set() else await self._claim_one()
-            if record is None:
-                self._semaphore.release()
-                await self._sleep(run_settings.claim_interval_seconds)
-                continue
-            task = asyncio.create_task(self._run_one(record))
-            self._tasks.add(task)
-            task.add_done_callback(self._tasks.discard)
+            try:
+                await self._claim_and_dispatch()
+            except Exception as exc:
+                # `_claim_one` already absorbs claim failures; reaching here
+                # means the loop's own machinery broke. Without this the
+                # dispatcher died for good and the instance kept serving 200s
+                # while no run ever executed again (design review §2.3).
+                self.health.mark_failure(exc)
+                logger.exception("Run dispatch loop failed; retrying")
+                await self._sleep(min(run_settings.claim_interval_seconds * 4, 5.0))
+        self.health.stopped = True
+
+    async def _claim_and_dispatch(self) -> None:
+        """One pass: take a slot, claim a run, start it."""
+        await self._semaphore.acquire()
+        record = None if self._stopping.is_set() else await self._claim_one()
+        self.health.mark_tick()
+        if record is None:
+            self._semaphore.release()
+            await self._sleep(run_settings.claim_interval_seconds)
+            return
+        task = asyncio.create_task(self._run_one(record))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _announce_liveness(self) -> None:
+        """Tell the cluster a dispatcher is up, on an independent timer.
+
+        Not stamped from the claim loop above: that loop blocks on
+        `_semaphore.acquire()` while every slot is busy, which is precisely the
+        backlog the reaper must not mistake for "nothing is dispatching".
+        """
+        while not self._stopping.is_set():
+            try:
+                await self.liveness.stamp(ttl=run_settings.heartbeat_timeout_seconds)
+            except Exception:  # noqa: BLE001 — a blip must not end the heartbeat
+                logger.warning("Dispatcher liveness stamp failed", exc_info=True)
+            await self._sleep(run_settings.heartbeat_interval_seconds)
 
     async def _claim_one(self) -> RunDB | None:
         """Claim the next dispatchable run; a claim failure (e.g. a transient
@@ -286,6 +353,9 @@ class RunDispatcher:
         closed connection; the reaper recovers anything left non-terminal.
         """
         self._stopping.set()
+        if self._heartbeat is not None:
+            await _cancel(self._heartbeat)
+            self._heartbeat = None
         if not self._tasks:
             return
         _, pending = await asyncio.wait(self._tasks, timeout=drain_timeout)

--- a/backend/app/agents/runs/worker.py
+++ b/backend/app/agents/runs/worker.py
@@ -24,7 +24,7 @@ from app.agents.runs.settings import run_settings
 from app.agents.runs.state import MCP_REAUTH_ERROR, RunStatus
 from app.agents.runtime import Agent
 from app.agents.stream import decode_sse_blocks
-from app.background import LoopHealth, registry
+from app.background import LoopHealth, register_loop
 from app.database import AsyncSessionLocal, get_checkpointer
 from app.exceptions import root_cause
 from app.mcp.client.exceptions import OAuthAuthorizationRequired
@@ -263,7 +263,7 @@ class RunDispatcher:
         # cadence. Ticking from the claim loop would make a *fully occupied*
         # dispatcher look dead within a minute and get a healthy, busy worker
         # recycled mid-run — worse than the failure /health exists to catch.
-        self.health = registry.register(
+        self.health = register_loop(
             LoopHealth(
                 name="run-dispatcher",
                 interval=run_settings.heartbeat_interval_seconds,

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -26,9 +26,9 @@ from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agents.core.service import AgentService
+from app.agents.core.repository import AgentRepository
 from app.agents.current_date import CurrentDateMiddleware
-from app.agents.schemas import AgentResponse
+from app.agents.run_spec import AgentSpec
 from app.agents.settings import agent_settings
 from app.agents.stream import (
     LangGraphStreamAdapter,
@@ -43,12 +43,12 @@ from app.agents.structured_output import (
 from app.agents.tool_errors import RepairInvalidToolCallsMiddleware, ToolErrorMiddleware
 from app.agents.toolset import PreparedToolset, Toolset, sanitize_tool_name
 from app.database import get_checkpointer
-from app.integrations.langfuse.callback import langfuse_callback_handler
+from app.exceptions import NotFoundError
+from app.integrations.langfuse.callback import get_langfuse_callback_handler
 from app.model_providers.catalog import ChatModelFactory
 from app.model_providers.service import ModelService
 from app.sandbox.lazy import LazySandboxBackend
 from app.sandbox.provider import BaseSandboxProvider, build_provider
-from app.sandbox.repository import SandboxRepository
 from app.threads.models import ThreadDB
 
 
@@ -207,7 +207,7 @@ class ResolvedAgent:
     per-server MCP session, and is the toolset actually handed to the LLM.
     """
 
-    config: AgentResponse
+    config: AgentSpec
     prepared: PreparedToolset
     live: Toolset | None = None
     sandbox: ResolvedSandbox | None = None
@@ -215,29 +215,30 @@ class ResolvedAgent:
     @classmethod
     async def resolve(
         cls,
-        agent_id,
+        spec: AgentSpec,
         db: AsyncSession,
         user_id: str,
         *,
         is_parent: bool = False,
     ) -> "ResolvedAgent":
-        config = await AgentService(db).get(agent_id, include_archived=True)
+        """Bind one agent's spec to a prepared toolset.
+
+        Takes an already-read `AgentSpec` rather than an id: the whole graph
+        comes from a single `get_run_spec`, so resolving a subagent costs no
+        further agent queries (design review §2.2). It also keeps the runtime
+        off `AgentService`/`AgentResponse` — the run path has no business
+        depending on API response assembly.
+        """
         prepared = await Toolset.prepare(
-            config.mcp_servers, db, user_id, apply_ui=is_parent
+            spec.mcp_servers, db, user_id, apply_ui=is_parent
         )
-        sandbox = await cls._resolve_sandbox(config, db)
-        return cls(config=config, prepared=prepared, sandbox=sandbox)
+        return cls(config=spec, prepared=prepared, sandbox=cls._resolve_sandbox(spec))
 
     @staticmethod
-    async def _resolve_sandbox(
-        config: AgentResponse, db: AsyncSession
-    ) -> ResolvedSandbox | None:
-        binding = next(iter(config.sandboxes or []), None)
-        if binding is None:
+    def _resolve_sandbox(spec: AgentSpec) -> ResolvedSandbox | None:
+        if spec.sandbox is None:
             return None
-        row = await SandboxRepository(db).get(binding.sandbox_id)
-        if row is None:
-            return None
+        row = spec.sandbox.row
         try:
             provider = build_provider(row)
         except Exception:
@@ -245,7 +246,7 @@ class ResolvedAgent:
             # kill the whole run — the agent just runs without code execution.
             logger.exception("Failed to build sandbox provider %s", row.id)
             return None
-        return ResolvedSandbox(provider=provider, tools=binding.tools)
+        return ResolvedSandbox(provider=provider, tools=spec.sandbox.tools)
 
     def compile(self, model, created_at: datetime) -> CompiledSubAgent:
         """Compile into a CompiledSubAgent runnable (for subagent use).
@@ -346,9 +347,14 @@ class Agent:
     ) -> "Agent":
         user_id = str(thread.user_id)
 
-        agent = await ResolvedAgent.resolve(
-            thread.agent_id, db, user_id, is_parent=True
-        )
+        # One read for the whole graph. This used to be a full `AgentService.get`
+        # per agent, run sequentially for subagents (§1.2): ~8 + 7N round-trips
+        # before the first token.
+        spec = await AgentRepository(db).get_run_spec(thread.agent_id)
+        if spec is None:
+            raise NotFoundError("Agent not found")
+
+        agent = await ResolvedAgent.resolve(spec.agent, db, user_id, is_parent=True)
 
         # Backstop for the RunService.create gate: covers the race where the
         # model is disabled between enqueue and worker pickup, and any future
@@ -365,14 +371,16 @@ class Agent:
 
         middleware = build_parent_middleware(thread.created_at, agent.prepared)
 
-        subagents: list[ResolvedAgent] = []
-        if agent.config.subagents:
-            for sub in agent.config.subagents:
-                subagents.append(await ResolvedAgent.resolve(sub.id, db, user_id))
+        # Still sequential, and deliberately so: these share one AsyncSession,
+        # which is not concurrency-safe. What used to make that expensive was the
+        # per-agent DB read, and `get_run_spec` has already done all of it — each
+        # resolve is now Redis/CPU work over rows already in hand.
+        subagents = [
+            await ResolvedAgent.resolve(sub, db, user_id) for sub in spec.subagents
+        ]
 
-        callbacks = (
-            [langfuse_callback_handler] if langfuse_callback_handler is not None else []
-        )
+        handler = get_langfuse_callback_handler()
+        callbacks = [handler] if handler is not None else []
 
         return cls(
             thread=thread,

--- a/backend/app/agents/toolset.py
+++ b/backend/app/agents/toolset.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import re
+from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
@@ -9,12 +10,11 @@ from langchain_core.tools import Tool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
-from app.agents.schemas import AgentMCPServerResponse
+from app.agents.models import AgentMCPServerBase
 from app.mcp.client.factory import MCPClientConfigFactory
 from app.mcp.client.tools import inject_ui_metadata_into_tool
-from app.mcp.servers.models import MCPServerDB
+from app.mcp.servers.repository import MCPServerRepository
 
 
 logger = logging.getLogger(__name__)
@@ -387,13 +387,18 @@ class Toolset:
     @classmethod
     async def prepare(
         cls,
-        agent_mcp_servers: list[AgentMCPServerResponse],
+        agent_mcp_servers: Sequence[AgentMCPServerBase],
         db: AsyncSession,
         user_id: str,
         *,
         apply_ui: bool,
     ) -> PreparedToolset:
         """Build-time phase: DB lookup -> configs -> interrupt_on. No network.
+
+        Typed on ``AgentMCPServerBase`` — the column set shared by the binding
+        row and its response DTO — because only ``mcp_server_id`` and ``tools``
+        are read here. The run path passes rows straight from ``RunSpec``; the
+        API paths pass their DTOs.
 
         All DB access happens here (request scope). ``interrupt_on`` is derived
         from the persisted per-agent tool map (synced at connect/save time), so
@@ -412,10 +417,7 @@ class Toolset:
 
         # 1. Load MCP server records from DB
         server_ids = [s.mcp_server_id for s in agent_mcp_servers]
-        result = await db.execute(
-            select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
-        )
-        mcp_servers = list(result.scalars().all())
+        mcp_servers = await MCPServerRepository(db).list_by_ids(server_ids)
 
         # 2. Build MCP client configs (resolves auth to Redis/header values — no
         #    live SQL handle is retained, so the client is safe to use later during

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -53,7 +53,7 @@ class AuthService:
         user = result.scalar_one_or_none()
         if user is None or user.password_hash is None:
             raise InvalidCredentialsError("Invalid email or password")
-        if not verify_password(data.password, user.password_hash):
+        if not await verify_password(data.password, user.password_hash):
             raise InvalidCredentialsError("Invalid email or password")
         return self.build_jwt_for_user(user)
 
@@ -63,7 +63,7 @@ class AuthService:
         user = UserDB(
             email=data.email,
             name=data.name,
-            password_hash=get_password_hash(data.password),
+            password_hash=await get_password_hash(data.password),
             role=WorkspaceRole.admin,
         )
         self.db.add(user)
@@ -81,7 +81,7 @@ class AuthService:
         user = UserDB(
             email=invite.email,
             name=data.name,
-            password_hash=get_password_hash(data.password),
+            password_hash=await get_password_hash(data.password),
             role=WorkspaceRole(invite.role),
             team_id=invite.team_id,
         )

--- a/backend/app/auth/tokens/repository.py
+++ b/backend/app/auth/tokens/repository.py
@@ -30,6 +30,6 @@ class PersonalAccessTokenRepository(BaseRepository[PersonalAccessTokenDB]):
         result = await self.db.execute(stmt)
         candidates = result.scalars().all()
         for pat in candidates:
-            if verify_password(plaintext, pat.token_hash):
+            if await verify_password(plaintext, pat.token_hash):
                 return pat
         return None

--- a/backend/app/auth/tokens/service.py
+++ b/backend/app/auth/tokens/service.py
@@ -25,18 +25,18 @@ class PersonalAccessTokenService(
         super().__init__(db, PersonalAccessTokenRepository(db))
 
     @staticmethod
-    def _generate_token() -> tuple[str, str, str]:
+    async def _generate_token() -> tuple[str, str, str]:
         """Generate a new token. Returns (plaintext, hash, prefix)."""
         raw = secrets.token_urlsafe(32)
         plaintext = f"{TOKEN_PREFIX}{raw}"
         prefix = plaintext[:12]
-        token_hash = get_password_hash(plaintext)
+        token_hash = await get_password_hash(plaintext)
         return plaintext, token_hash, prefix
 
     async def create(
         self, user_id: UUID, name: str
     ) -> tuple[PersonalAccessTokenDB, str]:
-        plaintext, token_hash, prefix = self._generate_token()
+        plaintext, token_hash, prefix = await self._generate_token()
         data = PersonalAccessTokenCreateDB(
             user_id=user_id,
             name=name,

--- a/backend/app/auth/utils.py
+++ b/backend/app/auth/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
@@ -10,18 +11,28 @@ from app.auth.settings import auth_settings
 password_hash = PasswordHash.recommended()
 
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """
-    Verify a plain password against the stored hash.
-    """
-    return password_hash.verify(plain_password, hashed_password)
+# Argon2id is deliberately slow and memory-hard: one verify costs tens of
+# milliseconds of pure CPU. Called inline from a coroutine that blocks the event
+# loop for the whole time, stalling every in-flight SSE stream on the worker, and
+# the PAT prefix scan pays it once per candidate. Both entry points are therefore
+# async and hand the work to a thread: argon2-cffi releases the GIL inside the
+# hash, so the loop really does get that time back (design review §3.1b, P1-2).
 
 
-def get_password_hash(password: str) -> str:
+async def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
-    Hash a password using the recommended algorithm (Argon2id).
+    Verify a plain password against the stored hash, off the event loop.
     """
-    return password_hash.hash(password)
+    return await asyncio.to_thread(
+        password_hash.verify, plain_password, hashed_password
+    )
+
+
+async def get_password_hash(password: str) -> str:
+    """
+    Hash a password with the recommended algorithm (Argon2id), off the event loop.
+    """
+    return await asyncio.to_thread(password_hash.hash, password)
 
 
 def create_access_token(user_id: UUID, expires_delta: timedelta | None = None) -> str:

--- a/backend/app/background.py
+++ b/backend/app/background.py
@@ -123,6 +123,18 @@ class LoopRegistry:
 registry = LoopRegistry()
 
 
+def register_loop(health: LoopHealth) -> LoopHealth:
+    """Register a loop's health with the process-wide registry.
+
+    A function, not `registry.register(...)` at each call site, because
+    `from app.background import registry` binds the object *by value* at import
+    time: a test that swaps `app.background.registry` would then isolate itself
+    from the reader but not from the writers, which is exactly how an "isolated"
+    fixture ends up isolating nothing. This resolves the global on every call.
+    """
+    return registry.register(health)
+
+
 class PeriodicLoop:
     """Runs `tick` every `interval` seconds until stopped, surviving failures.
 
@@ -143,7 +155,7 @@ class PeriodicLoop:
         # sets 0 means "as often as possible", and refusing to start a loop over
         # a config typo is a worse outcome than running it a little slower.
         interval = max(interval, MIN_INTERVAL_SECONDS)
-        self.health = registry.register(LoopHealth(name=name, interval=interval))
+        self.health = register_loop(LoopHealth(name=name, interval=interval))
         self._name = name
         self._interval = interval
         self._tick = tick

--- a/backend/app/background.py
+++ b/backend/app/background.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 
 # Backoff after a failing tick: doubles from the loop's own interval up to this.
 MAX_BACKOFF_SECONDS = 60.0
+# Floor for a loop's interval — see `PeriodicLoop.__init__`.
+MIN_INTERVAL_SECONDS = 0.001
 
 
 @dataclass
@@ -55,7 +57,11 @@ class LoopHealth:
 
     def mark_failure(self, exc: BaseException) -> None:
         self.consecutive_failures += 1
-        self.last_error = repr(exc)
+        # The exception *type* only. `/health` is unauthenticated, so anything
+        # kept here is world-readable; a repr can carry a DSN, a query, or a
+        # token from whatever raised. The full exception goes to the logs, where
+        # it belongs, via the caller's `logger.exception`.
+        self.last_error = type(exc).__name__
 
     @property
     def seconds_since_tick(self) -> float | None:
@@ -89,7 +95,7 @@ class LoopHealth:
                 else round(self.seconds_since_tick, 1)
             ),
             "consecutive_failures": self.consecutive_failures,
-            "last_error": self.last_error,
+            "last_error_type": self.last_error,
         }
 
 
@@ -132,6 +138,11 @@ class PeriodicLoop:
         interval: float,
         tick: Callable[[], Awaitable[None]],
     ):
+        # A non-positive interval makes `_sleep` return instantly and turns the
+        # loop into a busy spin. Clamped rather than rejected: an operator who
+        # sets 0 means "as often as possible", and refusing to start a loop over
+        # a config typo is a worse outcome than running it a little slower.
+        interval = max(interval, MIN_INTERVAL_SECONDS)
         self.health = registry.register(LoopHealth(name=name, interval=interval))
         self._name = name
         self._interval = interval

--- a/backend/app/background.py
+++ b/backend/app/background.py
@@ -1,0 +1,172 @@
+"""Supervised background loops, and a registry so `/health` can see them.
+
+The failure this exists to prevent: a background loop dies, logs one ERROR, and
+the instance carries on answering 200s while nothing executes runs or fires
+triggers ever again (design review §2.3). On Cloud Run that instance also keeps
+passing its health check, so nothing recycles it — the deployment is broken and
+looks fine.
+
+Two halves, and both are needed:
+
+* **Supervision** — a raising tick is logged and retried with exponential
+  backoff, so a transient failure (Postgres failing over, Redis blipping) costs
+  a retry rather than the loop. `TriggerScanner` and `RunReaper` already caught
+  per-tick exceptions; what they lacked was backoff, so a persistent failure
+  became a tight error-logging spin.
+* **Reporting** — supervision cannot save a loop from a bug in the supervisor,
+  a cancellation, or a `BaseException`. Liveness is therefore published, not
+  assumed, and `/health` fails the instance when a loop has stopped ticking.
+"""
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from dataclasses import dataclass, field
+
+
+logger = logging.getLogger(__name__)
+
+# Backoff after a failing tick: doubles from the loop's own interval up to this.
+MAX_BACKOFF_SECONDS = 60.0
+
+
+@dataclass
+class LoopHealth:
+    """What a loop publishes about itself.
+
+    `last_tick_at` is `time.monotonic()`, not a wall clock: it is only ever read
+    as an age, and a wall clock can jump.
+    """
+
+    name: str
+    interval: float
+    started: bool = False
+    stopped: bool = False
+    last_tick_at: float | None = None
+    consecutive_failures: int = 0
+    last_error: str | None = None
+
+    def mark_tick(self) -> None:
+        self.last_tick_at = time.monotonic()
+        self.consecutive_failures = 0
+        self.last_error = None
+
+    def mark_failure(self, exc: BaseException) -> None:
+        self.consecutive_failures += 1
+        self.last_error = repr(exc)
+
+    @property
+    def seconds_since_tick(self) -> float | None:
+        if self.last_tick_at is None:
+            return None
+        return time.monotonic() - self.last_tick_at
+
+    def is_healthy(self, *, tolerance: float = 3.0) -> bool:
+        """Healthy while it is ticking roughly on schedule.
+
+        A loop that has been asked to stop is healthy — that is shutdown, not
+        failure. One that has started but never ticked is judged on the same
+        deadline as a running one, so a loop that dies on its very first tick is
+        still caught.
+        """
+        if self.stopped or not self.started:
+            return True
+        deadline = self.interval * tolerance + MAX_BACKOFF_SECONDS
+        age = self.seconds_since_tick
+        return age is not None and age <= deadline
+
+    def snapshot(self) -> dict:
+        return {
+            "name": self.name,
+            "healthy": self.is_healthy(),
+            "started": self.started,
+            "stopped": self.stopped,
+            "seconds_since_tick": (
+                None
+                if self.seconds_since_tick is None
+                else round(self.seconds_since_tick, 1)
+            ),
+            "consecutive_failures": self.consecutive_failures,
+            "last_error": self.last_error,
+        }
+
+
+@dataclass
+class LoopRegistry:
+    """Every background loop this process is supposed to be running."""
+
+    loops: list[LoopHealth] = field(default_factory=list)
+
+    def register(self, health: LoopHealth) -> LoopHealth:
+        self.loops.append(health)
+        return health
+
+    def clear(self) -> None:
+        self.loops.clear()
+
+    @property
+    def healthy(self) -> bool:
+        return all(loop.is_healthy() for loop in self.loops)
+
+    def snapshot(self) -> list[dict]:
+        return [loop.snapshot() for loop in self.loops]
+
+
+registry = LoopRegistry()
+
+
+class PeriodicLoop:
+    """Runs `tick` every `interval` seconds until stopped, surviving failures.
+
+    Deliberately not a base class: the two loops that fit this shape (the reaper
+    and the trigger scanner) keep owning their own tick, and `RunDispatcher` —
+    which is not periodic at all, it blocks on a semaphore — reuses `LoopHealth`
+    without pretending to be one.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        interval: float,
+        tick: Callable[[], Awaitable[None]],
+    ):
+        self.health = registry.register(LoopHealth(name=name, interval=interval))
+        self._name = name
+        self._interval = interval
+        self._tick = tick
+        self._stopping = asyncio.Event()
+
+    async def run(self) -> None:
+        logger.info("%s started: interval=%ss", self._name, self._interval)
+        self.health.started = True
+        self.health.mark_tick()  # not yet stale at t=0
+        backoff = self._interval
+        while not self._stopping.is_set():
+            try:
+                await self._tick()
+            except Exception as exc:
+                self.health.mark_failure(exc)
+                logger.exception(
+                    "%s tick failed (%s consecutive); retrying in %.1fs",
+                    self._name,
+                    self.health.consecutive_failures,
+                    backoff,
+                )
+                await self._sleep(backoff)
+                backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+                continue
+            self.health.mark_tick()
+            backoff = self._interval
+            await self._sleep(self._interval)
+        self.health.stopped = True
+
+    async def _sleep(self, seconds: float) -> None:
+        """Sleep, but wake early if asked to stop."""
+        with suppress(TimeoutError):
+            await asyncio.wait_for(self._stopping.wait(), timeout=seconds)
+
+    def stop(self) -> None:
+        self._stopping.set()
+        self.health.stopped = True

--- a/backend/app/integrations/langfuse/__init__.py
+++ b/backend/app/integrations/langfuse/__init__.py
@@ -1,4 +1,4 @@
-from .callback import langfuse_callback_handler
+from .callback import flush_langfuse, get_langfuse_callback_handler
 
 
-__all__ = ["langfuse_callback_handler"]
+__all__ = ["flush_langfuse", "get_langfuse_callback_handler"]

--- a/backend/app/integrations/langfuse/callback.py
+++ b/backend/app/integrations/langfuse/callback.py
@@ -1,7 +1,29 @@
+"""The Langfuse client and LangChain callback handler, built lazily.
+
+Lazily on purpose. These used to be module-level constants, evaluated at import
+time — and `runtime.py` imports this module, so *any* failure constructing the
+client (a malformed base URL, a Langfuse SDK that validates eagerly) took down
+every import of the agent runtime, at startup, for an optional integration
+(design review §5.10). Now a bad configuration can at worst break tracing.
+
+The result is memoized rather than rebuilt per call: `CallbackHandler` is passed
+into every agent run, and a fresh client per run would mean a fresh exporter
+thread per run.
+"""
+
+import logging
+
 from langfuse import Langfuse
 from langfuse.langchain import CallbackHandler
 
 from app.integrations.langfuse.settings import langfuse_settings
+
+
+logger = logging.getLogger(__name__)
+
+_client: Langfuse | None = None
+_handler: CallbackHandler | None = None
+_built = False
 
 
 def _build_langfuse() -> tuple[Langfuse | None, CallbackHandler | None]:
@@ -21,4 +43,44 @@ def _build_langfuse() -> tuple[Langfuse | None, CallbackHandler | None]:
     return client, CallbackHandler()
 
 
-langfuse, langfuse_callback_handler = _build_langfuse()
+def _ensure_built() -> None:
+    """Build the client once, tolerating failure.
+
+    Tracing is optional; the agent runtime is not. A construction error is
+    logged and remembered as "no tracing" rather than retried per run.
+    """
+    global _client, _handler, _built
+    if _built:
+        return
+    _built = True
+    try:
+        _client, _handler = _build_langfuse()
+    except Exception:
+        # Tracing must never break a run.
+        logger.exception("Langfuse is misconfigured; continuing without tracing")
+        _client, _handler = None, None
+
+
+def get_langfuse_callback_handler() -> CallbackHandler | None:
+    """The handler to attach to a run's callbacks, or None when unconfigured."""
+    _ensure_built()
+    return _handler
+
+
+def flush_langfuse() -> None:
+    """Flush buffered traces. Called from the FastAPI lifespan on shutdown.
+
+    Langfuse batches spans and ships them on a background timer. On Cloud Run
+    the instance is frozen and killed the moment the last request drains, so
+    without this the tail of every scale-to-zero cycle is simply lost — and the
+    tail is disproportionately where the interesting runs are.
+
+    Never built here: flushing must not be the thing that constructs a client
+    the process never needed.
+    """
+    if _client is None:
+        return
+    try:
+        _client.flush()
+    except Exception:  # noqa: BLE001 — a failed flush must not fail shutdown
+        logger.warning("Flushing Langfuse traces on shutdown failed", exc_info=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.agents.runs.worker import RunDispatcher
 from app.auth.router import router as auth_router
 from app.auth.settings import auth_settings
 from app.auth.tokens.router import router as tokens_router
+from app.background import registry as background_loops
 from app.database import close_checkpointer_pool
 from app.exceptions import (
     AlreadyExistsError,
@@ -27,6 +28,7 @@ from app.exceptions import (
     NotFoundError,
     PermissionDeniedError,
 )
+from app.integrations.langfuse.callback import flush_langfuse
 from app.integrations.slack.consumer import build_slack_run_consumer
 from app.integrations.slack.router import router as slack_router
 from app.invites.router import router as invites_router
@@ -65,6 +67,10 @@ def _log_background_crash(task: asyncio.Task) -> None:
 async def lifespan(app: FastAPI):
     apply_mcp_client_patches()
     app.state.redis = get_redis()
+    # Loops register themselves on construction, so start from empty: a test
+    # app (or a reload) would otherwise accumulate entries for loops that no
+    # longer exist and report the instance unhealthy for ever.
+    background_loops.clear()
 
     # The dispatcher + reaper are background loops; they need an always-on
     # instance with CPU allocated (Cloud Run: --no-cpu-throttling, min-instances>=1).
@@ -103,6 +109,12 @@ async def lifespan(app: FastAPI):
             for task in background:
                 task.cancel()
             await asyncio.gather(*background, return_exceptions=True)
+            # Ship buffered traces before the instance is frozen. Langfuse
+            # batches spans on a background timer, and on Cloud Run there is no
+            # timer left once the last request drains — without this, the tail
+            # of every scale-to-zero cycle is lost. Runs in a thread: the SDK's
+            # flush is blocking, and this is the event loop's last breath.
+            await asyncio.to_thread(flush_langfuse)
             await close_checkpointer_pool()
             await close_redis()
 
@@ -213,6 +225,28 @@ app.add_middleware(
     same_site="lax",
     https_only=auth_settings.COOKIE_SECURE,
 )
+
+
+@app.get("/health", tags=["health"])
+async def health() -> JSONResponse:
+    """Liveness for the instance, including its background loops.
+
+    Returns 503 when a loop this process is supposed to be running has stopped
+    ticking. That is the point: a dead dispatcher used to leave an instance
+    answering 200s while no run ever executed again, so nothing recycled it and
+    the deployment looked healthy while being entirely broken (§2.3).
+
+    An instance with `RUN_DISPATCHER_ENABLED=false` registers no loops and is
+    simply healthy — request-only instances are a supported deployment, not a
+    degraded one.
+    """
+    loops = background_loops.snapshot()
+    healthy = background_loops.healthy
+    return JSONResponse(
+        status_code=200 if healthy else 503,
+        content={"status": "ok" if healthy else "degraded", "loops": loops},
+    )
+
 
 app.include_router(agents_router)
 app.include_router(runs_router)

--- a/backend/app/mcp/client/connectivity.py
+++ b/backend/app/mcp/client/connectivity.py
@@ -17,8 +17,11 @@ Two distinct questions live here, deliberately kept apart:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections.abc import Collection
 from contextlib import asynccontextmanager
+from uuid import UUID
 
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
@@ -31,6 +34,7 @@ from app.mcp.client.storage import RedisTokenStorage, TokenStorageFactory
 from app.mcp.servers.models import MCPAuthType, MCPServerDB
 from app.mcp.servers.repository import MCPServerRepository
 from app.mcp.servers.schemas import ConnectionTestResult
+from app.redis_client import get_redis
 from app.utils.encryption import decrypt_value
 
 
@@ -120,8 +124,14 @@ async def _open_session(
 
     The low-level primitive shared by every handshake path: the DB-backed
     :func:`connect_to_server` and the stateless :func:`probe_candidate`. Errors
-    raised while listing tools (or from the ``async with`` body) are wrapped in
-    ``DomainError`` to give callers a clean message.
+    raised **while listing tools** are wrapped in ``DomainError`` to give callers
+    a clean message.
+
+    The ``yield`` deliberately sits *outside* that wrapping. It used to be
+    inside, which meant any exception raised by the caller's ``async with`` body
+    — a domain error, a bug, anything — travelled back through this generator
+    and got laundered into a ``DomainError``, i.e. a 500 with someone else's
+    message (design review §5.7).
     """
     client_args: dict = {"url": url}
     if headers:
@@ -140,13 +150,13 @@ async def _open_session(
             await session.initialize()
             try:
                 tools = await _list_all_tools(session)
-                yield session, tools
             except OAuthAuthorizationRequired:
                 # Let the caller (e.g. test_connection) translate this into an
                 # oauth_required result instead of a generic DomainError.
                 raise
             except Exception as e:
                 raise DomainError(str(e)) from e
+            yield session, tools
 
 
 @asynccontextmanager
@@ -228,6 +238,96 @@ async def is_authorized(
     await provider._initialize()
     tokens = await provider.context.storage.get_tokens()
     return tokens is not None
+
+
+# A probe of an *authorized* OAuth server is the expensive one: it decrypts the
+# stored token and, when it has expired, does a token-refresh POST to the IdP.
+# The frontend polls readiness in a loop, so without a cache every poll pays
+# that — per server, per agent, forever.
+#
+# Only positives are cached. A negative is already cheap (no stored token, so
+# the probe returns without any network work), and caching it would leave a
+# user who has just completed the OAuth popup staring at "not connected" for the
+# length of the TTL. The cost of that choice is the other direction: a token
+# revoked at the IdP keeps reading as authorized for up to the TTL. Thirty
+# seconds of lag before the run fails in-thread is the cheaper mistake.
+_PROBE_CACHE_TTL_SECONDS = 30
+
+
+def _probe_cache_key(user_id: str, server_id: UUID) -> str:
+    return f"mcp:authprobe:{user_id}:{server_id}"
+
+
+async def probe_authorization(
+    servers: Collection[MCPServerDB], user_id: str
+) -> dict[UUID, bool]:
+    """Whether the user is authorized for each server — concurrent, fail-open,
+    and memoized per (user, server).
+
+    The single implementation behind both the polled readiness endpoint and the
+    run-start preflight, which used to carry divergent copies: one sequential
+    and fail-loud (so a single probe raising 500'd the polled endpoint), one
+    concurrent and fail-open (design review §4.1).
+
+    **Fail-open**: a probe that raises counts as authorized. Readiness is a
+    convenience, not a security boundary — the server itself rejects an
+    unauthorized call — so an IdP outage must not make every agent unlaunchable.
+
+    Probes are independent per (user, server), so they run concurrently: the
+    check costs one round trip, not one per server.
+    """
+    if not servers:
+        return {}
+
+    redis = get_redis()
+    unique = {server.id: server for server in servers}
+
+    try:
+        cached = await redis.mget([_probe_cache_key(user_id, sid) for sid in unique])
+    except Exception:  # noqa: BLE001 — a cache outage degrades to probing, never to failing
+        logger.warning("Authorization probe cache read failed", exc_info=True)
+        cached = [None] * len(unique)
+
+    results: dict[UUID, bool] = {}
+    to_probe: list[MCPServerDB] = []
+    for (server_id, server), hit in zip(unique.items(), cached, strict=True):
+        if hit == "1":
+            results[server_id] = True
+        else:
+            to_probe.append(server)
+
+    async def _probe(server: MCPServerDB) -> bool:
+        try:
+            return await is_authorized(server, user_id)
+        except Exception:  # noqa: BLE001 — fail-open, see the docstring
+            logger.warning(
+                "Authorization probe for MCP server %s failed; treating as authorized",
+                server.id,
+                exc_info=True,
+            )
+            return True
+
+    probed = await asyncio.gather(*(_probe(server) for server in to_probe))
+    authorized_ids: list[UUID] = []
+    for server, ok in zip(to_probe, probed, strict=True):
+        results[server.id] = ok
+        if ok:
+            authorized_ids.append(server.id)
+
+    if authorized_ids:
+        try:
+            async with redis.pipeline(transaction=False) as pipe:
+                for server_id in authorized_ids:
+                    pipe.set(
+                        _probe_cache_key(user_id, server_id),
+                        "1",
+                        ex=_PROBE_CACHE_TTL_SECONDS,
+                    )
+                await pipe.execute()
+        except Exception:  # noqa: BLE001 — a cache outage degrades to probing, never to failing
+            logger.warning("Authorization probe cache write failed", exc_info=True)
+
+    return results
 
 
 async def initiate_oauth(server: MCPServerDB, user_id: str, db: AsyncSession) -> None:

--- a/backend/app/mcp/client/connectivity.py
+++ b/backend/app/mcp/client/connectivity.py
@@ -252,10 +252,23 @@ async def is_authorized(
 # revoked at the IdP keeps reading as authorized for up to the TTL. Thirty
 # seconds of lag before the run fails in-thread is the cheaper mistake.
 _PROBE_CACHE_TTL_SECONDS = 30
+# The fail-open handlers below only catch *raised* errors. A Redis that accepts
+# the connection and then stalls would hang the polled readiness endpoint and
+# the run-start preflight indefinitely, so every cache round trip gets a
+# deadline. The cache is an optimization; missing it costs a probe.
+_CACHE_TIMEOUT_SECONDS = 2.0
 
 
 def _probe_cache_key(user_id: str, server_id: UUID) -> str:
-    return f"mcp:authprobe:{user_id}:{server_id}"
+    """Deliberately shaped `mcp:{user}:{server}:...`, matching `RedisTokenStorage`.
+
+    That layout is what `TokenStorageFactory.clear_server_data` /
+    `clear_user_server_data` scan (`mcp:*:{server_id}:*`). A key outside it
+    survives every purge, so a user who revoked their connection — or a server
+    whose URL or auth type just changed — would keep reading as authorized until
+    this TTL lapsed, from a cache nothing knows how to invalidate.
+    """
+    return f"mcp:{user_id}:{server_id}:authprobe"
 
 
 async def probe_authorization(
@@ -283,7 +296,10 @@ async def probe_authorization(
     unique = {server.id: server for server in servers}
 
     try:
-        cached = await redis.mget([_probe_cache_key(user_id, sid) for sid in unique])
+        async with asyncio.timeout(_CACHE_TIMEOUT_SECONDS):
+            cached = await redis.mget(
+                [_probe_cache_key(user_id, sid) for sid in unique]
+            )
     except Exception:  # noqa: BLE001 — a cache outage degrades to probing, never to failing
         logger.warning("Authorization probe cache read failed", exc_info=True)
         cached = [None] * len(unique)
@@ -316,14 +332,15 @@ async def probe_authorization(
 
     if authorized_ids:
         try:
-            async with redis.pipeline(transaction=False) as pipe:
-                for server_id in authorized_ids:
-                    pipe.set(
-                        _probe_cache_key(user_id, server_id),
-                        "1",
-                        ex=_PROBE_CACHE_TTL_SECONDS,
-                    )
-                await pipe.execute()
+            async with asyncio.timeout(_CACHE_TIMEOUT_SECONDS):
+                async with redis.pipeline(transaction=False) as pipe:
+                    for server_id in authorized_ids:
+                        pipe.set(
+                            _probe_cache_key(user_id, server_id),
+                            "1",
+                            ex=_PROBE_CACHE_TTL_SECONDS,
+                        )
+                    await pipe.execute()
         except Exception:  # noqa: BLE001 — a cache outage degrades to probing, never to failing
             logger.warning("Authorization probe cache write failed", exc_info=True)
 

--- a/backend/app/mcp/client/storage.py
+++ b/backend/app/mcp/client/storage.py
@@ -6,7 +6,7 @@ from mcp.shared.auth import OAuthClientInformationFull, OAuthMetadata, OAuthToke
 from pydantic import BaseModel
 from redis.asyncio import Redis
 
-from app.settings import app_settings
+from app.redis_client import get_redis
 from app.utils.encryption import decrypt_value, encrypt_value
 
 
@@ -34,17 +34,12 @@ class RedisTokenStorage(TokenStorage):
         user_id: str,
         mcp_server_id: str,
         *,
-        host: str = "localhost",
-        port: int = 6379,
-        db: int = 0,
+        redis: Redis,
         prefix: str = "mcp",
-        redis: Redis | None = None,
     ):
         self.user_id = str(user_id)
         self.mcp_server_id = str(mcp_server_id)
-        self.redis: Redis = redis or Redis(
-            host=host, port=port, db=db, decode_responses=True
-        )
+        self.redis = redis
         self._prefix = prefix
 
     def _base(self) -> str:
@@ -166,21 +161,23 @@ class RedisTokenStorage(TokenStorage):
     async def delete_verifier(self, state: str) -> None:
         await self.redis.delete(self._state_key(state, self._prefix))
 
-    async def aclose(self) -> None:
-        await self.redis.close()
-
 
 class TokenStorageFactory:
-    """Factory for creating token storage instances."""
+    """Factory for creating token storage instances.
 
-    def __init__(self):
-        self.redis = Redis(
-            host=app_settings.redis_host,
-            port=app_settings.redis_port,
-            db=app_settings.redis_db,
-            password=app_settings.redis_password,
-            decode_responses=True,
-        )
+    Holds no connection of its own: it borrows the app-wide client from
+    `app.redis_client`, which the FastAPI lifespan closes on shutdown. This class
+    used to build a fresh `ConnectionPool` in its constructor and was constructed
+    per call at eight sites — every readiness probe, is-connected poll, agent
+    build and OAuth callback leaked a pool that nothing ever closed (design
+    review §3.3, P1-3). Constructing it is now cheap, so the call sites are left
+    as they are.
+
+    `redis` is injectable for tests; production always takes the default.
+    """
+
+    def __init__(self, redis: Redis | None = None):
+        self.redis = redis if redis is not None else get_redis()
 
     def get_storage(self, user_id: str, mcp_server_id: str) -> RedisTokenStorage:
         return RedisTokenStorage(user_id, mcp_server_id, redis=self.redis)

--- a/backend/app/mcp/servers/repository.py
+++ b/backend/app/mcp/servers/repository.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from uuid import UUID
 
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -21,6 +23,19 @@ class MCPServerRepository(BaseRepository[MCPServerDB]):
 
     async def list(self) -> list[MCPServerDB]:
         stmt = select(MCPServerDB).order_by(MCPServerDB.created_at.asc())
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_by_ids(self, server_ids: Collection[UUID]) -> list[MCPServerDB]:
+        """The servers behind a set of agent bindings, in one `IN` query.
+
+        Order is unspecified — every caller looks rows up by id. An empty
+        `server_ids` short-circuits: `IN ()` is a round-trip for a known-empty
+        answer.
+        """
+        if not server_ids:
+            return []
+        stmt = select(MCPServerDB).where(MCPServerDB.id.in_(server_ids))
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 
@@ -78,6 +93,19 @@ class MCPServerRepository(BaseRepository[MCPServerDB]):
                     created_by=None,
                 )
             )
+        await self.db.flush()
+
+    async def delete_credentials(self, server_id: UUID, *, api_key: bool) -> None:
+        """Drop the stored credentials a server no longer has any use for.
+
+        `api_key=True` removes the API-key row, otherwise the OAuth-credentials
+        row. Called when a server's `auth_type` changes: the leftover row is
+        dead config that `list_responses` already has to gate on the current
+        auth type to avoid showing.
+        """
+        model = MCPServerAPIKeyDB if api_key else MCPServerOAuthCredentialsDB
+        stmt = delete(model).where(model.mcp_server_id == server_id)
+        await self.db.execute(stmt)
         await self.db.flush()
 
     async def get_oauth_credentials(

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -36,6 +37,9 @@ from app.mcp.servers.schemas import (
 from app.service import BaseService
 from app.users.repository import UserRepository
 from app.utils.encryption import decrypt_value
+
+
+logger = logging.getLogger(__name__)
 
 
 class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
@@ -114,9 +118,17 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
 
     async def update(self, server_id: UUID, data: MCPServerPatch) -> MCPServerDB:
         server = await self.get_or_404(server_id)
+        # Read before the patch is applied: both are needed to decide what
+        # stored state the edit has invalidated (see `_purge_invalidated_state`).
+        previous_auth_type = server.auth_type
+        previous_url = server.url
         # Credential fields are excluded from serialization, so repository.update
         # only touches the mcp_servers row; secrets are persisted separately.
         updated = await self.repository.update(server, data)
+
+        await self._purge_invalidated_state(
+            server_id, updated, previous_auth_type, previous_url
+        )
 
         if data.api_key:
             await self.repository.create_or_update_api_key(server_id, data.api_key)
@@ -137,6 +149,64 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
             )
 
         return updated
+
+    async def _purge_invalidated_state(
+        self,
+        server_id: UUID,
+        updated: MCPServerDB,
+        previous_auth_type: MCPAuthType,
+        previous_url: str,
+    ) -> None:
+        """Drop stored state the edit has just made meaningless.
+
+        Two triggers, with deliberately different blast radii (design review
+        §5.8 — this used to do nothing at all, orphaning credential rows and
+        leaving every user holding tokens minted for the old resource):
+
+        * **URL changed** — every per-user Redis artefact was issued *for the
+          old resource*: access and refresh tokens, the DCR client registration,
+          the cached authorization-server metadata. None of it is valid against
+          a different URL, and a stale refresh token is worse than none because
+          `is_authorized` will keep reporting the user as connected.
+          Admin-entered credential rows are **kept**: a static client id/secret
+          is configuration the admin typed, and an admin re-pointing a server at
+          a new path of the same provider must not silently lose it.
+        * **Auth type changed** — the same Redis purge, plus the credential row
+          for the scheme being left. That row is dead config; `list_responses`
+          already has to gate `oauth_client_id` on the current auth type
+          precisely because it could linger.
+
+        Redis purging is best-effort: a cache that is down must not fail the
+        edit. The cost of a miss is a stale token, which the next authorization
+        overwrites anyway.
+        """
+        auth_type_changed = updated.auth_type != previous_auth_type
+        if not auth_type_changed and updated.url == previous_url:
+            return
+
+        if auth_type_changed:
+            if previous_auth_type == MCPAuthType.api_key:
+                await self.repository.delete_credentials(server_id, api_key=True)
+            elif previous_auth_type == MCPAuthType.oauth2:
+                await self.repository.delete_credentials(server_id, api_key=False)
+
+        try:
+            deleted = await TokenStorageFactory().clear_server_data(str(server_id))
+        except Exception:  # noqa: BLE001 — a cache outage must not fail the edit
+            logger.warning(
+                "Could not purge stored tokens for MCP server %s after an edit; "
+                "users may need to reconnect manually",
+                server_id,
+                exc_info=True,
+            )
+            return
+        if deleted:
+            logger.info(
+                "Purged %s stored Redis keys for MCP server %s after an auth-type/URL "
+                "change; affected users must reconnect",
+                deleted,
+                server_id,
+            )
 
     async def list_agents(self, server_id: UUID) -> list[MCPServerAgentResponse]:
         """Agents currently bound to the server (delete-guard dialog)."""

--- a/backend/app/mcp/servers/service.py
+++ b/backend/app/mcp/servers/service.py
@@ -194,8 +194,8 @@ class MCPServerService(BaseService[MCPServerDB, MCPServerRepository]):
             deleted = await TokenStorageFactory().clear_server_data(str(server_id))
         except Exception:  # noqa: BLE001 — a cache outage must not fail the edit
             logger.warning(
-                "Could not purge stored tokens for MCP server %s after an edit; "
-                "users may need to reconnect manually",
+                "Could not purge stored authorization state for MCP server %s after "
+                "an edit; users may need to reconnect manually",
                 server_id,
                 exc_info=True,
             )

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter, Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.core.service import AgentService, get_agent_service
 from app.agents.stream import _serialize_lc_message
 from app.agents.structured_output import is_structured_output_artifact
 from app.auth.dependencies import detect_auth_method, get_current_user
-from app.database import get_checkpointer
+from app.database import get_checkpointer, get_db
 from app.exceptions import PermissionDeniedError
 from app.pagination import Page, PageParams
 from app.threads.models import ThreadDB, ThreadSource
@@ -225,11 +226,18 @@ async def delete_thread(
     thread_id: str,
     current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
+    db: AsyncSession = Depends(get_db),  # dependency-cached: the service's session
 ) -> None:
     thread = await service.get(thread_id)
     if thread.user_id != current_user.id:
         raise PermissionDeniedError("Not authorized to delete this thread")
-    async with get_checkpointer() as checkpointer:
-        await checkpointer.adelete_thread(thread_id=thread_id)
-
     await service.delete(thread_id)
+    # Commit the row delete BEFORE purging checkpoints — the order
+    # `purge_checkpoints` documents, and the reverse of what this endpoint used
+    # to do. Checkpoints live on a separate auto-committed connection and cannot
+    # be rolled back, so purging first meant a failed commit left a thread whose
+    # entire history was irrecoverably gone (design review §5.5). The other
+    # direction fails safe: a purge that errors leaves a deleted thread's
+    # checkpoints orphaned, which is invisible and reclaimable.
+    await db.commit()
+    await service.purge_checkpoints([thread_id])

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +16,8 @@ from app.threads.serialization import deserialize_to_ui_messages, pending_interr
 from app.threads.service import ThreadService, get_thread_service
 from app.users.models import UserDB
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/threads", tags=["threads"])
 
@@ -240,4 +244,15 @@ async def delete_thread(
     # direction fails safe: a purge that errors leaves a deleted thread's
     # checkpoints orphaned, which is invisible and reclaimable.
     await db.commit()
-    await service.purge_checkpoints([thread_id])
+    # Past the commit the delete has happened, so a purge failure must not turn
+    # into a 500: the client would retry and get a 404 for a thread that really
+    # is gone. Orphaned checkpoints are invisible and reclaimable; a confusing
+    # error on a successful operation is not. Logged loudly so they can be.
+    try:
+        await service.purge_checkpoints([thread_id])
+    except Exception:
+        logger.exception(
+            "Thread %s was deleted but its checkpoints could not be purged; "
+            "they are now orphaned",
+            thread_id,
+        )

--- a/backend/app/triggers/scanner.py
+++ b/backend/app/triggers/scanner.py
@@ -7,10 +7,9 @@ claim/commit/enqueue choreography. `FOR UPDATE SKIP LOCKED` in the claim query
 makes it safe to run the scanner on every instance; no leader election.
 """
 
-import asyncio
 import logging
-from contextlib import suppress
 
+from app.background import PeriodicLoop
 from app.database import AsyncSessionLocal
 from app.triggers.service import TriggerService
 from app.triggers.settings import trigger_settings
@@ -21,19 +20,12 @@ logger = logging.getLogger(__name__)
 
 class TriggerScanner:
     def __init__(self):
-        self._stopping = asyncio.Event()
+        self._loop = PeriodicLoop(
+            "trigger-scanner", trigger_settings.scan_interval_seconds, self._tick
+        )
 
     async def run(self) -> None:
-        logger.info(
-            "trigger scanner started: interval=%ss",
-            trigger_settings.scan_interval_seconds,
-        )
-        while not self._stopping.is_set():
-            try:
-                await self._tick()
-            except Exception:
-                logger.exception("Trigger scan failed")
-            await self._sleep(trigger_settings.scan_interval_seconds)
+        await self._loop.run()
 
     async def _tick(self) -> None:
         async with AsyncSessionLocal() as db:
@@ -41,10 +33,5 @@ class TriggerScanner:
         if run_ids:
             logger.info("Enqueued %d triggered run(s)", len(run_ids))
 
-    async def _sleep(self, seconds: float) -> None:
-        """Sleep, but wake early if asked to stop."""
-        with suppress(TimeoutError):
-            await asyncio.wait_for(self._stopping.wait(), timeout=seconds)
-
     def stop(self) -> None:
-        self._stopping.set()
+        self._loop.stop()

--- a/backend/app/triggers/service.py
+++ b/backend/app/triggers/service.py
@@ -290,6 +290,13 @@ class TriggerService(BaseService[TriggerDB, TriggerRepository]):
         schedule.
         """
         now = now or datetime.now(UTC)
+        # Warm the whitelist cache *before* the claim, exactly as
+        # `RunService.create` does and for a sharper version of the same reason:
+        # `is_available` below runs inside this transaction, which holds
+        # `FOR UPDATE SKIP LOCKED` locks on every claimed trigger row. A cold or
+        # expired catalog cache makes that a multi-second CDN fetch with those
+        # locks held (design review §3.7).
+        await ModelService.list_whitelisted()
         claimed = await self.repository.claim_due(
             now, limit=trigger_settings.claim_batch_size
         )

--- a/backend/tests/agents/core/conftest.py
+++ b/backend/tests/agents/core/conftest.py
@@ -1,0 +1,118 @@
+"""A real (SQLite) database for the agent-graph reads.
+
+`get_run_spec`'s whole point is the *number* of round-trips it makes, and a
+mocked session can't tell you that — it only tells you what you told it to say.
+So these tests run against a real engine with a statement counter attached.
+
+Two accommodations make the Postgres schema loadable on SQLite:
+
+* `JSONB` gets a SQLite DDL rendering (`JSON`). Only the DDL needs it — the
+  bind/result processors JSONB inherits from `types.JSON` already work on any
+  dialect, so values round-trip normally.
+* Tables are created by walking the foreign-key closure of the ones under test,
+  rather than the whole metadata: several unrelated tables carry Postgres-only
+  columns, and pulling them in would fail for reasons that have nothing to do
+  with agents.
+
+Foreign keys are not enforced by default on SQLite, which is why fixtures can
+reference owner/tag ids that were never inserted.
+"""
+
+import pytest
+from sqlalchemy import Table, event
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+import app.main  # noqa: F401 — imported for the side effect of registering every model
+from app.agents.models import (
+    AgentDB,
+    AgentMCPServerDB,
+    AgentSandboxDB,
+    AgentSubagentDB,
+    AgentTeamDB,
+    AgentUserPermissionDB,
+)
+
+
+@compiles(JSONB, "sqlite")
+def _render_jsonb_as_json_on_sqlite(type_, compiler, **kw) -> str:
+    return "JSON"
+
+
+def _fk_closure(roots: list[Table]) -> list[Table]:
+    """Every table reachable from `roots` by following foreign keys."""
+    seen: set[str] = set()
+    stack = list(roots)
+    out: list[Table] = []
+    while stack:
+        table = stack.pop()
+        if table.name in seen:
+            continue
+        seen.add(table.name)
+        out.append(table)
+        stack.extend(fk.column.table for fk in table.foreign_keys)
+    return out
+
+
+AGENT_TABLES = _fk_closure(
+    [
+        AgentDB.__table__,
+        AgentMCPServerDB.__table__,
+        AgentSandboxDB.__table__,
+        AgentSubagentDB.__table__,
+        AgentTeamDB.__table__,
+        AgentUserPermissionDB.__table__,
+    ]
+)
+
+
+class StatementCounter:
+    """Counts SQL statements issued on an engine, so a test can assert that a
+    read stays flat as the graph it reads grows."""
+
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def __len__(self) -> int:
+        return len(self.statements)
+
+    def reset(self) -> None:
+        self.statements.clear()
+
+
+@pytest.fixture
+async def agent_engine(tmp_path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'agents.db'}")
+
+    def _create(conn):
+        SQLModel.metadata.create_all(conn, tables=AGENT_TABLES)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(_create)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def agent_session(agent_engine):
+    factory = sessionmaker(
+        bind=agent_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with factory() as session:
+        yield session
+
+
+@pytest.fixture
+def statements(agent_engine) -> StatementCounter:
+    """Counts statements on `agent_engine`. Call `.reset()` after seeding so the
+    count covers only the code under test."""
+    counter = StatementCounter()
+
+    @event.listens_for(agent_engine.sync_engine, "before_cursor_execute")
+    def _record(conn, cursor, statement, parameters, context, executemany):
+        counter.statements.append(statement)
+
+    return counter

--- a/backend/tests/agents/core/test_run_spec.py
+++ b/backend/tests/agents/core/test_run_spec.py
@@ -1,0 +1,207 @@
+"""`AgentRepository.get_run_spec` — the narrow run-path read (design review §2.2).
+
+These run against a real engine (see `conftest.py`): the contract being tested is
+partly *how many queries it takes*, which a mocked session cannot observe.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.agents.core.repository import AgentRepository
+from app.agents.models import (
+    AgentDB,
+    AgentMCPServerDB,
+    AgentSandboxDB,
+    AgentSubagentDB,
+    ToolStatus,
+)
+from app.sandbox.models import SandboxDB, SandboxProviderType
+
+
+async def _add_agent(session, name: str, **kwargs) -> AgentDB:
+    agent = AgentDB(
+        name=name,
+        instructions=f"instructions for {name}",
+        owner_id=uuid4(),
+        **kwargs,
+    )
+    session.add(agent)
+    await session.flush()
+    return agent
+
+
+async def _bind_server(
+    session, agent_id: UUID, tools: dict[str, ToolStatus] | None = None
+) -> AgentMCPServerDB:
+    binding = AgentMCPServerDB(agent_id=agent_id, mcp_server_id=uuid4(), tools=tools)
+    session.add(binding)
+    await session.flush()
+    return binding
+
+
+async def _bind_subagent(session, supervisor_id: UUID, subagent_id: UUID) -> None:
+    session.add(AgentSubagentDB(supervisor_id=supervisor_id, subagent_id=subagent_id))
+    await session.flush()
+
+
+async def _bind_sandbox(
+    session, agent_id: UUID, tools: dict[str, ToolStatus] | None = None
+) -> SandboxDB:
+    sandbox = SandboxDB(
+        name="box",
+        provider=SandboxProviderType.opensandbox,
+        url="https://sandbox.example.com",
+    )
+    session.add(sandbox)
+    await session.flush()
+    session.add(AgentSandboxDB(agent_id=agent_id, sandbox_id=sandbox.id, tools=tools))
+    await session.flush()
+    return sandbox
+
+
+async def test_returns_none_for_an_unknown_agent(agent_session):
+    assert await AgentRepository(agent_session).get_run_spec(uuid4()) is None
+
+
+async def test_carries_the_agent_fields_the_runtime_actually_uses(agent_session):
+    agent = await _add_agent(agent_session, "Parent", description="a parent")
+
+    spec = await AgentRepository(agent_session).get_run_spec(agent.id)
+
+    assert spec is not None
+    assert spec.agent.id == agent.id
+    assert spec.agent.name == "Parent"
+    assert spec.agent.instructions == "instructions for Parent"
+    assert spec.agent.description == "a parent"
+    assert spec.agent.mcp_servers == []
+    assert spec.agent.sandbox is None
+    assert spec.subagents == []
+
+
+async def test_includes_direct_subagents_but_not_their_subagents(agent_session):
+    """One level only — `Agent.build` does not recurse, so neither does the read."""
+    parent = await _add_agent(agent_session, "Parent")
+    child = await _add_agent(agent_session, "Child")
+    grandchild = await _add_agent(agent_session, "Grandchild")
+    await _bind_subagent(agent_session, parent.id, child.id)
+    await _bind_subagent(agent_session, child.id, grandchild.id)
+
+    spec = await AgentRepository(agent_session).get_run_spec(parent.id)
+
+    assert spec is not None
+    assert [s.id for s in spec.subagents] == [child.id]
+
+
+async def test_subagents_keep_the_order_they_were_bound_in(agent_session):
+    parent = await _add_agent(agent_session, "Parent")
+    first = await _add_agent(agent_session, "First")
+    second = await _add_agent(agent_session, "Second")
+    await _bind_subagent(agent_session, parent.id, first.id)
+    await _bind_subagent(agent_session, parent.id, second.id)
+
+    spec = await AgentRepository(agent_session).get_run_spec(parent.id)
+
+    assert spec is not None
+    assert [s.name for s in spec.subagents] == ["First", "Second"]
+
+
+async def test_an_archived_agent_still_resolves(agent_session):
+    """A subagent is routinely archived out of the agents list while still wired
+    to a supervisor, and a run under way must survive its agent being archived."""
+    parent = await _add_agent(agent_session, "Parent", is_archived=True)
+    child = await _add_agent(agent_session, "Child", is_archived=True)
+    await _bind_subagent(agent_session, parent.id, child.id)
+
+    spec = await AgentRepository(agent_session).get_run_spec(parent.id)
+
+    assert spec is not None
+    assert [s.id for s in spec.subagents] == [child.id]
+
+
+async def test_bindings_land_on_the_agent_that_owns_them(agent_session):
+    parent = await _add_agent(agent_session, "Parent")
+    child = await _add_agent(agent_session, "Child")
+    await _bind_subagent(agent_session, parent.id, child.id)
+    parent_binding = await _bind_server(
+        agent_session, parent.id, {"search": ToolStatus.needs_approval}
+    )
+    child_binding = await _bind_server(agent_session, child.id, None)
+
+    spec = await AgentRepository(agent_session).get_run_spec(parent.id)
+
+    assert spec is not None
+    assert [b.id for b in spec.agent.mcp_servers] == [parent_binding.id]
+    assert spec.agent.mcp_servers[0].tools == {"search": ToolStatus.needs_approval}
+    assert [b.id for b in spec.subagents[0].mcp_servers] == [child_binding.id]
+
+
+async def test_all_mcp_bindings_spans_parent_and_subagents_without_deduping(
+    agent_session,
+):
+    """The `collect_run_bindings` contract: a server configured on the parent but
+    left unconfigured on a subagent must stay separately visible, so the
+    readiness check can see the unconfigured one."""
+    parent = await _add_agent(agent_session, "Parent")
+    child = await _add_agent(agent_session, "Child")
+    await _bind_subagent(agent_session, parent.id, child.id)
+    shared_server_id = uuid4()
+    agent_session.add(
+        AgentMCPServerDB(
+            agent_id=parent.id,
+            mcp_server_id=shared_server_id,
+            tools={"search": ToolStatus.always_allow},
+        )
+    )
+    agent_session.add(
+        AgentMCPServerDB(agent_id=child.id, mcp_server_id=shared_server_id, tools=None)
+    )
+    await agent_session.flush()
+
+    spec = await AgentRepository(agent_session).get_run_spec(parent.id)
+
+    assert spec is not None
+    bindings = spec.all_mcp_bindings
+    assert len(bindings) == 2
+    assert {b.mcp_server_id for b in bindings} == {shared_server_id}
+    assert sorted(b.tools is None for b in bindings) == [False, True]
+
+
+async def test_carries_the_sandbox_row_so_the_runtime_need_not_refetch_it(
+    agent_session,
+):
+    agent = await _add_agent(agent_session, "Parent")
+    sandbox = await _bind_sandbox(
+        agent_session, agent.id, {"execute": ToolStatus.always_allow}
+    )
+
+    spec = await AgentRepository(agent_session).get_run_spec(agent.id)
+
+    assert spec is not None
+    assert spec.agent.sandbox is not None
+    assert spec.agent.sandbox.row.id == sandbox.id
+    assert spec.agent.sandbox.row.url == "https://sandbox.example.com"
+    assert spec.agent.sandbox.tools == {"execute": ToolStatus.always_allow}
+
+
+@pytest.mark.parametrize("subagent_count", [0, 1, 5])
+async def test_cost_is_flat_in_the_number_of_subagents(
+    agent_session, statements, subagent_count
+):
+    """The reason this method exists. The path it replaces ran a full
+    `AgentService.get` per agent — ~5 queries each, so (1+N)×5 — three times per
+    send. Three queries, whatever N is."""
+    parent = await _add_agent(agent_session, "Parent")
+    await _bind_server(agent_session, parent.id)
+    await _bind_sandbox(agent_session, parent.id)
+    for i in range(subagent_count):
+        child = await _add_agent(agent_session, f"Child {i}")
+        await _bind_subagent(agent_session, parent.id, child.id)
+        await _bind_server(agent_session, child.id)
+    statements.reset()
+
+    spec = await AgentRepository(agent_session).get_run_spec(parent.id)
+
+    assert spec is not None
+    assert len(spec.subagents) == subagent_count
+    assert len(statements) == 3, "\n".join(statements.statements)

--- a/backend/tests/agents/core/test_run_spec.py
+++ b/backend/tests/agents/core/test_run_spec.py
@@ -93,17 +93,25 @@ async def test_includes_direct_subagents_but_not_their_subagents(agent_session):
     assert [s.id for s in spec.subagents] == [child.id]
 
 
-async def test_subagents_keep_the_order_they_were_bound_in(agent_session):
+async def test_subagent_order_is_stable_across_reads(agent_session):
+    """Repeatable, not semantic. Subagents bound in one save share a `created_at`
+    (it is the transaction timestamp), so the id tie-break is what stops the
+    planner returning them in a different order each time. They are addressed by
+    name, so their relative order carries no meaning beyond that."""
     parent = await _add_agent(agent_session, "Parent")
-    first = await _add_agent(agent_session, "First")
-    second = await _add_agent(agent_session, "Second")
-    await _bind_subagent(agent_session, parent.id, first.id)
-    await _bind_subagent(agent_session, parent.id, second.id)
+    for name in ("First", "Second", "Third"):
+        child = await _add_agent(agent_session, name)
+        await _bind_subagent(agent_session, parent.id, child.id)
 
-    spec = await AgentRepository(agent_session).get_run_spec(parent.id)
+    repository = AgentRepository(agent_session)
+    first_read = await repository.get_run_spec(parent.id)
+    second_read = await repository.get_run_spec(parent.id)
 
-    assert spec is not None
-    assert [s.name for s in spec.subagents] == ["First", "Second"]
+    assert first_read is not None and second_read is not None
+    assert [s.name for s in first_read.subagents] == [
+        s.name for s in second_read.subagents
+    ]
+    assert sorted(s.name for s in first_read.subagents) == ["First", "Second", "Third"]
 
 
 async def test_an_archived_agent_still_resolves(agent_session):

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -11,6 +11,7 @@ from app.agents.models import (
     PermissionLevel,
     ToolStatus,
 )
+from app.agents.run_spec import AgentSpec, RunSpec
 from app.agents.schemas import (
     AgentConfig,
     AgentCreateDB,
@@ -56,6 +57,7 @@ def mock_repo():
     repo.set_teams = AsyncMock(return_value=[])
     repo.delete_all_teams = AsyncMock()
     repo.list_with_permissions = AsyncMock(return_value=[])
+    repo.get_run_spec = AsyncMock(return_value=None)
     return repo
 
 
@@ -889,11 +891,45 @@ async def test_delete_permanently_denied_for_editor(
 # ---------------------------------------------------------------------------
 
 
-async def test_check_ready_returns_ready_when_no_mcp_servers(service, mock_repo):
-    agent = make_agent()
-    mock_repo.list_with_permissions.return_value = [(agent, None)]
+def _binding(agent_id, server_id, *, tools_ok=True) -> AgentMCPServerDB:
+    return AgentMCPServerDB(
+        id=uuid4(),
+        agent_id=agent_id,
+        mcp_server_id=server_id,
+        tools=({"x": ToolStatus.always_allow} if tools_ok else None),
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
 
-    result = await service.describe_readiness(agent.id, "user-id")
+
+def _spec(agent_id, server_ids, *, tools_ok=True) -> AgentSpec:
+    return AgentSpec(
+        id=agent_id,
+        name="Agent",
+        instructions="do things",
+        description=None,
+        mcp_servers=[_binding(agent_id, sid, tools_ok=tools_ok) for sid in server_ids],
+        sandbox=None,
+    )
+
+
+def _run_spec(agent_id, server_ids, *, subagents=(), tools_ok=True) -> RunSpec:
+    """A `RunSpec` as `AgentRepository.get_run_spec` would return it.
+
+    Real dataclasses rather than duck-typed mocks: the readiness rules turn on
+    `tools is None` and on parent/subagent bindings staying separate, and a mock
+    would happily satisfy either reading."""
+    return RunSpec(
+        agent=_spec(agent_id, server_ids, tools_ok=tools_ok),
+        subagents=list(subagents),
+    )
+
+
+async def test_check_ready_returns_ready_when_no_mcp_servers(service, mock_repo):
+    agent_id = uuid4()
+    mock_repo.get_run_spec.return_value = _run_spec(agent_id, [])
+
+    result = await service.describe_readiness(agent_id, "user-id")
 
     assert result["ready"] is True
     assert result["status"] == "ready"
@@ -903,19 +939,10 @@ async def test_check_ready_returns_ready_when_no_mcp_servers(service, mock_repo)
 async def test_check_ready_returns_not_configured_when_tools_is_none(
     service, mock_repo
 ):
-    agent = make_agent()
-    server_id = uuid4()
-    binding = AgentMCPServerDB(
-        id=uuid4(),
-        agent_id=agent.id,
-        mcp_server_id=server_id,
-        tools=None,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-    )
-    mock_repo.list_with_permissions.return_value = [(agent, binding)]
+    agent_id = uuid4()
+    mock_repo.get_run_spec.return_value = _run_spec(agent_id, [uuid4()], tools_ok=False)
 
-    result = await service.describe_readiness(agent.id, "user-id")
+    result = await service.describe_readiness(agent_id, "user-id")
 
     assert result["ready"] is False
     assert result["status"] == "not_configured"
@@ -924,119 +951,88 @@ async def test_check_ready_returns_not_configured_when_tools_is_none(
 async def test_check_ready_returns_ready_when_all_servers_connected(
     service, mock_db, mock_repo
 ):
-    agent = make_agent()
-    server_id = uuid4()
-    binding = AgentMCPServerDB(
-        id=uuid4(),
-        agent_id=agent.id,
-        mcp_server_id=server_id,
-        tools={"search": ToolStatus.always_allow},
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
+    agent_id, server_id = uuid4(), uuid4()
+    mock_repo.get_run_spec.return_value = _run_spec(agent_id, [server_id])
+    mock_db.execute.return_value = _make_mock_execute_result(
+        scalars_list=[MagicMock(id=server_id)]
     )
-    mcp_server = MagicMock()
-    mcp_server.id = server_id
-
-    mock_repo.list_with_permissions.return_value = [(agent, binding)]
-    mock_db.execute.return_value = _make_mock_execute_result(scalars_list=[mcp_server])
 
     with patch(
-        "app.agents.core.service.is_authorized",
-        new=AsyncMock(return_value=True),
+        "app.agents.core.service.probe_authorization",
+        new=AsyncMock(return_value={server_id: True}),
     ):
-        result = await service.describe_readiness(agent.id, "user-id")
+        result = await service.describe_readiness(agent_id, "user-id")
 
     assert result["ready"] is True
     assert result["disconnected_servers"] == []
+    assert result["status"] == "ready"
 
 
 async def test_check_ready_returns_not_ready_when_server_disconnected(
     service, mock_db, mock_repo
 ):
-    agent = make_agent()
-    server_id = uuid4()
-    binding = AgentMCPServerDB(
-        id=uuid4(),
-        agent_id=agent.id,
-        mcp_server_id=server_id,
-        tools={"search": ToolStatus.always_allow},
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
+    agent_id, server_id = uuid4(), uuid4()
+    mock_repo.get_run_spec.return_value = _run_spec(agent_id, [server_id])
+    mock_db.execute.return_value = _make_mock_execute_result(
+        scalars_list=[MagicMock(id=server_id)]
     )
-    mcp_server = MagicMock()
-    mcp_server.id = server_id
-
-    mock_repo.list_with_permissions.return_value = [(agent, binding)]
-    mock_db.execute.return_value = _make_mock_execute_result(scalars_list=[mcp_server])
 
     with patch(
-        "app.agents.core.service.is_authorized",
-        new=AsyncMock(return_value=False),
+        "app.agents.core.service.probe_authorization",
+        new=AsyncMock(return_value={server_id: False}),
     ):
-        result = await service.describe_readiness(agent.id, "user-id")
+        result = await service.describe_readiness(agent_id, "user-id")
 
     assert result["ready"] is False
     assert str(server_id) in result["disconnected_servers"]
 
 
 async def test_check_ready_disconnected_status_label(service, mock_db, mock_repo):
-    agent = make_agent()
-    server_id = uuid4()
-    binding = AgentMCPServerDB(
-        id=uuid4(),
-        agent_id=agent.id,
-        mcp_server_id=server_id,
-        tools={"x": ToolStatus.always_allow},
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
+    agent_id, server_id = uuid4(), uuid4()
+    mock_repo.get_run_spec.return_value = _run_spec(agent_id, [server_id])
+    mock_db.execute.return_value = _make_mock_execute_result(
+        scalars_list=[MagicMock(id=server_id)]
     )
-    mcp_server = MagicMock()
-    mcp_server.id = server_id
-
-    mock_repo.list_with_permissions.return_value = [(agent, binding)]
-    mock_db.execute.return_value = _make_mock_execute_result(scalars_list=[mcp_server])
 
     with patch(
-        "app.agents.core.service.is_authorized",
-        new=AsyncMock(return_value=False),
+        "app.agents.core.service.probe_authorization",
+        new=AsyncMock(return_value={server_id: False}),
     ):
-        result = await service.describe_readiness(agent.id, "user-id")
+        result = await service.describe_readiness(agent_id, "user-id")
 
     assert result["status"] == "disconnected"
 
 
-def _readiness_resp(mcp_server_ids, *, subagent_ids=(), tools_ok=True):
-    """Duck-typed AgentResponse for readiness/enumeration tests."""
-    resp = MagicMock()
-    resp.mcp_servers = [
-        MagicMock(
-            mcp_server_id=sid,
-            tools=({"x": ToolStatus.always_allow} if tools_ok else None),
-        )
-        for sid in mcp_server_ids
-    ]
-    resp.subagents = [MagicMock(id=sub) for sub in subagent_ids]
-    return resp
+async def test_check_ready_on_a_missing_agent_reports_ready_with_no_servers(
+    service, mock_repo
+):
+    """`get_run_spec` returns None for an unknown agent; readiness must not
+    explode on the polled endpoint."""
+    mock_repo.get_run_spec.return_value = None
+
+    result = await service.describe_readiness(uuid4(), "user-id")
+
+    assert result["ready"] is True
 
 
-async def test_describe_readiness_includes_subagent_servers(service, mock_db):
+async def test_describe_readiness_includes_subagent_servers(
+    service, mock_db, mock_repo
+):
     # The bug: a subagent's unauthorized OAuth server must keep the agent "not
     # ready" — otherwise the run launches and fails mid-flight.
     parent_id, sub_id = uuid4(), uuid4()
     parent_server, sub_server = uuid4(), uuid4()
-    responses = {
-        parent_id: _readiness_resp([parent_server], subagent_ids=[sub_id]),
-        sub_id: _readiness_resp([sub_server]),
-    }
-    service.get = AsyncMock(side_effect=lambda aid, **_: responses[aid])
+    mock_repo.get_run_spec.return_value = _run_spec(
+        parent_id, [parent_server], subagents=[_spec(sub_id, [sub_server])]
+    )
     mock_db.execute.return_value = _make_mock_execute_result(
         scalars_list=[MagicMock(id=parent_server), MagicMock(id=sub_server)]
     )
 
     with patch(
-        "app.agents.core.service.is_authorized",
+        "app.agents.core.service.probe_authorization",
         # parent authorized, subagent's server is not
-        new=AsyncMock(side_effect=lambda s, _u: s.id == parent_server),
+        new=AsyncMock(return_value={parent_server: True, sub_server: False}),
     ):
         result = await service.describe_readiness(parent_id, "user-id")
 
@@ -1045,33 +1041,41 @@ async def test_describe_readiness_includes_subagent_servers(service, mock_db):
     assert str(parent_server) not in result["disconnected_servers"]
 
 
-async def test_collect_run_bindings_keeps_shared_server_across_agents(service):
+async def test_collect_run_bindings_keeps_shared_server_across_agents(
+    service, mock_repo
+):
     # `tools` is per binding, so a server shared by parent + subagent yields
     # BOTH bindings (not deduped) — the readiness check needs to see each one.
     parent_id, sub_id = uuid4(), uuid4()
     shared = uuid4()
-    responses = {
-        parent_id: _readiness_resp([shared], subagent_ids=[sub_id]),
-        sub_id: _readiness_resp([shared]),
-    }
-    service.get = AsyncMock(side_effect=lambda aid, **_: responses[aid])
+    mock_repo.get_run_spec.return_value = _run_spec(
+        parent_id, [shared], subagents=[_spec(sub_id, [shared])]
+    )
 
     bindings = await service.collect_run_bindings(parent_id)
 
     assert [b.mcp_server_id for b in bindings] == [shared, shared]
 
 
-async def test_describe_readiness_flags_unconfigured_shared_subagent_binding(service):
+async def test_collect_run_bindings_is_empty_for_a_missing_agent(service, mock_repo):
+    mock_repo.get_run_spec.return_value = None
+
+    assert await service.collect_run_bindings(uuid4()) == []
+
+
+async def test_describe_readiness_flags_unconfigured_shared_subagent_binding(
+    service, mock_repo
+):
     # Parent configures server X; a subagent binds the SAME X but leaves it
     # unconfigured (tools=None). Deduping by server id would hide the None and
     # wrongly report ready — it must be not_configured.
     parent_id, sub_id = uuid4(), uuid4()
     shared = uuid4()
-    responses = {
-        parent_id: _readiness_resp([shared], subagent_ids=[sub_id], tools_ok=True),
-        sub_id: _readiness_resp([shared], tools_ok=False),
-    }
-    service.get = AsyncMock(side_effect=lambda aid, **_: responses[aid])
+    mock_repo.get_run_spec.return_value = _run_spec(
+        parent_id,
+        [shared],
+        subagents=[_spec(sub_id, [shared], tools_ok=False)],
+    )
 
     result = await service.describe_readiness(parent_id, "user-id")
 

--- a/backend/tests/agents/runs/conftest.py
+++ b/backend/tests/agents/runs/conftest.py
@@ -49,3 +49,28 @@ async def run_db(tmp_path, monkeypatch):
     monkeypatch.setattr(service_mod.RunService, "_ensure_runnable_thread", AsyncMock())
     yield factory
     await engine.dispose()
+
+
+@pytest.fixture
+def count_appends(monkeypatch):
+    """Count *awaited* stream appends made directly on the Redis client.
+
+    This is the measurement P1-11 is about. Buffered writes go through
+    `pipeline.xadd`, which costs nothing until `execute()`, so a client-level
+    `xadd` here means one blocking round trip that a token had to wait for.
+    Counting calls to `publish_many` instead would prove nothing — that is the
+    method whose *implementation* is under test.
+    """
+
+    def _count(redis) -> dict:
+        counter = {"xadd": 0}
+        original = redis.xadd
+
+        async def _counting_xadd(*args, **kwargs):
+            counter["xadd"] += 1
+            return await original(*args, **kwargs)
+
+        monkeypatch.setattr(redis, "xadd", _counting_xadd)
+        return counter
+
+    return _count

--- a/backend/tests/agents/runs/test_events.py
+++ b/backend/tests/agents/runs/test_events.py
@@ -1,4 +1,8 @@
-from app.agents.runs.events import RunEventStream
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.agents.runs.events import BufferedEventPublisher, RunEventStream
 from app.agents.runs.settings import run_settings
 from app.agents.runs.state import RunStatus
 
@@ -44,3 +48,134 @@ async def test_subscribe_resumes_after_cursor(redis):
     chunks = [c async for c in events.subscribe(first_id, block_ms=200)]
     assert "a" not in chunks
     assert chunks[0] == "b"
+
+
+async def test_first_publish_stamps_a_safety_ttl(redis):
+    """§5.4: a stream must never be able to outlive its run permanently.
+
+    `RunService.finalize` normally sets the TTL, but it is skipped when the run
+    row has vanished — a thread deleted mid-run CASCADEs the run away — and the
+    log would then sit in Redis for ever with no expiry at all.
+    """
+    events = RunEventStream("r-ttl", redis)
+
+    await events.publish("event: messages\ndata: 1\n\n")
+
+    assert 0 < await redis.ttl(events._key) <= run_settings.ttl_seconds
+
+
+async def test_touch_ttl_keeps_a_long_run_from_expiring_its_own_stream(redis):
+    """The worker's heartbeat calls this. Without it, a run longer than the
+    safety TTL (or an uncapped one) would lose its live stream mid-flight."""
+    events = RunEventStream("r-touch", redis)
+    await events.publish("a")
+    await redis.expire(events._key, 5)
+
+    await events.touch_ttl()
+
+    assert await redis.ttl(events._key) > 5
+
+
+async def test_touch_ttl_on_an_empty_log_is_a_noop(redis):
+    """The heartbeat starts before the first chunk is published."""
+    await RunEventStream("r-empty", redis).touch_ttl()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# BufferedEventPublisher (P1-11 / §3.4)
+# ---------------------------------------------------------------------------
+
+
+async def test_a_full_buffer_costs_no_per_chunk_round_trip(redis, count_appends):
+    """32 chunks used to be 32 awaited XADDs, each one a Redis RTT the next
+    token waited on. They now ride in a single pipeline."""
+    appends = count_appends(redis)
+    events = RunEventStream("r-buf", redis)
+
+    async with BufferedEventPublisher(
+        events, max_chunks=32, max_delay_seconds=3600
+    ) as publisher:
+        for i in range(32):
+            await publisher.publish(f"data: {i}\n\n")
+
+    assert appends["xadd"] == 0  # nothing blocked per chunk
+    assert await redis.xlen(events._key) == 32
+
+
+async def test_the_delay_bound_ships_a_partial_buffer(redis, until):
+    """The bound that matters for behaviour: these chunks are the tokens a user
+    is watching appear, so a run that goes quiet mid-stream (a long tool call)
+    must not sit on them until the buffer happens to fill."""
+    events = RunEventStream("r-delay", redis)
+
+    async with BufferedEventPublisher(
+        events, max_chunks=1000, max_delay_seconds=0.001
+    ) as publisher:
+        await publisher.publish("data: only\n\n")
+
+        async def _shipped() -> bool:
+            return await redis.xlen(events._key) > 0
+
+        await until(_shipped, what="the delay bound to ship a partial buffer")
+
+    assert await redis.xlen(events._key) == 1
+
+
+async def test_closing_drains_the_buffer(redis):
+    """What orders the last chunks ahead of finalize's end sentinel."""
+    events = RunEventStream("r-drain", redis)
+
+    async with BufferedEventPublisher(
+        events, max_chunks=1000, max_delay_seconds=3600
+    ) as publisher:
+        await publisher.publish("a")
+        await publisher.publish("b")
+        assert await redis.xlen(events._key) == 0  # still buffered
+
+    assert await redis.xlen(events._key) == 2
+
+
+async def test_chunk_order_is_preserved(redis):
+    events = RunEventStream("r-order", redis)
+
+    async with BufferedEventPublisher(
+        events, max_chunks=4, max_delay_seconds=3600
+    ) as publisher:
+        for i in range(10):
+            await publisher.publish(f"data: {i}\n\n")
+    await events.publish_end(RunStatus.success)
+
+    chunks = [c async for c in events.subscribe("0", block_ms=200)]
+    assert [c for c in chunks if "event: end" not in c] == [
+        f"data: {i}\n\n" for i in range(10)
+    ]
+
+
+async def test_a_flush_failure_surfaces_rather_than_dropping_output(redis):
+    """A Redis that has gone away must still fail the run. Buffering moves the
+    write off the publish call, so the error has to be carried back."""
+    events = RunEventStream("r-fail", redis)
+    events.publish_many = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    with pytest.raises(ConnectionError, match="redis down"):
+        async with BufferedEventPublisher(
+            events, max_chunks=1, max_delay_seconds=3600
+        ) as publisher:
+            await publisher.publish("a")
+
+
+async def test_a_background_flush_failure_surfaces_on_close(redis, until):
+    events = RunEventStream("r-fail2", redis)
+    events.publish_many = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    publisher = BufferedEventPublisher(events, max_chunks=1000, max_delay_seconds=0.001)
+    await publisher.__aenter__()
+    await publisher.publish("a")
+
+    async def _attempted() -> bool:
+        return events.publish_many.await_count > 0
+
+    await until(_attempted, what="the background flusher to attempt a write")
+
+    with pytest.raises(ConnectionError, match="redis down"):
+        await publisher.aclose()

--- a/backend/tests/agents/runs/test_events.py
+++ b/backend/tests/agents/runs/test_events.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -179,3 +180,49 @@ async def test_a_background_flush_failure_surfaces_on_close(redis, until):
 
     with pytest.raises(ConnectionError, match="redis down"):
         await publisher.aclose()
+
+
+async def test_closing_never_drops_a_write_that_is_already_in_flight(redis, until):
+    """`_flush_locked` takes the buffer *before* awaiting the write, so a close
+    that cancels the flusher mid-write destroys chunks the drain can no longer
+    see — the tail of a run, silently lost or landing after the end sentinel."""
+    events = RunEventStream("r-race", redis)
+    real_publish_many = events.publish_many
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_publish_many(chunks):
+        in_flight.set()
+        await release.wait()
+        await real_publish_many(chunks)
+
+    events.publish_many = _slow_publish_many
+
+    publisher = BufferedEventPublisher(events, max_chunks=1000, max_delay_seconds=0.001)
+    await publisher.__aenter__()
+    await publisher.publish("first")
+
+    async def _writing() -> bool:
+        return in_flight.is_set()
+
+    await until(_writing, what="the periodic flusher to start writing")
+
+    closing = asyncio.create_task(publisher.aclose())
+    await asyncio.sleep(0)  # let aclose reach its await
+    release.set()
+    await closing
+
+    await events.publish_end(RunStatus.success)
+    chunks = [c async for c in events.subscribe("0", block_ms=200)]
+    assert "first" in chunks
+    assert chunks.index("first") < len(chunks) - 1  # ahead of the end sentinel
+
+
+async def test_a_zero_delay_does_not_spin_the_flusher(redis):
+    """A configured 0 means "ship immediately", not "burn a core for the length
+    of the run" — the flusher's wait would return instantly forever."""
+    events = RunEventStream("r-zero", redis)
+
+    publisher = BufferedEventPublisher(events, max_chunks=1000, max_delay_seconds=0)
+
+    assert publisher._max_delay > 0

--- a/backend/tests/agents/runs/test_reaper.py
+++ b/backend/tests/agents/runs/test_reaper.py
@@ -14,6 +14,7 @@ reason `test_repository.py` uses naive datetimes), and `updated_at` carries an
 `now` forward tests the identical thresholds from the other side.
 """
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
@@ -160,7 +161,9 @@ async def test_pending_runs_are_reaped_once_no_dispatcher_is_alive(redis):
         thread_id="t-orphan", user_id=str(uuid4()), input={"messages": []}
     )
 
-    await RunReaper(redis)._reap_undispatched_pending(_after_pending_timeout())
+    reaper = RunReaper(redis)
+    await reaper._reap_undispatched_pending(_after_pending_timeout())
+    await reaper._reap_undispatched_pending(_after_pending_timeout())
 
     back = await service.get(record.id)
     assert back.status == RunStatus.error
@@ -178,13 +181,88 @@ async def test_a_young_pending_run_is_never_reaped(redis):
     assert (await service.get(record.id)).status == RunStatus.pending
 
 
-async def test_dispatcher_liveness_expires_so_a_dead_cluster_is_detectable(redis):
-    """The gate is a self-expiring key, not a flag: a dispatcher that dies
-    without cleaning up must stop counting as alive on its own."""
+async def test_dispatcher_liveness_is_a_self_expiring_key(redis):
+    """The gate has to expire on its own: a dispatcher that dies without
+    cleaning up must stop counting as alive.
+
+    Asserting the TTL is the whole point. Deleting the key by hand and checking
+    `any_alive()` proves nothing — it would pass just as well if `stamp` were a
+    plain SET with no expiry, which is the exact regression this guards.
+    """
+    liveness = DispatcherLiveness(redis)
+
+    await liveness.stamp(ttl=60)
+
+    assert await liveness.any_alive() is True
+    ttl = await redis.ttl("run:dispatchers:alive")
+    assert 0 < ttl <= 60  # -1 would mean "set, but never expires"
+
+
+async def test_an_expired_dispatcher_key_reads_as_no_dispatcher(redis):
     liveness = DispatcherLiveness(redis)
     await liveness.stamp(ttl=60)
-    assert await liveness.any_alive() is True
-
-    await redis.delete("run:dispatchers:alive")
+    await redis.pexpire("run:dispatchers:alive", 1)
+    await asyncio.sleep(0.05)
 
     assert await liveness.any_alive() is False
+
+
+async def test_a_missing_dispatcher_key_survives_its_first_sweep(redis):
+    """Same evidence problem as the running path: "no dispatcher" is a missing
+    Redis key, and a Redis restart makes every key missing at once. One sample
+    would turn a restart into "reap the entire queue"."""
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="t-restart", user_id=str(uuid4()), input={"messages": []}
+    )
+
+    await RunReaper(redis)._reap_undispatched_pending(_after_pending_timeout())
+
+    assert (await service.get(record.id)).status == RunStatus.pending
+
+
+async def test_a_dispatcher_coming_back_resets_the_no_dispatcher_suspicion(redis):
+    """The Redis-restart sequence end to end: the key vanishes, the reaper
+    notices, the dispatcher stamps again on its next heartbeat, nothing dies."""
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="t-restart2", user_id=str(uuid4()), input={"messages": []}
+    )
+    reaper = RunReaper(redis)
+
+    await reaper._reap_undispatched_pending(_after_pending_timeout())  # 1st sighting
+    await DispatcherLiveness(redis).stamp(ttl=60)  # dispatcher heartbeats again
+    await reaper._reap_undispatched_pending(_after_pending_timeout())  # cleared
+    await redis.delete("run:dispatchers:alive")
+    await reaper._reap_undispatched_pending(_after_pending_timeout())  # a *first* one
+
+    assert (await service.get(record.id)).status == RunStatus.pending
+
+
+async def test_a_failed_sweep_does_not_carry_suspicion_into_the_next_one(redis):
+    """A sweep that raises part-way used to leave `_suspect` untouched, so a run
+    it had already flagged would be reaped on its very next missing sample —
+    the single-sample rule, reintroduced through the error path."""
+    service = RunService(redis)
+    run_id = await _claimed(service, "t-aborted")
+    reaper = RunReaper(redis)
+
+    await reaper._reap_dead_running(_after_heartbeat_grace())  # suspected
+    assert run_id in reaper._suspect
+
+    # The next sweep blows up after listing.
+    original = reaper.service.list_running
+
+    async def _boom():
+        raise ConnectionError("postgres went away")
+
+    reaper.service.list_running = _boom
+    with pytest.raises(ConnectionError):
+        await reaper._reap_dead_running(_after_heartbeat_grace())
+    reaper.service.list_running = original
+
+    assert reaper._suspect == set()
+
+    # ...so the run needs a fresh pair of sightings, not one.
+    await reaper._reap_dead_running(_after_heartbeat_grace())
+    assert (await service.get(run_id)).status == RunStatus.running

--- a/backend/tests/agents/runs/test_reaper.py
+++ b/backend/tests/agents/runs/test_reaper.py
@@ -1,0 +1,190 @@
+"""RunReaper — recovery of orphaned runs, and the two ways it used to destroy
+healthy ones (design review §5.2, §5.3).
+
+The reaper had no tests. It is also the only component in the system that
+finalizes runs *it did not start*, so a false positive here is indistinguishable
+from a crash as far as the user is concerned.
+
+The two reap passes are driven directly rather than through `_sweep`, and given
+an explicit `now` in the future instead of backdated rows. Two reasons: the
+SQLite lane stores `DateTime(timezone=True)` as naive (so a `datetime.now(UTC)`
+computed inside the reaper can't be subtracted from a column value — the same
+reason `test_repository.py` uses naive datetimes), and `updated_at` carries an
+`onupdate=func.now()`, so it cannot be backdated by an UPDATE anyway. Moving
+`now` forward tests the identical thresholds from the other side.
+"""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.agents.runs.liveness import DispatcherLiveness, RunLiveness
+from app.agents.runs.reaper import RunReaper
+from app.agents.runs.service import RunService
+from app.agents.runs.settings import run_settings
+from app.agents.runs.state import RunStatus
+
+
+pytestmark = pytest.mark.usefixtures("run_db")
+
+
+def _db_now() -> datetime:
+    """ "Now" on the same clock the row timestamps are on.
+
+    The columns are filled by `server_default=func.now()`, which SQLite renders
+    as `CURRENT_TIMESTAMP` — **UTC**, and naive. A plain `datetime.now()` is
+    local time, so on any machine east of Greenwich it reads as hours in the
+    future and every young run looks stale.
+    """
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _after_heartbeat_grace() -> datetime:
+    return _db_now() + timedelta(seconds=run_settings.heartbeat_timeout_seconds + 60)
+
+
+def _after_pending_timeout() -> datetime:
+    return _db_now() + timedelta(seconds=run_settings.pending_timeout_seconds + 60)
+
+
+async def _claimed(service: RunService, thread_id: str) -> str:
+    record = await service.create(
+        thread_id=thread_id, user_id=str(uuid4()), input={"messages": []}
+    )
+    claimed = await service.claim_next()
+    assert claimed is not None and claimed.id == record.id
+    return claimed.id
+
+
+# ---------------------------------------------------------------------------
+# §5.3 — a Redis restart must not mass-reap running runs
+# ---------------------------------------------------------------------------
+
+
+async def test_a_dead_looking_run_survives_its_first_sweep(redis):
+    """One missing liveness key is not proof of death: a Redis restart drops
+    every key at once, and a single-sample rule would kill the whole cluster's
+    in-flight runs."""
+    service = RunService(redis)
+    run_id = await _claimed(service, "t-first")
+
+    await RunReaper(redis)._reap_dead_running(_after_heartbeat_grace())
+
+    assert (await service.get(run_id)).status == RunStatus.running
+
+
+async def test_a_dead_run_is_reaped_on_the_second_consecutive_sweep(redis):
+    service = RunService(redis)
+    run_id = await _claimed(service, "t-second")
+    reaper = RunReaper(redis)
+
+    await reaper._reap_dead_running(_after_heartbeat_grace())
+    await reaper._reap_dead_running(_after_heartbeat_grace())
+
+    record = await service.get(run_id)
+    assert record.status == RunStatus.error
+    assert record.error == "Worker stopped responding."
+
+
+async def test_a_run_that_comes_back_to_life_resets_the_suspicion(redis):
+    """The Redis-restart scenario end to end: keys vanish, the reaper notices,
+    the workers stamp again on their next heartbeat, and nothing is reaped."""
+    service = RunService(redis)
+    run_id = await _claimed(service, "t-revived")
+    reaper = RunReaper(redis)
+
+    await reaper._reap_dead_running(_after_heartbeat_grace())  # first sighting
+    await RunLiveness(run_id, redis).stamp(ttl=60)  # worker heartbeats again
+    await reaper._reap_dead_running(_after_heartbeat_grace())  # alive — cleared
+    await RunLiveness(run_id, redis).clear()
+    await reaper._reap_dead_running(_after_heartbeat_grace())  # a *first* sighting
+
+    assert (await service.get(run_id)).status == RunStatus.running
+
+
+async def test_a_live_run_is_never_reaped(redis):
+    service = RunService(redis)
+    run_id = await _claimed(service, "t-live")
+    await RunLiveness(run_id, redis).stamp(ttl=60)
+    reaper = RunReaper(redis)
+
+    await reaper._reap_dead_running(_after_heartbeat_grace())
+    await reaper._reap_dead_running(_after_heartbeat_grace())
+
+    assert (await service.get(run_id)).status == RunStatus.running
+
+
+async def test_a_recently_claimed_run_is_inside_the_grace_window(redis):
+    """The claim → first-stamp gap must not look like death."""
+    service = RunService(redis)
+    run_id = await _claimed(service, "t-fresh")
+    reaper = RunReaper(redis)
+
+    await reaper._reap_dead_running(_db_now())
+    await reaper._reap_dead_running(_db_now())
+
+    assert (await service.get(run_id)).status == RunStatus.running
+
+
+# ---------------------------------------------------------------------------
+# §5.2 — a backlog must not look like an undispatched zombie
+# ---------------------------------------------------------------------------
+
+
+async def test_queued_runs_survive_while_a_dispatcher_is_alive(redis):
+    """The regression: ~30 trigger firings, each on a fresh thread, queue behind
+    a saturated worker pool. "Pending, old, no running run on its thread" is
+    exactly their shape, and they used to be killed mid-queue."""
+    service = RunService(redis)
+    queued = [
+        (
+            await service.create(
+                thread_id=f"t-queue-{i}", user_id=str(uuid4()), input={"messages": []}
+            )
+        ).id
+        for i in range(3)
+    ]
+    await DispatcherLiveness(redis).stamp(ttl=60)
+
+    await RunReaper(redis)._reap_undispatched_pending(_after_pending_timeout())
+
+    for run_id in queued:
+        assert (await service.get(run_id)).status == RunStatus.pending
+
+
+async def test_pending_runs_are_reaped_once_no_dispatcher_is_alive(redis):
+    """The case the rule is actually for: nothing in the cluster can claim."""
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="t-orphan", user_id=str(uuid4()), input={"messages": []}
+    )
+
+    await RunReaper(redis)._reap_undispatched_pending(_after_pending_timeout())
+
+    back = await service.get(record.id)
+    assert back.status == RunStatus.error
+    assert back.error == "Run was never dispatched."
+
+
+async def test_a_young_pending_run_is_never_reaped(redis):
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="t-young", user_id=str(uuid4()), input={"messages": []}
+    )
+
+    await RunReaper(redis)._reap_undispatched_pending(_db_now())
+
+    assert (await service.get(record.id)).status == RunStatus.pending
+
+
+async def test_dispatcher_liveness_expires_so_a_dead_cluster_is_detectable(redis):
+    """The gate is a self-expiring key, not a flag: a dispatcher that dies
+    without cleaning up must stop counting as alive on its own."""
+    liveness = DispatcherLiveness(redis)
+    await liveness.stamp(ttl=60)
+    assert await liveness.any_alive() is True
+
+    await redis.delete("run:dispatchers:alive")
+
+    assert await liveness.any_alive() is False

--- a/backend/tests/agents/runs/test_reaper.py
+++ b/backend/tests/agents/runs/test_reaper.py
@@ -266,3 +266,32 @@ async def test_a_failed_sweep_does_not_carry_suspicion_into_the_next_one(redis):
     # ...so the run needs a fresh pair of sightings, not one.
     await reaper._reap_dead_running(_after_heartbeat_grace())
     assert (await service.get(run_id)).status == RunStatus.running
+
+
+async def test_a_failed_sweep_does_not_leave_half_a_no_dispatcher_observation(redis):
+    """Same latch bug as `_suspect`, one method over: a sweep that fails after
+    recording "no dispatcher" let the next single check reap the queue."""
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="t-latch", user_id=str(uuid4()), input={"messages": []}
+    )
+    reaper = RunReaper(redis)
+
+    await reaper._reap_undispatched_pending(_after_pending_timeout())  # 1st sighting
+    assert reaper._saw_no_dispatcher is True
+
+    original = reaper.service.list_stuck_pending
+
+    async def _boom(_cutoff):
+        raise ConnectionError("postgres went away")
+
+    reaper.service.list_stuck_pending = _boom
+    with pytest.raises(ConnectionError):
+        await reaper._reap_undispatched_pending(_after_pending_timeout())
+    reaper.service.list_stuck_pending = original
+
+    assert reaper._saw_no_dispatcher is False
+
+    # ...so the next check is a first sighting again, not a reap.
+    await reaper._reap_undispatched_pending(_after_pending_timeout())
+    assert (await service.get(record.id)).status == RunStatus.pending

--- a/backend/tests/agents/runs/test_worker.py
+++ b/backend/tests/agents/runs/test_worker.py
@@ -1,14 +1,18 @@
 import asyncio
+from contextlib import suppress
 from uuid import uuid4
 
 import pytest
 
 import app.agents.runs.worker as worker_mod
+from app.agents.runs import keys
+from app.agents.runs.events import RunEventStream
+from app.agents.runs.liveness import DispatcherLiveness, RunLiveness
 from app.agents.runs.models import RunDB
 from app.agents.runs.service import RunService
 from app.agents.runs.settings import run_settings
 from app.agents.runs.state import RunStatus
-from app.agents.runs.worker import RunWorker
+from app.agents.runs.worker import RunDispatcher, RunWorker
 
 
 pytestmark = pytest.mark.usefixtures("run_db")
@@ -344,3 +348,146 @@ async def test_worker_clears_liveness_key_on_finish(redis):
     record = await _create_and_claim(service, thread_id="t8", input={"messages": []})
     await RunWorker(redis).run(record)
     assert not await RunLiveness(record.id, redis).is_alive()
+
+
+# ---------------------------------------------------------------------------
+# §5.1 — the heartbeat must survive a transient Redis error
+# ---------------------------------------------------------------------------
+
+
+async def test_heartbeat_survives_a_failing_stamp(redis, monkeypatch, until):
+    """One transient error used to kill this loop silently. Liveness then
+    expired and the reaper finalized a healthy streaming run as `error`."""
+    monkeypatch.setattr(run_settings, "heartbeat_interval_seconds", 0)
+    liveness = RunLiveness("r-hb", redis)
+    events = RunEventStream("r-hb", redis)
+    calls = 0
+
+    async def _flaky(**_):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ConnectionError("redis blipped")
+
+    monkeypatch.setattr(liveness, "stamp", _flaky)
+    task = asyncio.create_task(RunWorker(redis)._heartbeat(liveness, events))
+
+    async def _ticked_again() -> bool:
+        return calls >= 3
+
+    try:
+        # The regression is the loop dying at call 1; reaching call 3 proves it
+        # kept ticking past the failure.
+        await until(_ticked_again, what="the heartbeat to tick again")
+    finally:
+        task.cancel()
+
+
+async def test_heartbeat_refreshes_the_event_log_ttl(redis, monkeypatch, until):
+    """A run longer than the safety TTL must not expire its own live stream."""
+    monkeypatch.setattr(run_settings, "heartbeat_interval_seconds", 0)
+    events = RunEventStream("r-hb2", redis)
+    await events.publish("a")
+    await redis.expire(events._key, 5)
+
+    task = asyncio.create_task(
+        RunWorker(redis)._heartbeat(RunLiveness("r-hb2", redis), events)
+    )
+
+    async def _ttl_pushed_out() -> bool:
+        return await redis.ttl(events._key) > 5
+
+    try:
+        await until(_ttl_pushed_out, what="the heartbeat to push the event-log TTL out")
+    finally:
+        task.cancel()
+
+
+# ---------------------------------------------------------------------------
+# §5.2 — the dispatcher announces cluster liveness independently of its claim
+# loop, which blocks on a saturated semaphore
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatcher_announces_liveness_while_saturated(redis, monkeypatch, until):
+    """The claim loop blocks on `_semaphore.acquire()` when every slot is busy —
+    precisely the backlog the reaper must not mistake for "nothing dispatching".
+    So the announcement runs on its own timer."""
+    monkeypatch.setattr(run_settings, "heartbeat_interval_seconds", 0)
+    monkeypatch.setattr(run_settings, "worker_concurrency", 1)
+    dispatcher = RunDispatcher(redis)
+    await dispatcher._semaphore.acquire()  # saturate
+
+    task = asyncio.create_task(dispatcher.run())
+    try:
+        await until(
+            DispatcherLiveness(redis).any_alive,
+            what="a saturated dispatcher to announce itself",
+        )
+    finally:
+        await dispatcher.stop(drain_timeout=0.1)
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+# ---------------------------------------------------------------------------
+# §5.4 — ephemera must get a TTL even when the run row is gone
+# ---------------------------------------------------------------------------
+
+
+async def test_finalize_expires_ephemera_even_when_the_run_row_is_gone(redis):
+    """A thread deleted mid-run CASCADEs its runs away, so the terminal UPDATE
+    matches nothing. That used to skip `_expire_ephemera` entirely and leave the
+    event log and control key in Redis for ever — and nothing will ever finalize
+    this run again, so there is no second chance."""
+    service = RunService(redis)
+    run_id = "run-with-no-row"
+    events = RunEventStream(run_id, redis)
+    await events.publish("event: messages\ndata: 1\n\n")
+    await redis.rpush(keys.run_control_key(run_id), "cancel")
+    # The safety TTL from the first publish is the *other* half of this fix;
+    # strip it so this test only observes what finalize does.
+    await redis.persist(events._key)
+    assert await redis.ttl(events._key) == -1
+    assert await redis.ttl(keys.run_control_key(run_id)) == -1
+
+    assert await service.finalize(run_id, RunStatus.error, error="orphaned") is None
+
+    assert await redis.ttl(events._key) > 0
+    assert await redis.ttl(keys.run_control_key(run_id)) > 0
+
+
+# ---------------------------------------------------------------------------
+# §3.4 — the worker publishes through the buffer, not chunk by chunk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("patch_agent")
+async def test_a_chatty_run_does_not_pay_a_round_trip_per_chunk(
+    redis, monkeypatch, count_appends
+):
+    """The regression this guards is the worker quietly going back to
+    `events.publish(sse)` in the stream loop: correct, fully tested by every
+    other test here, and one Redis RTT per token."""
+
+    class _ChattyAgent(_FakeAgent):
+        async def stream(self, **kwargs):
+            for i in range(50):
+                yield f'event: messages\ndata: {{"t": {i}}}\n\n'
+
+    monkeypatch.setattr(worker_mod, "Agent", _ChattyAgent)
+    monkeypatch.setattr(run_settings, "event_buffer_max_chunks", 25)
+    service = RunService(redis)
+    record = await _create_and_claim(
+        service, thread_id="t-chatty", input={"messages": []}
+    )
+    appends = count_appends(redis)
+
+    await RunWorker(redis).run(record)
+
+    # Only the end sentinel goes through a direct XADD; the 50 stream chunks
+    # ride in pipelines.
+    assert appends["xadd"] == 1
+    chunks = [c async for c in service.stream(record.id, "0")]
+    assert len([c for c in chunks if "event: messages" in c]) == 50

--- a/backend/tests/agents/runs/test_worker.py
+++ b/backend/tests/agents/runs/test_worker.py
@@ -414,12 +414,32 @@ def isolated_registry(monkeypatch):
     """`RunDispatcher` registers its health in the process-wide registry on
     construction, and a cancelled task never reaches the cleanup that marks it
     stopped — so without this, later tests (and /health) see a dispatcher that
-    does not exist."""
+    does not exist.
+
+    Patching `app.background.registry` is enough only because registration goes
+    through `register_loop()`, which resolves that global at call time. The
+    first version of this fixture patched the attribute while `worker.py` held
+    the registry object it had imported by value, so it isolated nothing —
+    hence the seam.
+    """
     from app.background import LoopRegistry
 
     registry = LoopRegistry()
     monkeypatch.setattr("app.background.registry", registry)
     return registry
+
+
+async def test_the_isolated_registry_fixture_actually_isolates(
+    redis, isolated_registry
+):
+    """Guards the fixture itself: it silently isolated nothing while `worker.py`
+    used its own imported reference to the registry."""
+    from app.background import registry as process_registry
+
+    RunDispatcher(redis)
+
+    assert [loop.name for loop in isolated_registry.loops] == ["run-dispatcher"]
+    assert process_registry is isolated_registry
 
 
 async def test_dispatcher_announces_liveness_while_saturated(

--- a/backend/tests/agents/runs/test_worker.py
+++ b/backend/tests/agents/runs/test_worker.py
@@ -409,7 +409,22 @@ async def test_heartbeat_refreshes_the_event_log_ttl(redis, monkeypatch, until):
 # ---------------------------------------------------------------------------
 
 
-async def test_dispatcher_announces_liveness_while_saturated(redis, monkeypatch, until):
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """`RunDispatcher` registers its health in the process-wide registry on
+    construction, and a cancelled task never reaches the cleanup that marks it
+    stopped — so without this, later tests (and /health) see a dispatcher that
+    does not exist."""
+    from app.background import LoopRegistry
+
+    registry = LoopRegistry()
+    monkeypatch.setattr("app.background.registry", registry)
+    return registry
+
+
+async def test_dispatcher_announces_liveness_while_saturated(
+    redis, monkeypatch, until, isolated_registry
+):
     """The claim loop blocks on `_semaphore.acquire()` when every slot is busy —
     precisely the backlog the reaper must not mistake for "nothing dispatching".
     So the announcement runs on its own timer."""
@@ -491,3 +506,77 @@ async def test_a_chatty_run_does_not_pay_a_round_trip_per_chunk(
     assert appends["xadd"] == 1
     chunks = [c async for c in service.stream(record.id, "0")]
     assert len([c for c in chunks if "event: messages" in c]) == 50
+
+
+async def test_a_losing_finalize_does_not_disturb_a_live_run(redis):
+    """A pending cancel (or a reaper sweep) can lose a race with a dispatcher
+    claim: the guarded UPDATE matches nothing while the run is now `running`.
+    Clearing its liveness key there fakes a dead worker for the reaper — the
+    exact failure the two-sample rule exists to prevent."""
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="t-race", user_id=str(uuid4()), input={"messages": []}
+    )
+    claimed = await service.claim_next()
+    assert claimed is not None
+    liveness = RunLiveness(record.id, redis)
+    await liveness.stamp(ttl=60)
+
+    # The reaper reaps a *pending* zombie; the dispatcher already claimed it.
+    result = await service.finalize(
+        record.id,
+        RunStatus.error,
+        error="Run was never dispatched.",
+        expected=RunStatus.pending,
+    )
+
+    assert result.status == RunStatus.running  # untouched
+    assert await liveness.is_alive() is True
+
+
+async def test_an_already_terminal_finalize_still_expires_ephemera(redis):
+    """The idempotent re-finalize (worker and reaper may both call it) must
+    still leave the ephemera on a TTL."""
+    service = RunService(redis)
+    record = await service.create(
+        thread_id="t-twice", user_id=str(uuid4()), input={"messages": []}
+    )
+    await service.claim_next()
+    await service.finalize(record.id, RunStatus.success)
+    await redis.persist(keys.run_events_key(record.id))
+
+    await service.finalize(record.id, RunStatus.success)
+
+    assert await redis.ttl(keys.run_events_key(record.id)) > 0
+
+
+async def test_a_saturated_dispatcher_stays_healthy(
+    redis, monkeypatch, until, isolated_registry
+):
+    """The regression: health used to be ticked by the claim loop, which blocks
+    on the semaphore for the whole length of an agent turn. A fully occupied
+    dispatcher went stale in about a minute, so /health returned 503 and the
+    platform recycled a healthy, busy worker mid-run — worse than the failure
+    /health exists to catch."""
+    monkeypatch.setattr(run_settings, "heartbeat_interval_seconds", 0)
+    monkeypatch.setattr(run_settings, "worker_concurrency", 1)
+    dispatcher = RunDispatcher(redis)
+    await dispatcher._semaphore.acquire()  # every slot busy on a long run
+
+    task = asyncio.create_task(dispatcher.run())
+    try:
+        # Two ticks, so this cannot pass on the single mark_tick() in `run()`.
+        ticks = []
+
+        async def _ticked_twice() -> bool:
+            ticks.append(dispatcher.health.last_tick_at)
+            return len({t for t in ticks if t is not None}) >= 2
+
+        await until(_ticked_twice, what="a saturated dispatcher to keep ticking health")
+    finally:
+        await dispatcher.stop(drain_timeout=0.1)
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    assert dispatcher.health.is_healthy() is True

--- a/backend/tests/auth/test_utils.py
+++ b/backend/tests/auth/test_utils.py
@@ -4,6 +4,7 @@ The auth module had no tests at all (backend design review §6.2), which is a ba
 place for a coverage hole: these four functions gate every authenticated request.
 """
 
+import asyncio
 from datetime import timedelta
 from uuid import uuid4
 
@@ -24,26 +25,47 @@ from app.auth.utils import (
 # ---------------------------------------------------------------------------
 
 
-def test_hash_verifies_against_its_own_password():
-    hashed = get_password_hash("correct horse battery staple")
+async def test_hash_verifies_against_its_own_password():
+    hashed = await get_password_hash("correct horse battery staple")
 
-    assert verify_password("correct horse battery staple", hashed) is True
-
-
-def test_hash_rejects_a_wrong_password():
-    hashed = get_password_hash("correct horse battery staple")
-
-    assert verify_password("Correct horse battery staple", hashed) is False
+    assert await verify_password("correct horse battery staple", hashed) is True
 
 
-def test_hashes_are_salted_so_the_same_password_hashes_differently():
-    assert get_password_hash("same") != get_password_hash("same")
+async def test_hash_rejects_a_wrong_password():
+    hashed = await get_password_hash("correct horse battery staple")
+
+    assert await verify_password("Correct horse battery staple", hashed) is False
 
 
-def test_hash_is_argon2id():
+async def test_hashes_are_salted_so_the_same_password_hashes_differently():
+    assert await get_password_hash("same") != await get_password_hash("same")
+
+
+async def test_hash_is_argon2id():
     """PAT lookup scans candidates by prefix and verifies each one, so knowing
     which algorithm is on the request path matters (§3.1 / P1-1)."""
-    assert get_password_hash("x").startswith("$argon2id$")
+    assert (await get_password_hash("x")).startswith("$argon2id$")
+
+
+async def test_hashing_does_not_block_the_event_loop():
+    """P1-2: Argon2 must run in a thread. A coroutine sharing the loop with a
+    hash has to keep making progress while the hash is in flight — which it can
+    only do if the hash is not running on the loop itself."""
+    ticks = 0
+
+    async def heartbeat() -> None:
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0)
+
+    beat = asyncio.create_task(heartbeat())
+    try:
+        await get_password_hash("some password")
+    finally:
+        beat.cancel()
+
+    assert ticks > 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -20,10 +20,12 @@ except ValidationError:
     # sys.modules, so the real import below re-executes with this in place.
     os.environ["SALT"] = "test-salt-not-a-real-secret"
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from fakeredis import FakeServer, aioredis
 from fastapi.testclient import TestClient
 
 from app.auth.dependencies import (
@@ -34,6 +36,23 @@ from app.auth.dependencies import (
 from app.database import get_db
 from app.main import app
 from app.users.models import UserDB, WorkspaceRole
+
+
+@pytest.fixture(autouse=True)
+def fake_shared_redis(monkeypatch):
+    """Every test gets a fresh in-memory Redis behind `app.redis_client`.
+
+    Autouse and unconditional on purpose. Code reached through the shared client
+    is often several layers below the thing under test — `probe_authorization`'s
+    memo, the token storage the MCP client builds — and if it fell through to the
+    real client the test would quietly connect to whatever is on localhost:6379,
+    passing on a developer's machine and hanging or erroring in CI.
+
+    Tests that need to inspect what was written can request this fixture by name.
+    """
+    client = aioredis.FakeRedis(server=FakeServer(), decode_responses=True)
+    monkeypatch.setattr("app.redis_client._redis", client)
+    return client
 
 
 @pytest.fixture
@@ -107,3 +126,27 @@ def admin_user():
     app.dependency_overrides[require_admin] = lambda: user
     yield user
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def until():
+    """Wait for a background task to make progress, with a deadline.
+
+    Several tests here assert that a task *keeps running* — the heartbeat, the
+    dispatcher's liveness announcement, the event buffer's periodic flusher. The
+    regression each one guards is that task dying, and with a plain `while` loop
+    that turns into a hung suite instead of a failing test.
+    """
+
+    async def _until(condition, *, what: str, seconds: float = 1.0) -> None:
+        try:
+            async with asyncio.timeout(seconds):
+                # Polling is the point: yielding hands control to the task under
+                # test. There is no event to wait on — that is what is being
+                # verified.
+                while not await condition():  # noqa: ASYNC110
+                    await asyncio.sleep(0.001)
+        except TimeoutError:
+            pytest.fail(f"timed out waiting for {what}")
+
+    return _until

--- a/backend/tests/integrations/langfuse/test_callback.py
+++ b/backend/tests/integrations/langfuse/test_callback.py
@@ -52,3 +52,92 @@ def test_langfuse_client_receives_configured_timeout(monkeypatch):
     callback_constructor.assert_called_once_with()
     assert client is langfuse_constructor.return_value
     assert handler is callback_constructor.return_value
+
+
+# ---------------------------------------------------------------------------
+# lazy construction + shutdown flush (P1-17)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _unbuilt(monkeypatch):
+    """Reset the module memo so each test observes a first build."""
+    monkeypatch.setattr(callback, "_built", False)
+    monkeypatch.setattr(callback, "_client", None)
+    monkeypatch.setattr(callback, "_handler", None)
+
+
+def _configure(monkeypatch):
+    monkeypatch.setattr(callback.langfuse_settings, "langfuse_public_key", "pk-test")
+    monkeypatch.setattr(callback.langfuse_settings, "langfuse_secret_key", "sk-test")
+    monkeypatch.setattr(
+        callback.langfuse_settings, "langfuse_base_url", "https://langfuse.test"
+    )
+
+
+def test_a_broken_langfuse_config_does_not_break_the_agent_runtime(monkeypatch):
+    """The regression: this was a module-level constant, and `runtime.py` imports
+    it — so a bad base URL took down every import of the agent runtime at
+    startup, for an optional integration."""
+    _configure(monkeypatch)
+    monkeypatch.setattr(
+        callback, "Langfuse", MagicMock(side_effect=ValueError("bad host"))
+    )
+
+    assert callback.get_langfuse_callback_handler() is None
+
+
+def test_the_client_is_built_once_not_per_run(monkeypatch):
+    """`CallbackHandler` is attached to every agent run; rebuilding would mean a
+    fresh exporter thread per run."""
+    _configure(monkeypatch)
+    constructor = MagicMock()
+    monkeypatch.setattr(callback, "Langfuse", constructor)
+    monkeypatch.setattr(callback, "CallbackHandler", MagicMock())
+
+    first = callback.get_langfuse_callback_handler()
+    second = callback.get_langfuse_callback_handler()
+
+    assert first is second
+    constructor.assert_called_once()
+
+
+def test_no_handler_when_unconfigured(monkeypatch):
+    monkeypatch.setattr(callback.langfuse_settings, "langfuse_public_key", None)
+    constructor = MagicMock()
+    monkeypatch.setattr(callback, "Langfuse", constructor)
+
+    assert callback.get_langfuse_callback_handler() is None
+    constructor.assert_not_called()
+
+
+def test_flush_ships_buffered_traces(monkeypatch):
+    _configure(monkeypatch)
+    client = MagicMock()
+    monkeypatch.setattr(callback, "Langfuse", MagicMock(return_value=client))
+    monkeypatch.setattr(callback, "CallbackHandler", MagicMock())
+    callback.get_langfuse_callback_handler()  # build it
+
+    callback.flush_langfuse()
+
+    client.flush.assert_called_once()
+
+
+def test_flush_does_not_build_a_client_the_process_never_needed(monkeypatch):
+    constructor = MagicMock()
+    monkeypatch.setattr(callback, "Langfuse", constructor)
+
+    callback.flush_langfuse()
+
+    constructor.assert_not_called()
+
+
+def test_a_failing_flush_does_not_fail_shutdown(monkeypatch):
+    _configure(monkeypatch)
+    client = MagicMock()
+    client.flush.side_effect = RuntimeError("langfuse unreachable")
+    monkeypatch.setattr(callback, "Langfuse", MagicMock(return_value=client))
+    monkeypatch.setattr(callback, "CallbackHandler", MagicMock())
+    callback.get_langfuse_callback_handler()
+
+    callback.flush_langfuse()  # must not raise

--- a/backend/tests/mcp/client/test_connectivity.py
+++ b/backend/tests/mcp/client/test_connectivity.py
@@ -6,16 +6,23 @@ pagination guards in tests/mcp/servers/test_connect_to_server.py.
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
+import pytest
+from fakeredis import FakeServer, aioredis
+
+from app.exceptions import DomainError, PermissionDeniedError
 from app.mcp.client import connectivity
+from app.mcp.client.exceptions import OAuthAuthorizationRequired
 from app.mcp.servers.models import MCPAuthType
 
 
-def _server(auth_type):
+def _server(auth_type, server_id="s1"):
     return SimpleNamespace(
-        id="s1", url="https://mcp.example.com/mcp", auth_type=auth_type
+        id=server_id, url="https://mcp.example.com/mcp", auth_type=auth_type
     )
 
 
@@ -66,3 +73,209 @@ async def test_probe_candidate_rejects_oauth_before_saving():
     assert result.reachable is False
     assert result.oauth_required is False
     assert "saved" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# probe_authorization (P1-6) — the single concurrent, fail-open, memoized probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def probe_redis(monkeypatch):
+    client = aioredis.FakeRedis(server=FakeServer(), decode_responses=True)
+    monkeypatch.setattr(connectivity, "get_redis", lambda: client)
+    yield client
+    await client.aclose()
+
+
+async def test_probe_returns_empty_without_touching_redis():
+    with patch.object(connectivity, "get_redis") as get_redis:
+        assert await connectivity.probe_authorization([], "u1") == {}
+    get_redis.assert_not_called()
+
+
+async def test_probe_runs_concurrently(probe_redis):
+    """Sequential probes are what made the polled readiness endpoint slow: each
+    one can do a token-refresh POST. All three must be in flight at once."""
+    import asyncio
+
+    servers = [_server(MCPAuthType.oauth2, uuid4()) for _ in range(3)]
+    in_flight = 0
+    peak = 0
+
+    async def _slow(server, user_id, **_):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return True
+
+    with patch.object(connectivity, "is_authorized", _slow):
+        result = await connectivity.probe_authorization(servers, "u1")
+
+    assert peak == 3
+    assert result == {s.id: True for s in servers}
+
+
+async def test_probe_fails_open_when_one_probe_raises(probe_redis):
+    """Readiness is a convenience, not a security boundary — the server itself
+    rejects unauthorized calls. An IdP outage must not make agents unlaunchable."""
+    good, bad = (
+        _server(MCPAuthType.oauth2, uuid4()),
+        _server(MCPAuthType.oauth2, uuid4()),
+    )
+
+    async def _flaky(server, user_id, **_):
+        if server.id == bad.id:
+            raise RuntimeError("IdP is down")
+        return False
+
+    with patch.object(connectivity, "is_authorized", _flaky):
+        result = await connectivity.probe_authorization([good, bad], "u1")
+
+    assert result == {good.id: False, bad.id: True}
+
+
+async def test_probe_memoizes_a_positive_so_the_polling_loop_stops_refreshing(
+    probe_redis,
+):
+    server = _server(MCPAuthType.oauth2, uuid4())
+    probe = AsyncMock(return_value=True)
+
+    with patch.object(connectivity, "is_authorized", probe):
+        first = await connectivity.probe_authorization([server], "u1")
+        second = await connectivity.probe_authorization([server], "u1")
+
+    assert first == second == {server.id: True}
+    probe.assert_awaited_once()
+    assert await probe_redis.ttl(f"mcp:authprobe:u1:{server.id}") > 0
+
+
+async def test_probe_does_not_memoize_a_negative(probe_redis):
+    """A user who has just finished the OAuth popup must not keep reading as
+    disconnected for the length of the TTL."""
+    server = _server(MCPAuthType.oauth2, uuid4())
+    probe = AsyncMock(return_value=False)
+
+    with patch.object(connectivity, "is_authorized", probe):
+        await connectivity.probe_authorization([server], "u1")
+        await connectivity.probe_authorization([server], "u1")
+
+    assert probe.await_count == 2
+
+
+async def test_probe_cache_is_scoped_per_user(probe_redis):
+    server = _server(MCPAuthType.oauth2, uuid4())
+    probe = AsyncMock(return_value=True)
+
+    with patch.object(connectivity, "is_authorized", probe):
+        await connectivity.probe_authorization([server], "alice")
+        await connectivity.probe_authorization([server], "bob")
+
+    assert probe.await_count == 2
+
+
+async def test_probe_survives_a_redis_outage(monkeypatch):
+    """A cache failure degrades to probing, never to failing — this sits on the
+    endpoint the frontend polls."""
+    broken = SimpleNamespace(
+        mget=AsyncMock(side_effect=RuntimeError("redis down")),
+        pipeline=lambda **_: (_ for _ in ()).throw(RuntimeError("redis down")),
+    )
+    monkeypatch.setattr(connectivity, "get_redis", lambda: broken)
+    server = _server(MCPAuthType.oauth2, uuid4())
+
+    with patch.object(connectivity, "is_authorized", AsyncMock(return_value=True)):
+        result = await connectivity.probe_authorization([server], "u1")
+
+    assert result == {server.id: True}
+
+
+async def test_probe_dedupes_a_server_bound_by_both_parent_and_subagent(probe_redis):
+    server = _server(MCPAuthType.oauth2, uuid4())
+    probe = AsyncMock(return_value=True)
+
+    with patch.object(connectivity, "is_authorized", probe):
+        result = await connectivity.probe_authorization([server, server], "u1")
+
+    assert result == {server.id: True}
+    probe.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _open_session (P1-14) — the try wraps the handshake, not the caller's body
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def initialize(self):
+        return None
+
+
+@pytest.fixture
+def open_session(monkeypatch):
+    """Stub the transport + SDK session so `_open_session` reaches its yield."""
+
+    @asynccontextmanager
+    async def _transport(**_kwargs):
+        yield (None, None, None)
+
+    monkeypatch.setattr(connectivity, "streamablehttp_client", _transport)
+    monkeypatch.setattr(connectivity, "ClientSession", _FakeSession)
+    monkeypatch.setattr(
+        connectivity, "_list_all_tools", AsyncMock(return_value=["tool-a"])
+    )
+
+
+async def test_open_session_yields_the_listed_tools(open_session):
+    async with connectivity._open_session("https://mcp.example.com/mcp") as (
+        _session,
+        tools,
+    ):
+        assert tools == ["tool-a"]
+
+
+async def test_a_caller_body_exception_propagates_unchanged(open_session):
+    """The regression: the `yield` used to sit inside the `except Exception`
+    wrapper, so a `PermissionDeniedError` raised by the caller came back out as
+    a `DomainError` — a 500 carrying someone else's message."""
+    with pytest.raises(PermissionDeniedError, match="the caller's own error"):
+        async with connectivity._open_session("https://mcp.example.com/mcp"):
+            raise PermissionDeniedError("the caller's own error")
+
+
+async def test_a_failing_tools_list_is_still_wrapped(open_session, monkeypatch):
+    """The wrapping that should stay: a handshake failure gets a clean message."""
+    monkeypatch.setattr(
+        connectivity,
+        "_list_all_tools",
+        AsyncMock(side_effect=RuntimeError("server hung up")),
+    )
+
+    with pytest.raises(DomainError, match="server hung up"):
+        async with connectivity._open_session("https://mcp.example.com/mcp"):
+            pass  # pragma: no cover — never reached
+
+
+async def test_an_oauth_requirement_is_not_wrapped(open_session, monkeypatch):
+    """`test_connection` translates this into an `oauth_required` result, so it
+    must not arrive as a generic DomainError."""
+    monkeypatch.setattr(
+        connectivity,
+        "_list_all_tools",
+        AsyncMock(side_effect=OAuthAuthorizationRequired("https://auth.example")),
+    )
+
+    with pytest.raises(OAuthAuthorizationRequired):
+        async with connectivity._open_session("https://mcp.example.com/mcp"):
+            pass  # pragma: no cover — never reached

--- a/backend/tests/mcp/client/test_connectivity.py
+++ b/backend/tests/mcp/client/test_connectivity.py
@@ -149,7 +149,7 @@ async def test_probe_memoizes_a_positive_so_the_polling_loop_stops_refreshing(
 
     assert first == second == {server.id: True}
     probe.assert_awaited_once()
-    assert await probe_redis.ttl(f"mcp:authprobe:u1:{server.id}") > 0
+    assert await probe_redis.ttl(f"mcp:u1:{server.id}:authprobe") > 0
 
 
 async def test_probe_does_not_memoize_a_negative(probe_redis):
@@ -279,3 +279,59 @@ async def test_an_oauth_requirement_is_not_wrapped(open_session, monkeypatch):
     with pytest.raises(OAuthAuthorizationRequired):
         async with connectivity._open_session("https://mcp.example.com/mcp"):
             pass  # pragma: no cover — never reached
+
+
+async def test_the_probe_cache_lives_where_the_purges_can_reach_it(probe_redis):
+    """The cache key must sit inside `mcp:{user}:{server}:...`, the layout
+    `TokenStorageFactory.clear_server_data` / `clear_user_server_data` scan
+    (`mcp:*:{server_id}:*`). Outside it, the key survives every purge — so a
+    user who revoked their connection, or a server whose URL just changed, would
+    keep reading as authorized from a cache nothing knows how to invalidate."""
+    from app.mcp.client.storage import TokenStorageFactory
+
+    server = _server(MCPAuthType.oauth2, uuid4())
+    with patch.object(connectivity, "is_authorized", AsyncMock(return_value=True)):
+        await connectivity.probe_authorization([server], "u1")
+    assert await probe_redis.exists(f"mcp:u1:{server.id}:authprobe")
+
+    deleted = await TokenStorageFactory(redis=probe_redis).clear_server_data(
+        str(server.id)
+    )
+
+    assert deleted >= 1
+    assert not await probe_redis.exists(f"mcp:u1:{server.id}:authprobe")
+
+
+async def test_a_stalled_redis_does_not_hang_the_polled_endpoint(monkeypatch):
+    """Fail-open only catches raised errors. A Redis that accepts the connection
+    then stalls would hang readiness and the run-start preflight indefinitely."""
+    import asyncio as _asyncio
+
+    async def _never_returns(*_args, **_kwargs):
+        await _asyncio.Event().wait()
+
+    class _StallingPipeline:
+        """Stalls on entry, the way a wedged connection would — so the write
+        path is timed out rather than failing on a type error."""
+
+        async def __aenter__(self):
+            await _asyncio.Event().wait()
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    monkeypatch.setattr(connectivity, "_CACHE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        connectivity,
+        "get_redis",
+        lambda: SimpleNamespace(
+            mget=_never_returns, pipeline=lambda **_kw: _StallingPipeline()
+        ),
+    )
+    server = _server(MCPAuthType.oauth2, uuid4())
+
+    with patch.object(connectivity, "is_authorized", AsyncMock(return_value=True)):
+        async with _asyncio.timeout(2):
+            result = await connectivity.probe_authorization([server], "u1")
+
+    assert result == {server.id: True}

--- a/backend/tests/mcp/client/test_storage.py
+++ b/backend/tests/mcp/client/test_storage.py
@@ -4,6 +4,7 @@ from fnmatch import fnmatch
 import pytest
 from mcp.shared.auth import OAuthToken
 
+from app.mcp.client import storage as storage_module
 from app.mcp.client.storage import RedisTokenStorage, TokenStorageFactory
 
 
@@ -79,9 +80,20 @@ async def test_set_tokens_without_existing_token_stores_as_is():
 
 
 def _factory() -> TokenStorageFactory:
-    factory = TokenStorageFactory.__new__(TokenStorageFactory)
-    factory.redis = _FakeRedis()
-    return factory
+    return TokenStorageFactory(redis=_FakeRedis())
+
+
+def test_factory_borrows_the_app_wide_client_instead_of_opening_a_pool(monkeypatch):
+    """P1-3: the factory used to build its own never-closed `ConnectionPool` in
+    `__init__`, once per call at eight call sites. It must now hand back the
+    lifespan-managed client so nothing leaks."""
+    shared = _FakeRedis()
+    monkeypatch.setattr(storage_module, "get_redis", lambda: shared)
+
+    factory = TokenStorageFactory()
+
+    assert factory.redis is shared
+    assert factory.get_storage("u1", "s1").redis is shared
 
 
 @pytest.mark.asyncio

--- a/backend/tests/mcp/servers/test_repository.py
+++ b/backend/tests/mcp/servers/test_repository.py
@@ -1,5 +1,9 @@
-"""Tests for MCPServerRepository.update_oauth_credentials — the partial patch
-that lets the edit form change client_id while keeping the stored secret.
+"""Tests for MCPServerRepository.
+
+`update_oauth_credentials` — the partial patch that lets the edit form change
+client_id while keeping the stored secret — plus `list_by_ids`, the shared read
+that replaced three copies of `select(MCPServerDB).where(id.in_(...))` scattered
+across the agents module (design review §2.1 / P1-7).
 """
 
 from __future__ import annotations
@@ -70,3 +74,23 @@ async def test_no_existing_credentials_with_both_creates():
     repo.create_or_update_oauth_credentials.assert_awaited_once_with(
         sid, "id", "sec", None
     )
+
+
+async def test_list_by_ids_does_not_query_for_an_empty_id_set():
+    """`IN ()` is a round-trip for a known-empty answer, and every caller
+    reaches this with an empty set whenever an agent binds no servers."""
+    repo = _repo()
+
+    assert await repo.list_by_ids([]) == []
+
+    repo.db.execute.assert_not_awaited()
+
+
+async def test_list_by_ids_returns_the_rows():
+    rows = [SimpleNamespace(id=uuid4()), SimpleNamespace(id=uuid4())]
+    repo = _repo()
+    result = AsyncMock()
+    result.scalars = lambda: SimpleNamespace(all=lambda: rows)
+    repo.db.execute = AsyncMock(return_value=result)
+
+    assert await repo.list_by_ids([r.id for r in rows]) == rows

--- a/backend/tests/mcp/servers/test_service.py
+++ b/backend/tests/mcp/servers/test_service.py
@@ -610,7 +610,7 @@ async def test_leaving_oauth_deletes_the_now_dead_oauth_credentials(
     token_storage.clear_server_data.assert_awaited_once()
 
 
-async def test_leaving_api_key_deletes_the_now_dead_api_key(
+async def test_leaving_api_key_deletes_the_now_dead_api_key_and_purges_redis(
     service, mock_repo, token_storage
 ):
     before = _server_at("https://mcp.example.com/mcp", MCPAuthType.api_key)
@@ -622,6 +622,9 @@ async def test_leaving_api_key_deletes_the_now_dead_api_key(
     await service.update(before.id, MCPServerPatch(auth_type=MCPAuthType.oauth2))
 
     mock_repo.delete_credentials.assert_awaited_once_with(before.id, api_key=True)
+    # Both directions must purge: stale per-user OAuth state left behind here
+    # would report users as connected to a server they have never authorized.
+    token_storage.clear_server_data.assert_awaited_once_with(str(before.id))
 
 
 async def test_an_unrelated_edit_purges_nothing(service, mock_repo, token_storage):

--- a/backend/tests/mcp/servers/test_service.py
+++ b/backend/tests/mcp/servers/test_service.py
@@ -19,7 +19,7 @@ from app.mcp.client import connectivity as connectivity_module
 from app.mcp.client.connectivity import build_oauth_provider
 from app.mcp.servers import service as service_module
 from app.mcp.servers.models import MCPAuthType
-from app.mcp.servers.schemas import MCPServerCreate
+from app.mcp.servers.schemas import MCPServerCreate, MCPServerPatch
 from app.mcp.servers.service import MCPServerService
 
 
@@ -133,6 +133,7 @@ def mock_repo():
     repo.create_or_update_oauth_credentials = AsyncMock()
     repo.update_oauth_credentials = AsyncMock()
     repo.get_oauth_credentials = AsyncMock()
+    repo.delete_credentials = AsyncMock()
     return repo
 
 
@@ -215,8 +216,6 @@ async def test_create_still_validates_api_key_for_new_url(service, mock_repo):
 async def test_update_patches_client_id_without_secret(service, mock_repo):
     # Editing the client_id while leaving the secret blank must patch client_id
     # and pass client_secret=None so the stored secret is kept.
-    from app.mcp.servers.schemas import MCPServerPatch
-
     server = make_mcp_server()
     server.auth_type = MCPAuthType.oauth2
     mock_repo.get.return_value = server
@@ -231,8 +230,6 @@ async def test_update_patches_client_id_without_secret(service, mock_repo):
 
 
 async def test_update_skips_oauth_when_no_credential_fields(service, mock_repo):
-    from app.mcp.servers.schemas import MCPServerPatch
-
     server = make_mcp_server()
     server.auth_type = MCPAuthType.oauth2
     mock_repo.get.return_value = server
@@ -455,8 +452,6 @@ async def test_delete_connection_clears_only_that_users_keys(
 
 
 async def test_update_persists_auth_method_only(service, mock_repo):
-    from app.mcp.servers.schemas import MCPServerPatch
-
     server = make_mcp_server()
     server.auth_type = MCPAuthType.oauth2
     mock_repo.get.return_value = server
@@ -555,3 +550,113 @@ async def test_delete_with_detach_agents_removes_bindings_first(
 
     bindings.delete_all_for_server.assert_awaited_once_with(server_id)
     mock_repo.delete.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# update — purging state the edit invalidated (design review §5.8 / P1-15)
+# ---------------------------------------------------------------------------
+
+
+def _server_at(url: str, auth_type: MCPAuthType, server_id=None):
+    server = make_mcp_server(url=url)
+    if server_id is not None:
+        server.id = server_id
+    server.auth_type = auth_type
+    return server
+
+
+@pytest.fixture
+def token_storage(monkeypatch):
+    """A stand-in TokenStorageFactory reporting 3 purged keys."""
+    factory = MagicMock(clear_server_data=AsyncMock(return_value=3))
+    monkeypatch.setattr(
+        service_module, "TokenStorageFactory", MagicMock(return_value=factory)
+    )
+    return factory
+
+
+async def test_changing_the_url_purges_tokens_minted_for_the_old_resource(
+    service, mock_repo, token_storage
+):
+    """Access tokens, refresh tokens, the DCR registration and the cached AS
+    metadata were all issued for the old URL. A surviving refresh token is worse
+    than none: `is_authorized` keeps reporting the user as connected."""
+    before = _server_at("https://old.example.com/mcp", MCPAuthType.oauth2)
+    mock_repo.get.return_value = before
+    mock_repo.update.return_value = _server_at(
+        "https://new.example.com/mcp", MCPAuthType.oauth2, server_id=before.id
+    )
+
+    await service.update(before.id, MCPServerPatch(url="https://new.example.com/mcp"))
+
+    token_storage.clear_server_data.assert_awaited_once_with(str(before.id))
+    # Admin-entered config survives: re-pointing a server must not silently
+    # discard a client id/secret the admin typed.
+    mock_repo.delete_credentials.assert_not_awaited()
+
+
+async def test_leaving_oauth_deletes_the_now_dead_oauth_credentials(
+    service, mock_repo, token_storage
+):
+    before = _server_at("https://mcp.example.com/mcp", MCPAuthType.oauth2)
+    mock_repo.get.return_value = before
+    mock_repo.update.return_value = _server_at(
+        "https://mcp.example.com/mcp", MCPAuthType.api_key, server_id=before.id
+    )
+
+    await service.update(before.id, MCPServerPatch(auth_type=MCPAuthType.api_key))
+
+    mock_repo.delete_credentials.assert_awaited_once_with(before.id, api_key=False)
+    token_storage.clear_server_data.assert_awaited_once()
+
+
+async def test_leaving_api_key_deletes_the_now_dead_api_key(
+    service, mock_repo, token_storage
+):
+    before = _server_at("https://mcp.example.com/mcp", MCPAuthType.api_key)
+    mock_repo.get.return_value = before
+    mock_repo.update.return_value = _server_at(
+        "https://mcp.example.com/mcp", MCPAuthType.oauth2, server_id=before.id
+    )
+
+    await service.update(before.id, MCPServerPatch(auth_type=MCPAuthType.oauth2))
+
+    mock_repo.delete_credentials.assert_awaited_once_with(before.id, api_key=True)
+
+
+async def test_an_unrelated_edit_purges_nothing(service, mock_repo, token_storage):
+    """Renaming a server must not disconnect every user of it."""
+    before = _server_at("https://mcp.example.com/mcp", MCPAuthType.oauth2)
+    mock_repo.get.return_value = before
+    mock_repo.update.return_value = before
+
+    await service.update(before.id, MCPServerPatch(name="Renamed"))
+
+    token_storage.clear_server_data.assert_not_awaited()
+    mock_repo.delete_credentials.assert_not_awaited()
+
+
+async def test_a_redis_outage_does_not_fail_the_edit(service, mock_repo, monkeypatch):
+    """The cost of a missed purge is a stale token, which the next authorization
+    overwrites. The cost of a failed edit is an admin who cannot fix a server."""
+    before = _server_at("https://old.example.com/mcp", MCPAuthType.oauth2)
+    after = _server_at(
+        "https://new.example.com/mcp", MCPAuthType.oauth2, server_id=before.id
+    )
+    mock_repo.get.return_value = before
+    mock_repo.update.return_value = after
+    monkeypatch.setattr(
+        service_module,
+        "TokenStorageFactory",
+        MagicMock(
+            return_value=MagicMock(
+                clear_server_data=AsyncMock(side_effect=RuntimeError("redis down"))
+            )
+        ),
+    )
+
+    result = await service.update(
+        before.id, MCPServerPatch(url="https://new.example.com/mcp")
+    )
+
+    assert result is after

--- a/backend/tests/test_background.py
+++ b/backend/tests/test_background.py
@@ -94,7 +94,7 @@ async def test_a_persistent_failure_backs_off_instead_of_spinning(until, monkeyp
 
     assert waits[:3] == [0.001, 0.002, 0.004]  # doubling
     assert loop.health.consecutive_failures >= 3
-    assert "still broken" in (loop.health.last_error or "")
+    assert loop.health.last_error == "RuntimeError"
 
 
 async def test_backoff_is_capped(until, monkeypatch):
@@ -133,7 +133,8 @@ async def test_failures_are_visible_in_health_while_they_last(until):
 
     await _run_briefly(loop, until, _failed, what="a recorded failure")
 
-    assert loop.health.snapshot()["last_error"] is not None
+    snapshot = loop.health.snapshot()
+    assert snapshot["last_error_type"] == "RuntimeError"
 
 
 # ---------------------------------------------------------------------------
@@ -238,3 +239,22 @@ def test_health_is_ok_on_a_request_only_instance(client, isolated_registry):
 
     assert response.status_code == 200
     assert response.json()["loops"] == []
+
+
+async def test_health_never_exposes_raw_exception_text(until):
+    """`/health` is unauthenticated, so anything kept here is world-readable —
+    and an exception repr can carry a DSN, a query, or a token from whatever
+    raised. The type is enough to triage; the rest belongs in the logs."""
+
+    async def tick() -> None:
+        raise RuntimeError("postgresql://admin:hunter2@db.internal:5432/prod")
+
+    loop = PeriodicLoop("leaky", 0.001, tick)
+
+    async def _failed() -> bool:
+        return loop.health.consecutive_failures > 0
+
+    await _run_briefly(loop, until, _failed, what="a recorded failure")
+
+    assert "hunter2" not in repr(loop.health.snapshot())
+    assert loop.health.snapshot()["last_error_type"] == "RuntimeError"

--- a/backend/tests/test_background.py
+++ b/backend/tests/test_background.py
@@ -258,3 +258,39 @@ async def test_health_never_exposes_raw_exception_text(until):
 
     assert "hunter2" not in repr(loop.health.snapshot())
     assert loop.health.snapshot()["last_error_type"] == "RuntimeError"
+
+
+def test_the_loop_intervals_that_sleep_directly_are_clamped():
+    """`PeriodicLoop`'s floor does not reach the dispatcher's and the run
+    heartbeat's loops — they sleep directly — so the settings clamp at source.
+    Zero would otherwise burn a core for the life of the process."""
+    from app.agents.runs.settings import RunSettings
+
+    settings = RunSettings(
+        heartbeat_interval_seconds=0,
+        reaper_interval_seconds=0,
+        claim_interval_seconds=0,
+        cancel_poll_seconds=-1,
+        _env_file=None,
+    )
+
+    assert settings.heartbeat_interval_seconds == 1
+    assert settings.reaper_interval_seconds == 1
+    assert settings.claim_interval_seconds > 0
+    assert settings.cancel_poll_seconds > 0
+    # The whole-second fields must stay whole — they are typed `int`.
+    assert isinstance(settings.heartbeat_interval_seconds, int)
+    assert isinstance(settings.reaper_interval_seconds, int)
+
+
+def test_register_loop_resolves_the_registry_at_call_time(monkeypatch):
+    """The seam that makes registry isolation possible at all: callers that did
+    `from app.background import registry` kept writing to the original."""
+    swapped = LoopRegistry()
+    monkeypatch.setattr("app.background.registry", swapped)
+
+    from app.background import register_loop
+
+    register_loop(LoopHealth(name="somewhere-else", interval=1))
+
+    assert [loop.name for loop in swapped.loops] == ["somewhere-else"]

--- a/backend/tests/test_background.py
+++ b/backend/tests/test_background.py
@@ -9,6 +9,7 @@ import asyncio
 from contextlib import suppress
 
 import pytest
+from pydantic import ValidationError
 
 from app.background import MAX_BACKOFF_SECONDS, LoopHealth, LoopRegistry, PeriodicLoop
 
@@ -281,6 +282,19 @@ def test_the_loop_intervals_that_sleep_directly_are_clamped():
     # The whole-second fields must stay whole — they are typed `int`.
     assert isinstance(settings.heartbeat_interval_seconds, int)
     assert isinstance(settings.reaper_interval_seconds, int)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_intervals_are_rejected_not_clamped(bad):
+    """`max(nan, x)` is `nan`, which then becomes a sleep timeout with undefined
+    behaviour, and `inf` is a loop that never ticks again. Neither expresses an
+    intent worth honouring the way 0 does, so this fails loudly at boot."""
+    from app.agents.runs.settings import RunSettings
+
+    with pytest.raises(ValidationError):
+        RunSettings(claim_interval_seconds=bad, _env_file=None)
+    with pytest.raises(ValidationError):
+        RunSettings(cancel_poll_seconds=bad, _env_file=None)
 
 
 def test_register_loop_resolves_the_registry_at_call_time(monkeypatch):

--- a/backend/tests/test_background.py
+++ b/backend/tests/test_background.py
@@ -1,0 +1,240 @@
+"""Supervised background loops and the health they publish (design review §2.3).
+
+The failure being prevented: a loop dies, logs one ERROR, and the instance keeps
+answering 200s while nothing executes runs or fires triggers ever again — and on
+Cloud Run keeps passing its health check, so nothing recycles it.
+"""
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+
+from app.background import MAX_BACKOFF_SECONDS, LoopHealth, LoopRegistry, PeriodicLoop
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(monkeypatch):
+    """Loops register themselves on construction; keep tests out of each
+    other's registry (and out of the process-wide one)."""
+    registry = LoopRegistry()
+    monkeypatch.setattr("app.background.registry", registry)
+    # `main` imports the registry by value, so the endpoint's reference has to
+    # be swapped too.
+    monkeypatch.setattr("app.main.background_loops", registry)
+    return registry
+
+
+async def _run_briefly(loop: PeriodicLoop, until, condition, *, what: str) -> None:
+    """Run the loop until `condition` holds, then stop it.
+
+    `stop()` wakes the loop out of its sleep, so it usually exits on its own;
+    the cancel is only there for the case where it does not.
+    """
+    task = asyncio.create_task(loop.run())
+    try:
+        await until(condition, what=what)
+    finally:
+        loop.stop()
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+# ---------------------------------------------------------------------------
+# supervision
+# ---------------------------------------------------------------------------
+
+
+async def test_a_raising_tick_is_retried_rather_than_ending_the_loop(until):
+    calls = 0
+
+    async def tick() -> None:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise RuntimeError("postgres failing over")
+
+    loop = PeriodicLoop("flaky", 0.001, tick)
+
+    async def _recovered() -> bool:
+        return calls >= 3
+
+    await _run_briefly(loop, until, _recovered, what="the loop to recover")
+
+    assert loop.health.consecutive_failures == 0
+    assert loop.health.last_error is None
+
+
+async def test_a_persistent_failure_backs_off_instead_of_spinning(until, monkeypatch):
+    """Without backoff a permanently broken dependency turns the loop into a
+    tight error-logging spin — the second-worst outcome after dying.
+
+    The waits are captured rather than timed: asserting on real elapsed time
+    would make this test a flake generator on a loaded CI box.
+    """
+    waits: list[float] = []
+
+    async def tick() -> None:
+        raise RuntimeError("still broken")
+
+    loop = PeriodicLoop("broken", 0.001, tick)
+    real_sleep = loop._sleep
+
+    async def _recording_sleep(seconds: float) -> None:
+        waits.append(seconds)
+        await real_sleep(0)
+
+    monkeypatch.setattr(loop, "_sleep", _recording_sleep)
+
+    async def _backed_off_thrice() -> bool:
+        return len(waits) >= 3
+
+    await _run_briefly(loop, until, _backed_off_thrice, what="three backoffs")
+
+    assert waits[:3] == [0.001, 0.002, 0.004]  # doubling
+    assert loop.health.consecutive_failures >= 3
+    assert "still broken" in (loop.health.last_error or "")
+
+
+async def test_backoff_is_capped(until, monkeypatch):
+    """A loop broken for an hour must still retry, just not often."""
+    waits: list[float] = []
+
+    async def tick() -> None:
+        raise RuntimeError("still broken")
+
+    loop = PeriodicLoop("broken", MAX_BACKOFF_SECONDS, tick)
+
+    async def _recording_sleep(seconds: float) -> None:
+        waits.append(seconds)
+        # Must yield: a coroutine with no await never hands control back, so the
+        # loop would spin without the poller below ever getting to run.
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(loop, "_sleep", _recording_sleep)
+
+    async def _backed_off_twice() -> bool:
+        return len(waits) >= 2
+
+    await _run_briefly(loop, until, _backed_off_twice, what="two backoffs")
+
+    assert set(waits) == {MAX_BACKOFF_SECONDS}
+
+
+async def test_failures_are_visible_in_health_while_they_last(until):
+    async def tick() -> None:
+        raise RuntimeError("boom")
+
+    loop = PeriodicLoop("boom", 0.001, tick)
+
+    async def _failed() -> bool:
+        return loop.health.consecutive_failures > 0
+
+    await _run_briefly(loop, until, _failed, what="a recorded failure")
+
+    assert loop.health.snapshot()["last_error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# health reporting
+# ---------------------------------------------------------------------------
+
+
+def test_a_loop_that_never_started_is_not_reported_unhealthy():
+    """`RUN_DISPATCHER_ENABLED=false` is a supported deployment, not a degraded
+    one."""
+    assert LoopHealth(name="idle", interval=1).is_healthy() is True
+
+
+def test_a_stopped_loop_is_healthy():
+    """Shutdown is not failure."""
+    health = LoopHealth(name="done", interval=1, started=True, stopped=True)
+
+    assert health.is_healthy() is True
+
+
+def test_a_started_loop_that_never_ticked_is_unhealthy():
+    """The case that matters most: a loop that dies on its very first tick."""
+    health = LoopHealth(name="stillborn", interval=1, started=True)
+
+    assert health.is_healthy() is False
+
+
+def test_a_loop_that_stopped_ticking_is_unhealthy():
+    health = LoopHealth(name="wedged", interval=1, started=True)
+    health.mark_tick()
+    health.last_tick_at -= MAX_BACKOFF_SECONDS + 100
+
+    assert health.is_healthy() is False
+
+
+def test_a_loop_ticking_on_schedule_is_healthy():
+    health = LoopHealth(name="fine", interval=1, started=True)
+    health.mark_tick()
+
+    assert health.is_healthy() is True
+
+
+def test_a_slow_but_ticking_loop_gets_slack_for_its_backoff():
+    """A loop retrying with backoff is still working; the deadline has to leave
+    room for a full backoff or every transient failure reads as a dead loop."""
+    health = LoopHealth(name="retrying", interval=1, started=True)
+    health.mark_tick()
+    health.last_tick_at -= MAX_BACKOFF_SECONDS - 1
+
+    assert health.is_healthy() is True
+
+
+def test_the_registry_is_unhealthy_if_any_loop_is(isolated_registry):
+    isolated_registry.register(LoopHealth(name="ok", interval=1))
+    dead = isolated_registry.register(LoopHealth(name="dead", interval=1, started=True))
+
+    assert isolated_registry.healthy is False
+    assert [loop["name"] for loop in isolated_registry.snapshot()] == ["ok", "dead"]
+    assert dead.is_healthy() is False
+
+
+def test_an_empty_registry_is_healthy(isolated_registry):
+    assert isolated_registry.healthy is True
+
+
+# ---------------------------------------------------------------------------
+# /health — what Cloud Run acts on
+# ---------------------------------------------------------------------------
+
+
+def test_health_is_ok_when_every_loop_is_ticking(client, isolated_registry):
+    health = isolated_registry.register(LoopHealth(name="run-dispatcher", interval=1))
+    health.started = True
+    health.mark_tick()
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["loops"][0]["name"] == "run-dispatcher"
+
+
+def test_health_is_503_when_a_loop_has_stopped_ticking(client, isolated_registry):
+    """The whole point: a dead dispatcher used to leave an instance answering
+    200s while no run ever executed again, so nothing recycled it."""
+    health = isolated_registry.register(LoopHealth(name="run-dispatcher", interval=1))
+    health.started = True
+    health.mark_tick()
+    health.last_tick_at -= MAX_BACKOFF_SECONDS + 100
+
+    response = client.get("/health")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "degraded"
+
+
+def test_health_is_ok_on_a_request_only_instance(client, isolated_registry):
+    """`RUN_DISPATCHER_ENABLED=false` registers no loops — a supported
+    deployment, not a degraded one."""
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["loops"] == []

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -400,7 +400,7 @@ def test_update_thread_not_found(client: TestClient, mock_db):
     assert response.json()["detail"] == "Thread not found"
 
 
-@patch("app.threads.router.get_checkpointer")
+@patch("app.threads.service.get_checkpointer")
 def test_delete_thread(mock_checkpointer, client: TestClient, mock_db, current_user):
     """Test deleting a thread."""
     thread_id = str(uuid4())
@@ -429,10 +429,14 @@ def test_delete_thread(mock_checkpointer, client: TestClient, mock_db, current_u
     response = client.delete(f"/threads/{thread_id}")
     assert response.status_code == 204
     mock_db.delete.assert_called_once()
+    # Assert the checkpointer was actually the mock. Without this the patch
+    # target can drift (it did: the call moved from the router into the service)
+    # and the test silently opens a real Postgres pool instead of failing.
+    mock_saver_instance.adelete_thread.assert_awaited_once_with(thread_id=thread_id)
 
 
 @pytest.mark.usefixtures("current_user")
-@patch("app.threads.router.get_checkpointer")
+@patch("app.threads.service.get_checkpointer")
 def test_delete_thread_not_found(mock_checkpointer, client: TestClient, mock_db):
     """Test deleting a non-existent thread returns 404."""
     fake_id = uuid4()

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -452,3 +452,61 @@ def test_delete_thread_not_found(mock_checkpointer, client: TestClient, mock_db)
     response = client.delete(f"/threads/{fake_id}")
     assert response.status_code == 404
     assert response.json()["detail"] == "Thread not found"
+
+
+# ---------------------------------------------------------------------------
+# delete ordering (design review §5.5)
+# ---------------------------------------------------------------------------
+
+
+def _thread_owned_by(user_id) -> ThreadDB:
+    return ThreadDB(
+        id=str(uuid4()),
+        user_id=user_id,
+        agent_id=uuid4(),
+        model_id="some-model",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+
+def test_delete_commits_the_row_before_purging_checkpoints(
+    client: TestClient, mock_db, current_user
+):
+    """Checkpoints live on a separate auto-committed connection and cannot be
+    rolled back. Purging first meant a failed commit left a thread whose entire
+    history was irrecoverably gone."""
+    thread = _thread_owned_by(current_user.id)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    mock_db.execute.return_value = mock_result
+
+    calls = MagicMock()
+    calls.attach_mock(mock_db.commit, "commit")
+    with patch("app.threads.service.get_checkpointer") as checkpointer:
+        checkpointer.return_value.__aenter__.return_value = MagicMock(
+            adelete_thread=AsyncMock()
+        )
+        calls.attach_mock(
+            checkpointer.return_value.__aenter__.return_value.adelete_thread, "purge"
+        )
+        response = client.delete(f"/threads/{thread.id}")
+
+    assert response.status_code == 204
+    ordered = [name for name, _, _ in calls.mock_calls]
+    assert "commit" in ordered and "purge" in ordered
+    assert ordered.index("commit") < ordered.index("purge")
+
+
+def test_delete_refuses_another_users_thread(client: TestClient, mock_db, current_user):
+    thread = _thread_owned_by(uuid4())  # someone else's
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = thread
+    mock_db.execute.return_value = mock_result
+
+    with patch("app.threads.service.get_checkpointer") as checkpointer:
+        response = client.delete(f"/threads/{thread.id}")
+
+    assert response.status_code == 403
+    mock_db.delete.assert_not_called()
+    checkpointer.assert_not_called()

--- a/backend/tests/triggers/test_claim_and_enqueue.py
+++ b/backend/tests/triggers/test_claim_and_enqueue.py
@@ -1,0 +1,46 @@
+"""TriggerService.claim_and_enqueue — the scanner tick.
+
+Covers the ordering constraint from design review §3.7: the model whitelist must
+be warmed *before* the claim transaction opens.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.triggers.service as triggers_mod
+from app.triggers.service import TriggerService
+
+
+@pytest.fixture
+def service(monkeypatch) -> TriggerService:
+    svc = TriggerService(AsyncMock())
+    svc.repository = MagicMock(claim_due=AsyncMock(return_value=[]))
+    svc.model_service = AsyncMock()
+    monkeypatch.setattr(triggers_mod, "RunService", MagicMock())
+    return svc
+
+
+async def test_warms_the_whitelist_before_opening_the_claim_transaction(
+    service, monkeypatch
+):
+    """`claim_due` takes `FOR UPDATE SKIP LOCKED` locks on every trigger it
+    claims, and `is_available` runs inside that transaction. On a cold or
+    expired catalog cache that check is a multi-second CDN fetch — held open
+    across those row locks unless the cache is warmed first."""
+    calls = MagicMock()
+    warm = AsyncMock()
+    calls.attach_mock(warm, "warm")
+    calls.attach_mock(service.repository.claim_due, "claim")
+    monkeypatch.setattr(triggers_mod.ModelService, "list_whitelisted", warm)
+
+    await service.claim_and_enqueue()
+
+    ordered = [name for name, _, _ in calls.mock_calls]
+    assert ordered.index("warm") < ordered.index("claim")
+
+
+async def test_a_tick_with_nothing_due_enqueues_nothing(service, monkeypatch):
+    monkeypatch.setattr(triggers_mod.ModelService, "list_whitelisted", AsyncMock())
+
+    assert await service.claim_and_enqueue() == []


### PR DESCRIPTION
Implements **Phase 1** of the backend design review (`backend-design-review.md` §9). P1-2 through P1-17; **P1-1 is blocked** on an owner decision (which database, and someone to run the PAT backfill) and is untouched here.

Tracker updated in `backend-cleanup-todo.md` with per-task notes, including what each task deliberately did *not* cover.

## Hot path

The agent graph was fully resolved **three times per send** (readiness poll, run preflight, worker build), always through the most expensive read in the module.

- **`AgentRepository.get_run_spec` → `RunSpec`** (new `app/agents/run_spec.py`) reads a parent and its direct subagents in **three flat queries**, whatever the width. `Agent.build` does one read; `ResolvedAgent.resolve` takes an `AgentSpec` rather than an id, so subagents cost no further queries, and the sandbox row is no longer re-fetched after the same query joined it. `runtime.py` no longer imports `AgentService`, `AgentResponse` or `SandboxRepository` — the run path is off API response assembly.
- **`collect_run_bindings`** becomes a projection of `RunSpec`, fixing the (1+N)×~5 on the endpoint the frontend *polls*.
- **One `probe_authorization`** — concurrent, fail-open, memoized in Redis — replacing a sequential fail-loud copy and a concurrent one. Also fixes `describe_readiness` returning a constant `"disconnected"` status that contradicted the `ready` flag beside it.
- **Argon2 off the event loop.** The PAT prefix scan blocked it once *per candidate* on every Bearer request.
- **`TokenStorageFactory`** borrows the lifespan Redis client instead of constructing a never-closed `ConnectionPool` at each of eight call sites.
- **Buffered SSE appends** — bounded on chunks *and* delay.
- `MCPServerRepository.list_by_ids` replaces three raw cross-module `select(MCPServerDB)`s.

## Stability

- **Supervised background loops** (`app/background.py`) that publish liveness, and a **new `GET /health`** returning 503 when one stops ticking. A dead dispatcher used to leave an instance answering 200s while no run ever executed again — so nothing recycled it and the deployment looked healthy.
- **Reaper**: two consecutive dead samples before killing a run (a Redis restart drops every liveness key at once), and queued runs are only reaped when no dispatcher is alive (a saturated pool is indistinguishable from an undispatched one — a burst of trigger firings produced exactly that shape).
- **Heartbeat** survives a Redis blip instead of dying silently and letting the reaper finalize a healthy streaming run as `error`.
- **Run ephemera** always get a TTL, plus a safety TTL on the event log, so a thread deleted mid-run can't leak its stream forever.
- **Thread delete** commits the row before purging checkpoints, per `purge_checkpoints`' own documented contract.
- **`_open_session`** no longer launders caller-body exceptions into `DomainError` 500s.
- **`MCPServerService.update`** purges state an auth-type/URL change invalidated.
- **Trigger scanner** warms the model whitelist outside the claim transaction (it holds `FOR UPDATE SKIP LOCKED` row locks).
- **Langfuse** built lazily (a bad URL used to break every import of `runtime.py` at startup) and flushed on shutdown.

## Judgement calls worth a reviewer's eye

1. **`probe_authorization` caches positives only.** Caching a negative would leave a user who just completed the OAuth popup reading as disconnected for the TTL. The cost is the other direction: a token revoked at the IdP reads as authorized for ≤30s.
2. **`MCPServerService.update` uses two different blast radii.** A URL change purges Redis but **keeps** admin-entered credential rows — re-pointing a server must not silently discard a client id/secret someone typed. An auth-type change purges Redis *and* deletes the row for the scheme being left.
3. **A wedged-but-alive dispatcher leaves pending runs un-reaped.** Accepted deliberately in P1-8, and closed by P1-12 in the same PR: it now fails `/health` and gets recycled.
4. **`AgentService.delete_permanently` keeps a narrower version of the P1-9 bug** (purges after flush, before the request commit). Not expanded into here — its ordering is pinned by an existing test and fixing it changes that method's transaction contract. Noted against P3-5.

## Testing

**784 passing, up from 702.** Every fix carries a regression test **verified to fail with the fix reverted**. Two components had no tests at all before (`RunReaper`, `DELETE /threads/{id}`).

Two new test lanes were needed:
- A **SQLite engine with a statement counter** (`tests/agents/core/conftest.py`), because `get_run_spec`'s contract is partly *how many queries it takes* and a mocked session can't observe that. Needs a `JSONB`→`JSON` DDL rendering and FK-closure table creation.
- An **autouse fake Redis** in `tests/conftest.py`, because once readiness reaches the shared client any test on that path would connect to whatever sits on `localhost:6379` — green locally, hanging in CI.

## Deployment note

Point the platform health check at **`GET /health`** (documented in `runs/SPEC.md`). Instances with `RUN_DISPATCHER_ENABLED=false` register no loops and report healthy — request-only instances are a supported deployment, not a degraded one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 1 cuts per-send backend overhead and hardens run execution. Agent graphs now load through a narrow three-query `RunSpec` read instead of three full API-response assemblies; Argon2 verification, SSE buffering, and probe checks no longer block or stall the event loop, and supervised background loops now fail `/health` when they stop ticking. P1-1, the PAT digest migration, stays blocked pending a database and backfill owner decision.

**Stability**

- Background loops retry with backoff and publish liveness for the reaper, dispatcher, and trigger scanner.
- The reaper needs two consecutive dead-worker and no-dispatcher samples; a sweep that raises clears both its suspicion set and the no-dispatcher latch.
- Dispatcher health is ticked by the heartbeat, not the claim loop, so a busy dispatcher stays healthy mid-run.
- `finalize` no longer expires run ephemera when its guarded UPDATE races a claim; the event buffer flusher is awaited, never cancelled.
- Loop intervals and buffer delays are clamped when non-positive; non-finite (`nan`/`inf`) intervals fail at settings validation instead of silently stalling a loop.
- Probe-cache reads and writes are timeout-bounded and keyed under `mcp:{user}:{server}:*` so revoked or re-pointed servers stop reporting authorized.
- Thread deletion no longer 500s on checkpoint-purge failure after commit; subagent ordering gets an id tie-break; the trigger scanner warms the whitelist before the claim transaction.

**Deployment and tests**

- `/health` stays unauthenticated and reports an exception type, not a repr that could leak a DSN or token.
- Instances with `RUN_DISPATCHER_ENABLED=false` stay healthy for request-only deployments.
- Adds query-count, supervision, reaping, SSE buffering, and thread-delete regression tests; two no-op tests were replaced and loop-registration now resolves the registry at call time so isolation works. 800 tests pass.

<sup>Written for commit 99152b07973feed28565af7ebee5ec5e9fa64fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

