### PR TITLE
refactor(agents): unify the runtime on create_agent with an explicit middleware stack

### DIFF
--- a/backend-cleanup-todo.md
+++ b/backend-cleanup-todo.md
@@ -315,8 +315,10 @@ Last updated: 2026-08-29
       `task` tool and a hidden subagent inheriting its toolset; and its `.with_config`
       binds `recursion_limit=9_999`, which is the budget a sandbox *subagent* actually
       runs under (the `task` tool gives it a fresh config), so dropping that config would
-      have cut it 400×. On the review's open question — the answer is that the whole
-      `BASE_AGENT_PROMPT` has to be appended ourselves, and is
+      have cut it 400×. The review's open question was which prompt fragment, if any, we
+      would have to append ourselves: the answer is the whole of `BASE_AGENT_PROMPT`,
+      plus the harness profile's suffix where one is registered, and `harness_system_prompt`
+      appends both
 - [x] **P2-3** `build_runnable` unified on `create_agent`. `app/agents/harness.py` holds
       the explicit bundle; a sandbox now *adds middleware and tools to the same list*
       instead of dispatching to a second builder. The `PatchToolCallsMiddleware`
@@ -324,11 +326,16 @@ Last updated: 2026-08-29
       injects the replacement) and the dual `str`/`SystemMessage` prompt shape is gone —
       every caller passes the instruction string, which `create_agent` normalises to
       `SystemMessage(content=str)`, so parent bytes are unchanged.
-      **Reproduction is exact — no behaviour was changed.** The three deliberate
-      decisions the review wanted made (drop the auto-added subagent; settle summarization
-      + prompt caching for *all* agents; trim the harness prompt) are now one-line diffs
-      and are listed, un-taken, at the end of the finding — they change a frozen-per-thread
-      system prompt, so they are owner calls, not refactor side-effects
+      **The sandbox assembly is reproduced exactly** — that is what the parity test
+      asserts, and no middleware, tool or prompt byte on that path changed. One thing did
+      change, deliberately and outside the parity test's scope: `ResolvedAgent.compile`
+      used to wrap a *subagent's* prompt as a single `{"type": "text"}` content block and
+      now passes the string, since `create_agent` normalises a `str` to
+      `SystemMessage(content=str)`. Same content, one less shape; parent bytes unchanged.
+      The three deliberate decisions the review wanted made (drop the auto-added subagent;
+      settle summarization + prompt caching for *all* agents; trim the harness prompt) are
+      now one-line diffs and are listed, un-taken, at the end of the finding — they change
+      a frozen-per-thread system prompt, so they are owner calls, not refactor side-effects
 - [x] **P2-4** One `build_agent_middleware(created_at, *, recursion_limit, interrupt_on)`
       for parent and subagent. They differ in exactly two documented ways, both forced by
       the subagent having no checkpointer: no approval gate and no tool-call patcher

--- a/backend-cleanup-todo.md
+++ b/backend-cleanup-todo.md
@@ -297,13 +297,70 @@ Last updated: 2026-08-29
 
 ## Phase 2 — Runtime unification (before the deepagents/langchain upgrades)
 
-- [ ] **P2-1** Behavioural `Agent.build`/`stream` tests with a scripted fake model — *blocks P2-3*
-- [ ] **P2-2** Spike: `FilesystemMiddleware` + `LazySandboxBackend` parity outside `create_deep_agent`
-- [ ] **P2-3** Unify `build_runnable` on `create_agent` + explicit middleware list
-- [ ] **P2-4** Share one middleware assembly with `ResolvedAgent.compile`
-- [ ] **P2-5** File issues for subagent HITL + subagent sandbox persistence gaps
-- [ ] **P2-6** Batch subagent resolution (queries, not `gather`)
-- [ ] **P2-7** `convert_to_messages` + O(1) regeneration checkpoint lookup
+- [x] **P2-1** Behavioural `Agent.build`/`stream` tests with a scripted fake model.
+      `tests/agents/scripted_model.py` (a `BaseChatModel` that replays a fixed script and
+      raises on an unscripted extra turn) + `tests/agents/test_runtime_behaviour.py`: 13
+      tests that run the real graph — tool round-trip, tool failure coming back as an
+      error ToolMessage, the recursion fallback persisting a resumable message, the HITL
+      gate stopping before the tool executes, a model failure ending the turn visibly with
+      the sandbox still persisted, the stale-`structured_response` reset, regeneration,
+      and the harness/no-harness toolsets
+- [x] **P2-2** Spike: parity **confirmed and made executable**. Write-up at repo root
+      `backend-harness-parity-finding.md`. `tests/agents/test_harness_parity.py` builds a
+      sandbox agent both ways for four model shapes and asserts the resulting
+      `create_agent(**kwargs)` match — middleware, tools, and the prompt byte for byte —
+      with an `EXPECTED_DEVIATIONS` list the test asserts is empty.
+      Two things the spike surfaced that were invisible at the call site: deepagents
+      **auto-adds a `general-purpose` subagent**, so every sandbox agent already has a
+      `task` tool and a hidden subagent inheriting its toolset; and its `.with_config`
+      binds `recursion_limit=9_999`, which is the budget a sandbox *subagent* actually
+      runs under (the `task` tool gives it a fresh config), so dropping that config would
+      have cut it 400×. On the review's open question — the answer is that the whole
+      `BASE_AGENT_PROMPT` has to be appended ourselves, and is
+- [x] **P2-3** `build_runnable` unified on `create_agent`. `app/agents/harness.py` holds
+      the explicit bundle; a sandbox now *adds middleware and tools to the same list*
+      instead of dispatching to a second builder. The `PatchToolCallsMiddleware`
+      strip-hack is no longer a workaround (one filter line beside the harness that
+      injects the replacement) and the dual `str`/`SystemMessage` prompt shape is gone —
+      every caller passes the instruction string, which `create_agent` normalises to
+      `SystemMessage(content=str)`, so parent bytes are unchanged.
+      **Reproduction is exact — no behaviour was changed.** The three deliberate
+      decisions the review wanted made (drop the auto-added subagent; settle summarization
+      + prompt caching for *all* agents; trim the harness prompt) are now one-line diffs
+      and are listed, un-taken, at the end of the finding — they change a frozen-per-thread
+      system prompt, so they are owner calls, not refactor side-effects
+- [x] **P2-4** One `build_agent_middleware(created_at, *, recursion_limit, interrupt_on)`
+      for parent and subagent. They differ in exactly two documented ways, both forced by
+      the subagent having no checkpointer: no approval gate and no tool-call patcher
+      (`interrupt_on=None`), and a tool budget sized to langgraph's default recursion
+      limit rather than ours
+- [x] **P2-5** Both gaps filed and cross-referenced from the code that documents them:
+      [#301](https://github.com/keurcien/auxilia/issues/301) subagent tool approvals are
+      silently dropped (`HumanInTheLoopMiddleware` needs a checkpointer; `task` gives a
+      subagent a fresh config without one) and
+      [#302](https://github.com/keurcien/auxilia/issues/302) subagent sandboxes never
+      persist (`_persist_sandbox` is the *parent's* teardown hook; a `CompiledSubAgent`
+      has none). Each issue carries the repro, why it is silent, and the two design
+      shapes worth weighing — including whether a subagent should get its own sandbox at
+      all rather than sharing the parent's
+- [x] **P2-6** Batch MCP resolution across the run graph. `Toolset.MCPResolutionScope`
+      preloads every server row the graph names in one `IN` query and shares the decrypted
+      API keys; `Agent.build` builds one scope from `RunSpec.all_mcp_bindings` and passes
+      it to the parent and every subagent. Was one `list_by_ids` **and** one API-key
+      decrypt per agent per server. Still sequential and still one `AsyncSession` — the
+      queries went away, the concurrency hazard was never worth taking.
+      Only reads are shared: the OAuth branch still builds a fresh
+      `WebOAuthClientProvider` per agent, because it is stateful and the graph's sessions
+      are opened concurrently
+- [x] **P2-7** `convert_to_messages` replaces the hand-rolled `_dicts_to_lc_messages`
+      (~30 lines). It rejects an unknown role instead of silently filing it as a user
+      turn, so `_resolve_input` raises `DomainValidationError` — run input is
+      client-supplied, and every producer we own already sends `type: human`.
+      `get_regeneration_checkpoint_id` now asks the checkpointer for the last
+      `source="input"` checkpoint (`filter=`, `limit=1`): **one state load**, verified
+      equal to the old walk across a three-turn thread with tool calls. Note the review's
+      premise was half right — the old loop early-terminated at the last human message, so
+      it walked the last *turn*, not the whole history; O(1) is real, O(turns) was not
 
 ## Phase 3 — Consolidation (order flexible)
 

--- a/backend-harness-parity-finding.md
+++ b/backend-harness-parity-finding.md
@@ -1,0 +1,114 @@
+# P2-2 — `create_agent` + explicit middleware reproduces `create_deep_agent`
+
+Spike finding for [`backend-design-review.md` §1.4](./backend-design-review.md), the
+precondition for **P2-3**. Verified against the installed `deepagents` 0.5.6 /
+`langchain` 1.3.17.
+
+**Verdict: parity is exact, and it is now executable.** `app/agents/harness.py`
+assembles deepagents' bundle by hand; `tests/agents/test_harness_parity.py` builds a
+sandbox agent both ways for four model shapes, captures the `create_agent(**kwargs)`
+each path would issue, and asserts they match — middleware for middleware, tool for
+tool, byte for byte on the system prompt. The file carries an
+`EXPECTED_DEVIATIONS: list[str] = []` that the test asserts is empty, so any future
+divergence has to be written down rather than discovered.
+
+## What the harness actually is
+
+`create_deep_agent` is `create_agent` plus this, in this order:
+
+| # | Middleware | Notes |
+|---|---|---|
+| 1 | `TodoListMiddleware` | adds `write_todos` |
+| 2 | `FilesystemMiddleware` | adds `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `execute` |
+| 3 | `SubAgentMiddleware` | adds `task` |
+| 4 | `SummarizationMiddleware` | deepagents' variant: evicted history offloaded to the backend, thresholds sized from the model profile |
+| 5 | `PatchToolCallsMiddleware` | the one our own copy was being stripped for |
+| … | *the caller's middleware* | our parent stack + `ToolErrorMiddleware` land here |
+| n | `AnthropicPromptCachingMiddleware` | unconditional; `"ignore"` makes it a no-op off Anthropic |
+
+…then `system_prompt + "\n\n" + BASE_AGENT_PROMPT`, and a `.with_config` binding
+`recursion_limit=9_999` plus `ls_integration: deepagents` trace metadata.
+
+Two things that were true in production and visible nowhere at the call site:
+
+- **Every sandbox agent already has a `task` tool.** deepagents auto-adds a
+  `general-purpose` subagent whenever the caller supplies none by that name, which we
+  never do. So `SubAgentMiddleware` is always present on the sandbox path — with a
+  hidden subagent that inherits the parent's full toolset and runs its own todo /
+  filesystem / summarization / prompt-caching stack. Agents with no subagents
+  configured are not subagent-free.
+- **`recursion_limit=9_999` is what a sandbox subagent runs under**, not langgraph's
+  default of 25. The `task` tool invokes a `CompiledSubAgent` with a fresh config, so
+  the `.with_config` bound at build time is the budget that applies. Dropping it
+  would have silently cut it by 400×; `HARNESS_CONFIG` keeps it, and a test pins it.
+
+### The prompt fragment question
+
+The review asked which prompt fragment, if any, we would have to append ourselves.
+Answer: **all of it, and we do.** `harness_system_prompt` appends `BASE_AGENT_PROMPT`
+verbatim, plus the harness profile's suffix where one is registered. Measured, for a
+sandbox agent with one MCP tool:
+
+| Model | System prompt | Middleware prompt fragments |
+|---|---|---|
+| `openai:gpt-4o` | 2 264 chars (2 251 of them the harness) | 3 903 chars |
+| `anthropic:claude-sonnet-4-6` | 3 721 chars | 3 903 chars |
+
+The ~1.5 KB spread is deepagents' built-in *harness profiles*, which are registered
+under four exact model specs (`anthropic:claude-sonnet-4-6`, `claude-opus-4-7`,
+`claude-haiku-4-5`, and the Codex line) and contribute nothing but a system-prompt
+suffix. Nothing falls back to a provider-wide key, so every other model we serve gets
+the plain base prompt.
+
+So a sandbox agent carries roughly **6 KB of harness prompt and 9 extra tools** before
+its own instructions and MCP tools. That is unchanged by P2-3 — it is just no longer
+invisible.
+
+## What P2-3 changed
+
+- One construction path. `build_runnable` always calls `create_agent`; a sandbox adds
+  middleware and tools to the same list instead of dispatching to a second builder.
+- The `PatchToolCallsMiddleware` strip-hack is gone as a *workaround* — the filter
+  remains, one line, next to the harness that injects the replacement.
+- The dual `str` / `SystemMessage` prompt shape is gone: every caller passes the
+  instruction string. `create_agent` normalises a `str` to `SystemMessage(content=str)`,
+  so the parent's bytes are unchanged. One shape did change — `ResolvedAgent.compile`
+  used to wrap a **subagent's** prompt as a single `{"type": "text"}` content block and
+  now passes the string; same content, one less shape.
+- Parent and subagent share `build_agent_middleware`. They differ in exactly two
+  documented ways, both forced by the subagent having no checkpointer: no approval gate
+  and no tool-call patcher, and a tool budget sized to langgraph's default recursion
+  limit rather than ours.
+
+## What this now depends on
+
+`app/agents/harness.py` imports four things deepagents does not consider public:
+`graph.BASE_AGENT_PROMPT`, `_version.__version__`, and
+`profiles.harness.harness_profiles.{_apply_profile_prompt, _harness_profile_for_model}`.
+That is the price of reproducing the assembly, and it is guarded twice: the parity test
+fails if any of them stops producing what `create_deep_agent` produces, and
+`harness._profile` raises if a resolved profile starts using a feature we do not
+reproduce (`extra_middleware`, `excluded_tools`, `excluded_middleware`, a
+general-purpose-subagent override) rather than silently dropping it.
+
+This is the shape the deepagents 0.7 upgrade wanted: the surface is now three
+middleware classes and one prompt constant, all in one file, with a test that says
+whether the upgrade changed behaviour.
+
+## Decisions this makes available (none taken)
+
+Now that the stack is one list, each of these is a one-line diff and a product call —
+deliberately **not** made as part of a refactor:
+
+1. **Drop the auto-added `general-purpose` subagent** for agents that configure none.
+   Removes the `task` tool and its hidden agent; changes behaviour for existing sandbox
+   threads.
+2. **Decide summarization and prompt caching for all agents**, rather than inheriting
+   them for sandbox agents only. Today plain agents have neither — including long
+   threads that would benefit from summarization, and Anthropic threads that are paying
+   full price for an uncached prefix.
+3. **Trim the harness prompt.** ~2.2 KB of "you are a deep agent" guidance goes to
+   every sandbox agent ahead of its own instructions.
+
+Anything acted on here changes the frozen-per-thread system prompt, so it wants the
+same care as any prompt change (see `prompt-cache-safe-system-prompt`).

--- a/backend-harness-parity-finding.md
+++ b/backend-harness-parity-finding.md
@@ -66,6 +66,10 @@ invisible.
 
 ## What P2-3 changed
 
+Nothing on the sandbox path: the parity test is the claim, and it holds. The changes
+below are to the *shape* of the code, plus one deliberate prompt-shape normalisation
+called out in the last bullet.
+
 - One construction path. `build_runnable` always calls `create_agent`; a sandbox adds
   middleware and tools to the same list instead of dispatching to a second builder.
 - The `PatchToolCallsMiddleware` strip-hack is gone as a *workaround* — the filter
@@ -75,6 +79,12 @@ invisible.
   so the parent's bytes are unchanged. One shape did change — `ResolvedAgent.compile`
   used to wrap a **subagent's** prompt as a single `{"type": "text"}` content block and
   now passes the string; same content, one less shape.
+- The plain path is unchanged, including where `SubAgentMiddleware` sits. It goes
+  *after* the caller's stack there and *before* it inside the harness, because those
+  are the two positions the two assemblers used. The position is load-bearing: a
+  middleware's system-prompt fragment lands in list order, so moving it rewrites the
+  prompt of every non-sandbox agent that has subagents. Two tests pin it — one on the
+  assembled middleware list, one on the prompt the model actually receives.
 - Parent and subagent share `build_agent_middleware`. They differ in exactly two
   documented ways, both forced by the subagent having no checkpointer: no approval gate
   and no tool-call patcher, and a tool budget sized to langgraph's default recursion

--- a/backend/app/agents/harness.py
+++ b/backend/app/agents/harness.py
@@ -135,6 +135,14 @@ def harness_middleware(*, model, tools: list, backend, subagents=None) -> list:
     parent's full toolset.
     """
     profile = _profile(model)
+    supplied = list(subagents or [])
+    # deepagents adds its default subagent only when the caller supplies none by
+    # that name — an explicit spec is how a caller overrides it.
+    specs = (
+        supplied
+        if any(s["name"] == GENERAL_PURPOSE_SUBAGENT["name"] for s in supplied)
+        else [_general_purpose_subagent(model, tools, backend, profile), *supplied]
+    )
     return [
         TodoListMiddleware(),
         FilesystemMiddleware(
@@ -143,10 +151,7 @@ def harness_middleware(*, model, tools: list, backend, subagents=None) -> list:
         ),
         SubAgentMiddleware(
             backend=backend,
-            subagents=[
-                _general_purpose_subagent(model, tools, backend, profile),
-                *(subagents or []),
-            ],
+            subagents=specs,
             task_description=profile.tool_description_overrides.get("task"),
         ),
         create_summarization_middleware(model, backend),

--- a/backend/app/agents/harness.py
+++ b/backend/app/agents/harness.py
@@ -1,0 +1,184 @@
+"""deepagents' harness bundle, assembled explicitly.
+
+``create_deep_agent`` is ``create_agent`` plus a fixed middleware bundle
+(``deepagents/graph.py``). Calling it gave the runtime a second construction
+path with its own prompt assembly, its own middleware order, and a
+``PatchToolCallsMiddleware`` strip-hack to work around the copy it injects —
+so middleware added to the parent stack behaved differently depending on
+whether the agent happened to have a sandbox bound (design review §1.4).
+
+This module composes the same bundle by hand, so ``build_runnable`` has one
+path and the stack is one diffable list. Everything here is a faithful
+reproduction of deepagents 0.5.6 for the one call shape the runtime uses (a
+pre-built model, no skills/memory/permissions, `interrupt_on` handled by our
+own HITL middleware), **not** a redesign: ``tests/agents/test_harness_parity.py``
+builds a graph both ways and asserts the resulting ``create_agent(...)`` calls
+match, middleware for middleware. Deliberate deviations belong in
+``build_runnable``, one commented line at a time — not here.
+
+Two consequences of that reproduction are worth knowing, because neither is
+visible at the call site today:
+
+- **Every sandbox agent gets a `task` tool.** deepagents auto-adds a
+  `general-purpose` subagent whenever the caller supplies none named that, so
+  `SubAgentMiddleware` is always present on this path — with its own todo /
+  filesystem / summarization stack and a copy of the parent's tools.
+- **Summarization and Anthropic prompt caching are on**, for sandbox agents
+  only. Plain agents get neither. That fork is inherited, not chosen; making
+  it explicit here is the point.
+"""
+
+from typing import Any
+
+from deepagents._version import __version__ as _deepagents_version
+from deepagents.graph import BASE_AGENT_PROMPT
+from deepagents.middleware.filesystem import FilesystemMiddleware
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+from deepagents.middleware.subagents import (
+    GENERAL_PURPOSE_SUBAGENT,
+    SubAgentMiddleware,
+)
+from deepagents.middleware.summarization import create_summarization_middleware
+from deepagents.profiles.harness.harness_profiles import (
+    HarnessProfile,
+    _apply_profile_prompt,
+    _harness_profile_for_model,
+)
+from langchain.agents.middleware import TodoListMiddleware
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+from langchain_core.messages import SystemMessage
+
+
+# `create_deep_agent` binds this onto the compiled graph. The parent overrides
+# `recursion_limit` from its own run config, but a *subagent* compiled on the
+# sandbox path is invoked by the `task` tool with a fresh config, so 9_999 is
+# what it actually runs under (its ToolCallLimitMiddleware is the real budget).
+# The metadata is what marks deepagents runs in LangSmith/Langfuse traces.
+HARNESS_CONFIG: dict[str, Any] = {
+    "recursion_limit": 9_999,
+    "metadata": {
+        "ls_integration": "deepagents",
+        "versions": {"deepagents": _deepagents_version},
+        "lc_agent_name": None,
+    },
+}
+
+
+def _profile(model) -> HarnessProfile:
+    """The harness profile deepagents would resolve for this model.
+
+    Built-in profiles cover three Anthropic model specs and the Codex line,
+    and all of them contribute nothing but a system-prompt suffix. The other
+    profile features exist, though, and a deepagents upgrade could start using
+    them — so refuse to build a stack we would silently be assembling wrong.
+    """
+    profile = _harness_profile_for_model(model, None)
+    unsupported = {
+        "extra_middleware": profile.extra_middleware,
+        "excluded_tools": profile.excluded_tools,
+        "excluded_middleware": profile.excluded_middleware,
+        "general_purpose_subagent": profile.general_purpose_subagent,
+    }
+    used = sorted(name for name, value in unsupported.items() if value)
+    if used:
+        msg = (
+            f"deepagents harness profile for {type(model).__name__} uses "
+            f"{used}, which app/agents/harness.py does not reproduce. "
+            "Port the missing branch from deepagents.graph.create_deep_agent "
+            "(and extend tests/agents/test_harness_parity.py)."
+        )
+        raise RuntimeError(msg)
+    return profile
+
+
+def _base_harness_stack(model, backend, profile: HarnessProfile) -> list:
+    """The middleware every deepagents stack starts with — main agent and the
+    auto-added general-purpose subagent alike, minus the subagent wiring."""
+    return [
+        TodoListMiddleware(),
+        FilesystemMiddleware(
+            backend=backend,
+            custom_tool_descriptions=profile.tool_description_overrides,
+        ),
+        create_summarization_middleware(model, backend),
+        PatchToolCallsMiddleware(),
+    ]
+
+
+def _general_purpose_subagent(model, tools: list, backend, profile: HarnessProfile):
+    """deepagents' default subagent: the parent's tools, its own harness stack.
+
+    Inserted whenever the caller supplies no subagent named `general-purpose`,
+    which the runtime never does — so on the sandbox path this is always here,
+    and is the reason a sandbox agent always has a `task` tool.
+    """
+    return {
+        **GENERAL_PURPOSE_SUBAGENT,
+        "model": model,
+        "tools": tools,
+        "middleware": [
+            *_base_harness_stack(model, backend, profile),
+            AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"),
+        ],
+        "system_prompt": _apply_profile_prompt(
+            profile, GENERAL_PURPOSE_SUBAGENT["system_prompt"]
+        ),
+    }
+
+
+def harness_middleware(*, model, tools: list, backend, subagents=None) -> list:
+    """The harness middleware that runs *before* the caller's own stack.
+
+    Order matters and mirrors deepagents exactly: todos, filesystem, the task
+    tool, summarization, then the patcher. ``tools`` must already include the
+    sandbox lifecycle tools — the general-purpose subagent inherits the
+    parent's full toolset.
+    """
+    profile = _profile(model)
+    return [
+        TodoListMiddleware(),
+        FilesystemMiddleware(
+            backend=backend,
+            custom_tool_descriptions=profile.tool_description_overrides,
+        ),
+        SubAgentMiddleware(
+            backend=backend,
+            subagents=[
+                _general_purpose_subagent(model, tools, backend, profile),
+                *(subagents or []),
+            ],
+            task_description=profile.tool_description_overrides.get("task"),
+        ),
+        create_summarization_middleware(model, backend),
+        PatchToolCallsMiddleware(),
+    ]
+
+
+def harness_trailing_middleware(model) -> list:
+    """The harness middleware that runs *after* the caller's own stack.
+
+    Prompt caching is unconditional in deepagents; `"ignore"` makes it a no-op
+    on non-Anthropic models.
+    """
+    _profile(model)  # same guard, so a bad profile fails on either entry point
+    return [AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore")]
+
+
+def harness_system_prompt(model, system_prompt: str | SystemMessage | None):
+    """The agent's instructions with deepagents' harness prompt appended.
+
+    Caller instructions always come first (deepagents' invariant), so an
+    agent's own prompt still outranks the harness guidance.
+    """
+    profile = _profile(model)
+    base_prompt = _apply_profile_prompt(profile, BASE_AGENT_PROMPT)
+    if system_prompt is None:
+        return base_prompt
+    if isinstance(system_prompt, SystemMessage):
+        return SystemMessage(
+            content_blocks=[
+                *system_prompt.content_blocks,
+                {"type": "text", "text": f"\n\n{base_prompt}"},
+            ]
+        )
+    return system_prompt + "\n\n" + base_prompt

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -131,7 +131,7 @@ def build_runnable(
     without a sandbox it is added here over the in-state filesystem.
     """
     tools = list(tools)
-    middleware: list = []
+    harness: list = []
 
     if sandbox_backend is not None:
         from app.sandbox.tools import create_sandbox_tools
@@ -140,7 +140,7 @@ def build_runnable(
         # The general-purpose subagent inherits the parent's tools, so the
         # harness has to see the sandbox tools too — assemble it after the
         # toolset is complete.
-        middleware += harness_middleware(
+        harness += harness_middleware(
             model=model,
             tools=tools,
             backend=sandbox_backend,
@@ -152,10 +152,16 @@ def build_runnable(
         base_middleware = [
             m for m in base_middleware if not isinstance(m, PatchToolCallsMiddleware)
         ]
-    elif subagents:
-        middleware.append(SubAgentMiddleware(backend=StateBackend, subagents=subagents))
 
-    middleware += list(base_middleware)
+    middleware = [*harness, *base_middleware]
+    if sandbox_backend is None and subagents:
+        # Deliberately on the far side of the caller's stack, where the plain
+        # path has always put it — the harness wires its own SubAgentMiddleware
+        # *before* the caller's, because that is where deepagents puts it. Both
+        # positions are load-bearing: a middleware's system-prompt fragment
+        # lands in list order, so moving this one rewrites the prompt (and
+        # thread prompts are frozen at creation).
+        middleware.append(SubAgentMiddleware(backend=StateBackend, subagents=subagents))
     if output_schema is not None:
         middleware.append(DeferredStructuredOutputMiddleware(format_mode))
     middleware.append(ToolErrorMiddleware())
@@ -476,13 +482,19 @@ class Agent:
         The message dicts come from a client (the chat UI, a trigger, Slack), so
         a malformed one is a bad request, not a server fault — `convert_to_messages`
         rejects an unknown role instead of silently filing it as a user turn.
+        It signals rejection with whatever fits the shape it was handed:
+        `ValueError` for an unknown role or a dict missing `content`,
+        `NotImplementedError` for an item that is not a message at all (a bare
+        number, `None`, a nested list). All of them are the client's fault.
         """
         if command is not None:
             return Command(resume=command.get("resume"))
         raw = agent_input.get("messages", []) if agent_input else []
+        if not isinstance(raw, list):
+            raise DomainValidationError("Invalid run input: `messages` must be a list")
         try:
             messages = convert_to_messages(raw)
-        except ValueError as e:
+        except (ValueError, TypeError, KeyError, NotImplementedError) as e:
             raise DomainValidationError(f"Invalid run input: {e}") from e
         return {"messages": messages}
 

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import uuid4
 
-from deepagents import create_deep_agent
 from deepagents.backends import StateBackend
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgentMiddleware
@@ -18,9 +17,7 @@ from langchain.agents.middleware import (
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
-    HumanMessage,
-    SystemMessage,
-    ToolMessage,
+    convert_to_messages,
 )
 from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
@@ -28,6 +25,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.core.repository import AgentRepository
 from app.agents.current_date import CurrentDateMiddleware
+from app.agents.harness import (
+    HARNESS_CONFIG,
+    harness_middleware,
+    harness_system_prompt,
+    harness_trailing_middleware,
+)
 from app.agents.run_spec import AgentSpec
 from app.agents.settings import agent_settings
 from app.agents.stream import (
@@ -41,9 +44,14 @@ from app.agents.structured_output import (
     is_structured_output_artifact,
 )
 from app.agents.tool_errors import RepairInvalidToolCallsMiddleware, ToolErrorMiddleware
-from app.agents.toolset import PreparedToolset, Toolset, sanitize_tool_name
+from app.agents.toolset import (
+    MCPResolutionScope,
+    PreparedToolset,
+    Toolset,
+    sanitize_tool_name,
+)
 from app.database import get_checkpointer
-from app.exceptions import NotFoundError
+from app.exceptions import DomainValidationError, NotFoundError
 from app.integrations.langfuse.callback import get_langfuse_callback_handler
 from app.model_providers.catalog import ChatModelFactory
 from app.model_providers.service import ModelService
@@ -66,17 +74,18 @@ RECURSION_LIMIT_MESSAGE = (
 
 
 async def get_regeneration_checkpoint_id(agent, config: dict) -> str | None:
-    """Walk back checkpoint history to find the state before the last user message was added."""
-    current_state = await agent.aget_state(config)
-    current_messages = current_state.values.get("messages", [])
-    current_human_count = sum(1 for m in current_messages if m.type == "human")
+    """The checkpoint to fork from when regenerating the last answer.
 
-    async for state in agent.aget_state_history(config):
-        messages = state.values.get("messages", [])
-        human_count = sum(1 for m in messages if m.type == "human")
-        if human_count < current_human_count:
-            return state.config["configurable"]["checkpoint_id"]
-
+    That is the state as it was before the last user message was applied — the
+    turn's ``source="input"`` checkpoint, which holds the message as a pending
+    write rather than in its values. Asking the checkpointer for that one
+    directly is a single state load; counting human messages backwards through
+    the history was one full-state deserialization per step of the last turn.
+    """
+    async for state in agent.aget_state_history(
+        config, filter={"source": "input"}, limit=1
+    ):
+        return state.config["configurable"]["checkpoint_id"]
     return None
 
 
@@ -93,99 +102,145 @@ def build_runnable(
     output_schema: dict | None = None,
     format_mode: str = FORMAT_TOOL,
 ):
-    """Build a LangGraph runnable, dispatching on whether a sandbox is needed.
+    """Build a LangGraph runnable. One construction path, one middleware list.
 
-    Single construction path for both the parent agent and subagents. The
-    no-sandbox branch uses a plain ``create_agent`` (so simple agents avoid
-    deepagents' always-on filesystem/todo/patch scaffolding); the sandbox branch
-    uses ``create_deep_agent`` with the caller's ``sandbox_backend`` — a
-    ``LazySandboxBackend`` the caller keeps a reference to for turn-end
-    persistence (the sandbox itself is created on first tool call, not here).
+    Every agent — parent or subagent, sandboxed or not — is a ``create_agent``
+    with an explicit middleware stack. A sandbox adds deepagents' harness
+    (todos, filesystem, the ``task`` tool, summarization, the tool-call patcher
+    and prompt caching) plus the sandbox lifecycle tools, and appends the
+    harness prompt to the agent's instructions; ``app/agents/harness.py``
+    assembles that bundle and ``tests/agents/test_harness_parity.py`` pins it
+    to what ``create_deep_agent`` builds. Nothing else forks on the sandbox.
 
-    ``base_middleware`` is the caller's middleware stack — the parent passes
+    ``base_middleware`` is the caller's own stack — the parent passes
     ``build_parent_middleware``'s list; subagents pass their own retry/limit/
-    repair/date stack (see ``ResolvedAgent.compile``). ``DeferredStructuredOutputMiddleware`` is
-    appended whenever an ``output_schema`` is given (it keeps the schema off the
-    tool-calling loop and applies it on one final formatting turn).
-    ``ToolErrorMiddleware`` is appended on BOTH paths: without it the ToolNode
-    has no tool-call wrapper, and langgraph's default handler re-raises any
-    exception that isn't a ``ToolInvocationError`` — an MCP transport failure
-    in a tool (or in a subagent reached through ``task``) then kills the whole
-    run instead of feeding back to the model as an error ToolMessage. On the
-    sandbox path the caller's ``PatchToolCallsMiddleware`` is dropped, since
-    ``create_deep_agent`` injects its own and langchain asserts against
-    duplicates.
+    repair/date stack (see ``ResolvedAgent.compile``). It sits where deepagents
+    puts caller middleware: after the harness, before prompt caching.
 
-    ``subagents`` (already-compiled ``CompiledSubAgent`` runnables) wire in via
-    ``SubAgentMiddleware`` on the no-sandbox path and via the ``subagents=`` arg
-    on the sandbox path.
+    ``DeferredStructuredOutputMiddleware`` is appended whenever an
+    ``output_schema`` is given (it keeps the schema off the tool-calling loop
+    and applies it on one final formatting turn). ``ToolErrorMiddleware`` is
+    always appended: without it the ToolNode has no tool-call wrapper, and
+    langgraph's default handler re-raises any exception that isn't a
+    ``ToolInvocationError`` — an MCP transport failure in a tool (or in a
+    subagent reached through ``task``) would then kill the whole run instead of
+    feeding back to the model as an error ToolMessage.
+
+    ``subagents`` (already-compiled ``CompiledSubAgent`` runnables) wire in
+    through ``SubAgentMiddleware`` either way: the harness builds it, and
+    without a sandbox it is added here over the in-state filesystem.
     """
+    tools = list(tools)
+    middleware: list = []
+
     if sandbox_backend is not None:
         from app.sandbox.tools import create_sandbox_tools
 
-        middleware = [
+        tools += create_sandbox_tools(sandbox_backend, sandbox_provider)
+        # The general-purpose subagent inherits the parent's tools, so the
+        # harness has to see the sandbox tools too — assemble it after the
+        # toolset is complete.
+        middleware += harness_middleware(
+            model=model,
+            tools=tools,
+            backend=sandbox_backend,
+            subagents=subagents,
+        )
+        system_prompt = harness_system_prompt(model, system_prompt)
+        # The harness brings its own PatchToolCallsMiddleware and langchain
+        # asserts against duplicates, so the caller's copy is dropped.
+        base_middleware = [
             m for m in base_middleware if not isinstance(m, PatchToolCallsMiddleware)
         ]
-        if output_schema is not None:
-            middleware.append(DeferredStructuredOutputMiddleware(format_mode))
-        return create_deep_agent(
-            model=model,
-            tools=[*tools, *create_sandbox_tools(sandbox_backend, sandbox_provider)],
-            system_prompt=system_prompt,
-            backend=sandbox_backend,
-            middleware=[*middleware, ToolErrorMiddleware()],
-            subagents=subagents,
-            checkpointer=checkpointer,
-            response_format=output_schema,
-        )
-
-    middleware = list(base_middleware)
-    if subagents:
+    elif subagents:
         middleware.append(SubAgentMiddleware(backend=StateBackend, subagents=subagents))
+
+    middleware += list(base_middleware)
     if output_schema is not None:
         middleware.append(DeferredStructuredOutputMiddleware(format_mode))
-    return create_agent(
+    middleware.append(ToolErrorMiddleware())
+    if sandbox_backend is not None:
+        middleware += harness_trailing_middleware(model)
+
+    agent = create_agent(
         model=model,
         tools=tools,
         system_prompt=system_prompt,
         checkpointer=checkpointer,
-        middleware=[*middleware, ToolErrorMiddleware()],
+        middleware=middleware,
         response_format=output_schema,
     )
+    # deepagents binds this onto every graph it builds; keep it on the sandbox
+    # path so a subagent invoked by `task` keeps the recursion budget it had.
+    return agent.with_config(HARNESS_CONFIG) if sandbox_backend is not None else agent
 
 
-def build_parent_middleware(created_at: datetime, prepared: PreparedToolset) -> list:
-    """The parent agent's middleware stack.
+def build_agent_middleware(
+    created_at: datetime,
+    *,
+    recursion_limit: int,
+    interrupt_on: dict[str, bool] | None = None,
+) -> list:
+    """The middleware stack every agent gets, parent or subagent.
 
-    PatchToolCallsMiddleware runs first so that any dangling tool_calls left
-    by a previous aborted turn (recursion limit, cancelled stream, etc.) get
-    synthetic ToolMessage responses before the model sees them.
-    RepairInvalidToolCallsMiddleware is placed *before* HITL so it runs
-    *after* it (after_model hooks execute last-to-first): HITL must see only
-    the genuine tool_calls and gate those, while the malformed calls stay in
-    invalid_tool_calls (invisible to HITL) until Repair promotes them into
-    tool_calls answered by error ToolMessages.
+    Order is load-bearing. PatchToolCallsMiddleware runs first so that any
+    dangling tool_calls left by a previous aborted turn (recursion limit,
+    cancelled stream, etc.) get synthetic ToolMessage responses before the model
+    sees them. ModelRetryMiddleware is listed early so a retry re-runs the whole
+    inner pipeline (date stamp, deferred formatting); it retries transient model
+    failures (rate limits, timeouts, connection drops — classified via
+    ``ModelError.is_retryable``) and, when retries are exhausted, persists the
+    failure as an AIMessage so the turn ends visibly instead of crashing.
+    Non-retryable errors (e.g. provider 400s) re-raise immediately and surface
+    through the run record. RepairInvalidToolCallsMiddleware is placed *before*
+    HITL so it runs *after* it (after_model hooks execute last-to-first): HITL
+    must see only the genuine tool_calls and gate those, while the malformed
+    calls stay in invalid_tool_calls (invisible to HITL) until Repair promotes
+    them into tool_calls answered by error ToolMessages.
+
+    Parent and subagent differ in exactly two documented ways:
+
+    - ``interrupt_on`` — a mapping (even an empty one) means this agent runs
+      against a checkpointer, so it can be interrupted for approval and can
+      have dangling tool calls persisted by an aborted turn. A subagent has
+      neither: the deepagents ``task`` tool invokes CompiledSubAgent runnables
+      with a fresh config and no checkpointer, so it passes ``None`` and loses
+      both the approval gate and the patcher. Approval gates on subagent tools
+      being silently dropped is a known product gap: issue #301.
+    - ``recursion_limit`` — the tool budget is sized to end the run gracefully
+      one step before the graph's own recursion limit trips. A subagent runs
+      under langgraph's default (``SUBAGENT_RECURSION_LIMIT``) rather than
+      ours, because ``task`` doesn't propagate the parent's config.
     """
+    checkpointed = interrupt_on is not None
     return [
-        PatchToolCallsMiddleware(),
-        # Retries transient model failures (rate limits, timeouts, connection
-        # drops — classified via ModelError.is_retryable) and, when retries
-        # are exhausted, persists the failure as an AIMessage so the turn ends
-        # visibly instead of crashing. Non-retryable errors (e.g. provider
-        # 400s) re-raise immediately and surface through the run record.
-        # Listed early so a retry re-runs the whole inner model pipeline
-        # (date stamp, deferred formatting).
+        *([PatchToolCallsMiddleware()] if checkpointed else []),
         ModelRetryMiddleware(),
         ToolCallLimitMiddleware(
-            run_limit=(agent_settings.recursion_limit - 1) // 2, exit_behavior="end"
+            run_limit=(recursion_limit - 1) // 2, exit_behavior="end"
         ),
         RepairInvalidToolCallsMiddleware(),
-        HumanInTheLoopMiddleware(
-            interrupt_on=prepared.interrupt_on,
-            description_prefix="Tool execution pending approval",
+        *(
+            [
+                HumanInTheLoopMiddleware(
+                    interrupt_on=interrupt_on,
+                    description_prefix="Tool execution pending approval",
+                )
+            ]
+            if checkpointed
+            else []
         ),
         CurrentDateMiddleware(created_at),
     ]
+
+
+def build_parent_middleware(created_at: datetime, prepared: PreparedToolset) -> list:
+    """The parent agent's stack: checkpointed, under our own recursion limit."""
+    return build_agent_middleware(
+        created_at,
+        recursion_limit=agent_settings.recursion_limit,
+        interrupt_on=prepared.interrupt_on,
+    )
 
 
 @dataclass
@@ -220,6 +275,7 @@ class ResolvedAgent:
         user_id: str,
         *,
         is_parent: bool = False,
+        scope: MCPResolutionScope | None = None,
     ) -> "ResolvedAgent":
         """Bind one agent's spec to a prepared toolset.
 
@@ -228,9 +284,12 @@ class ResolvedAgent:
         further agent queries (design review §2.2). It also keeps the runtime
         off `AgentService`/`AgentResponse` — the run path has no business
         depending on API response assembly.
+
+        `scope` carries the graph's MCP server rows, read once by `Agent.build`
+        for the parent and every subagent together.
         """
         prepared = await Toolset.prepare(
-            spec.mcp_servers, db, user_id, apply_ui=is_parent
+            spec.mcp_servers, db, user_id, apply_ui=is_parent, scope=scope
         )
         return cls(config=spec, prepared=prepared, sandbox=cls._resolve_sandbox(spec))
 
@@ -254,45 +313,28 @@ class ResolvedAgent:
         ``created_at`` is the thread's creation date, stamped onto the
         subagent's system prompt by ``CurrentDateMiddleware``.
 
-        Subagent-level HITL is intentionally not wired here: CompiledSubAgent
-        runnables don't inherit the parent's checkpointer, and HumanInTheLoopMiddleware
-        needs one. Approval gates on subagent tools are silently dropped today.
-
-        Unlike the parent, subagents DO need their own repair/limit/retry
-        middleware: the deepagents ``task`` tool invokes them with a fresh
-        config (parent middleware and recursion_limit don't propagate) and
-        reports back only ``messages[-1].text`` — a subagent that exits its
-        loop silently (invalid tool-call JSON) returns an empty ToolMessage,
-        and one that blows the recursion limit discards its progress.
+        A subagent gets its own copy of the shared middleware stack rather than
+        inheriting the parent's: the deepagents ``task`` tool invokes it with a
+        fresh config (parent middleware and recursion_limit don't propagate)
+        and reports back only ``messages[-1].text``, so a subagent that exits
+        its loop silently (invalid tool-call JSON) would return an empty
+        ToolMessage and one that blows the recursion limit would discard its
+        progress. It runs without a checkpointer, which is what drops the
+        approval gate — see ``build_agent_middleware`` for both differences.
         """
         sandbox = self.sandbox is not None
-        system_prompt = (
-            self.config.instructions or ""
-            if sandbox
-            else SystemMessage(
-                content=[{"type": "text", "text": self.config.instructions or ""}]
-            )
-        )
         # Subagent sandboxes get no turn-end persist hook: CompiledSubAgent
-        # runnables have no teardown point, same as the HITL limitation above.
+        # runnables have no teardown point, so whatever a subagent writes is
+        # lost when its `task` call ends — issue #302.
         runnable = build_runnable(
             model=model,
             tools=self.live.all,
-            system_prompt=system_prompt,
+            system_prompt=self.config.instructions or "",
             sandbox_backend=LazySandboxBackend() if sandbox else None,
             sandbox_provider=self.sandbox.provider if self.sandbox else None,
-            base_middleware=[
-                ModelRetryMiddleware(),
-                # The task tool doesn't propagate the parent's recursion_limit,
-                # so subagents run under langgraph's default of 25 — size the
-                # tool budget to end gracefully before that backstop trips.
-                ToolCallLimitMiddleware(
-                    run_limit=(SUBAGENT_RECURSION_LIMIT - 1) // 2,
-                    exit_behavior="end",
-                ),
-                RepairInvalidToolCallsMiddleware(),
-                CurrentDateMiddleware(created_at),
-            ],
+            base_middleware=build_agent_middleware(
+                created_at, recursion_limit=SUBAGENT_RECURSION_LIMIT
+            ),
         )
         return CompiledSubAgent(
             name=sanitize_tool_name(self.config.name),
@@ -354,7 +396,12 @@ class Agent:
         if spec is None:
             raise NotFoundError("Agent not found")
 
-        agent = await ResolvedAgent.resolve(spec.agent, db, user_id, is_parent=True)
+        # Every MCP server the graph touches, in one query — the parent's and
+        # each subagent's (design review §2.2 / P2-6).
+        scope = await MCPResolutionScope.build(spec.all_mcp_bindings, db, user_id)
+        agent = await ResolvedAgent.resolve(
+            spec.agent, db, user_id, is_parent=True, scope=scope
+        )
 
         # Backstop for the RunService.create gate: covers the race where the
         # model is disabled between enqueue and worker pickup, and any future
@@ -372,11 +419,12 @@ class Agent:
         middleware = build_parent_middleware(thread.created_at, agent.prepared)
 
         # Still sequential, and deliberately so: these share one AsyncSession,
-        # which is not concurrency-safe. What used to make that expensive was the
-        # per-agent DB read, and `get_run_spec` has already done all of it — each
-        # resolve is now Redis/CPU work over rows already in hand.
+        # which is not concurrency-safe. It no longer costs anything to be —
+        # `get_run_spec` read the agent rows and `scope` the MCP ones, so each
+        # resolve is Redis/CPU work over rows already in hand.
         subagents = [
-            await ResolvedAgent.resolve(sub, db, user_id) for sub in spec.subagents
+            await ResolvedAgent.resolve(sub, db, user_id, scope=scope)
+            for sub in spec.subagents
         ]
 
         handler = get_langfuse_callback_handler()
@@ -407,17 +455,10 @@ class Agent:
             if self.subagents
             else None
         )
-        # Deep agents take the raw instruction string; create_agent takes a
-        # SystemMessage. Keep each form as-is to avoid a prompt-shape change.
-        system_prompt = (
-            self.agent.config.instructions or ""
-            if sandbox
-            else SystemMessage(self.agent.config.instructions)
-        )
         return build_runnable(
             model=self.model,
             tools=self.agent.live.all,
-            system_prompt=system_prompt,
+            system_prompt=self.agent.config.instructions or "",
             sandbox_backend=self._sandbox_backend,
             sandbox_provider=self.agent.sandbox.provider
             if self.agent.sandbox
@@ -430,13 +471,20 @@ class Agent:
         )
 
     def _resolve_input(self, agent_input: dict | None, command: dict | None):
-        """Resolve raw input/command dicts into the value to pass to the agent."""
+        """Resolve raw input/command dicts into the value to pass to the agent.
+
+        The message dicts come from a client (the chat UI, a trigger, Slack), so
+        a malformed one is a bad request, not a server fault — `convert_to_messages`
+        rejects an unknown role instead of silently filing it as a user turn.
+        """
         if command is not None:
             return Command(resume=command.get("resume"))
-        lc_messages = _dicts_to_lc_messages(
-            agent_input.get("messages", []) if agent_input else []
-        )
-        return {"messages": lc_messages}
+        raw = agent_input.get("messages", []) if agent_input else []
+        try:
+            messages = convert_to_messages(raw)
+        except ValueError as e:
+            raise DomainValidationError(f"Invalid run input: {e}") from e
+        return {"messages": messages}
 
     async def _resolve_config(
         self,
@@ -619,33 +667,3 @@ def _extract_text(message: BaseMessage) -> str:
         for block in content
         if isinstance(block, dict) and block.get("type") == "text"
     )
-
-
-def _dicts_to_lc_messages(dicts: list[dict]) -> list[BaseMessage]:
-    """Convert message dicts (LangChain format) to LangChain BaseMessage objects."""
-    messages: list[BaseMessage] = []
-    for d in dicts:
-        msg_type = d.get("type", d.get("role", "human"))
-        content = d.get("content", "")
-        msg_id = d.get("id")
-
-        if msg_type in ("human", "user"):
-            messages.append(HumanMessage(content=content, id=msg_id))
-        elif msg_type in ("ai", "assistant"):
-            kwargs: dict = {"content": content, "id": msg_id}
-            if d.get("tool_calls"):
-                kwargs["tool_calls"] = d["tool_calls"]
-            messages.append(AIMessage(**kwargs))
-        elif msg_type == "tool":
-            messages.append(
-                ToolMessage(
-                    content=content,
-                    tool_call_id=d.get("tool_call_id", ""),
-                    id=msg_id,
-                )
-            )
-        elif msg_type == "system":
-            messages.append(SystemMessage(content=content, id=msg_id))
-        else:
-            messages.append(HumanMessage(content=content, id=msg_id))
-    return messages

--- a/backend/app/agents/toolset.py
+++ b/backend/app/agents/toolset.py
@@ -1,9 +1,10 @@
 import asyncio
 import logging
 import re
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from uuid import UUID
 
 import anyio
 from langchain_core.tools import Tool
@@ -14,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agents.models import AgentMCPServerBase
 from app.mcp.client.factory import MCPClientConfigFactory
 from app.mcp.client.tools import inject_ui_metadata_into_tool
+from app.mcp.servers.models import MCPServerDB
 from app.mcp.servers.repository import MCPServerRepository
 
 
@@ -370,6 +372,55 @@ async def _open_sessions(
             raise result
 
 
+class MCPResolutionScope:
+    """Server rows and API keys read once for a whole run graph.
+
+    `Toolset.prepare` runs once per agent, and a run graph is a parent plus its
+    direct subagents — which routinely bind the same MCP servers. Resolved per
+    agent, that was one `list_by_ids` *and* one API-key decrypt per agent per
+    server: O(N) round-trips before the first token, for rows a single `IN`
+    query covers (design review §2.2).
+
+    Only reads are shared. Each agent still gets its own client config, because
+    an OAuth config carries a stateful `WebOAuthClientProvider` and the parent's
+    and subagents' sessions are opened concurrently.
+    """
+
+    def __init__(self, db: AsyncSession, user_id: str):
+        self._repo = MCPServerRepository(db)
+        self._factory = MCPClientConfigFactory(db=db, user_id=user_id)
+        self._rows: dict[UUID, MCPServerDB] = {}
+        self._api_keys: dict[UUID, str | None] = {}
+
+    @classmethod
+    async def build(
+        cls,
+        bindings: Sequence[AgentMCPServerBase],
+        db: AsyncSession,
+        user_id: str,
+    ) -> "MCPResolutionScope":
+        """Preload every server the graph's `bindings` name, in one query."""
+        scope = cls(db, user_id)
+        await scope.load([b.mcp_server_id for b in bindings])
+        return scope
+
+    async def load(self, server_ids: Collection[UUID]) -> None:
+        missing = [sid for sid in dict.fromkeys(server_ids) if sid not in self._rows]
+        for server in await self._repo.list_by_ids(missing):
+            self._rows[server.id] = server
+
+    def servers(self, server_ids: Sequence[UUID]) -> list[MCPServerDB]:
+        """The rows behind `server_ids`, skipping ids with no server left."""
+        rows = [
+            self._rows[sid] for sid in dict.fromkeys(server_ids) if sid in self._rows
+        ]
+        return rows
+
+    async def config(self, server: MCPServerDB) -> dict:
+        """This agent's client config for `server`, sharing the decrypted key."""
+        return await self._factory.build(server, api_keys=self._api_keys)
+
+
 class Toolset:
     """Resolved, ready-to-use tools from MCP servers."""
 
@@ -392,6 +443,7 @@ class Toolset:
         user_id: str,
         *,
         apply_ui: bool,
+        scope: MCPResolutionScope | None = None,
     ) -> PreparedToolset:
         """Build-time phase: DB lookup -> configs -> interrupt_on. No network.
 
@@ -403,6 +455,10 @@ class Toolset:
         All DB access happens here (request scope). ``interrupt_on`` is derived
         from the persisted per-agent tool map (synced at connect/save time), so
         no MCP session is opened — live discovery happens once, in :meth:`open`.
+
+        ``scope`` lets a caller resolving several agents (a run graph) share one
+        batched server read across them; without it this agent gets a scope of
+        its own and the reads stay per-agent.
         """
         empty = PreparedToolset(
             client=None,
@@ -417,15 +473,15 @@ class Toolset:
 
         # 1. Load MCP server records from DB
         server_ids = [s.mcp_server_id for s in agent_mcp_servers]
-        mcp_servers = await MCPServerRepository(db).list_by_ids(server_ids)
+        if scope is None:
+            scope = MCPResolutionScope(db, user_id)
+            await scope.load(server_ids)
+        mcp_servers = scope.servers(server_ids)
 
         # 2. Build MCP client configs (resolves auth to Redis/header values — no
         #    live SQL handle is retained, so the client is safe to use later during
         #    streaming, after the request DB session has closed).
-        mcp_factory = MCPClientConfigFactory(db=db, user_id=user_id)
-        configs = {
-            server.name: await mcp_factory.build(server) for server in mcp_servers
-        }
+        configs = {server.name: await scope.config(server) for server in mcp_servers}
 
         # 3. Build tool settings map
         tool_settings = {

--- a/backend/app/mcp/client/factory.py
+++ b/backend/app/mcp/client/factory.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.mcp.client.auth import WebOAuthClientProvider, build_oauth_client_metadata
@@ -13,7 +15,18 @@ class MCPClientConfigFactory:
         self._token_storage_factory = TokenStorageFactory()
         self._servers = MCPServerRepository(db)
 
-    async def build(self, config: MCPServerDB) -> dict:
+    async def build(
+        self, config: MCPServerDB, api_keys: dict[UUID, str | None] | None = None
+    ) -> dict:
+        """The client config for one server.
+
+        ``api_keys`` is an optional caller-owned memo of decrypted keys, used
+        when several agents in one run graph bind the same server — the key is
+        the same for all of them, and decrypting it is a DB round-trip each
+        time. Only the key is shared: the OAuth branch returns a fresh
+        ``WebOAuthClientProvider`` per call, because it is stateful and the
+        graph's sessions are opened concurrently.
+        """
         base_config = {
             "transport": "http",
             "url": config.url,
@@ -23,8 +36,13 @@ class MCPClientConfigFactory:
             return base_config
 
         if config.auth_type == MCPAuthType.api_key:
-            api_key = await self._servers.get_api_key(config.id)
-            return {**base_config, "headers": {"Authorization": f"Bearer {api_key}"}}
+            if api_keys is None or config.id not in api_keys:
+                key = await self._servers.get_api_key(config.id)
+                if api_keys is not None:
+                    api_keys[config.id] = key
+            else:
+                key = api_keys[config.id]
+            return {**base_config, "headers": {"Authorization": f"Bearer {key}"}}
 
         if config.auth_type == MCPAuthType.oauth2:
             return {

--- a/backend/tests/agents/scripted_model.py
+++ b/backend/tests/agents/scripted_model.py
@@ -1,0 +1,63 @@
+"""A chat model that replays a fixed script, for graph-level runtime tests.
+
+`tests/agents/test_runtime.py` asserts on middleware *lists*; the tests that
+actually run the graph need a model whose every turn is known in advance, so
+the assertion can be "the agent did X", not "the agent was configured with X".
+
+Each entry in `script` is one model turn: either a ready `AIMessage` or a
+string (wrapped into an `AIMessage`). Calls past the end of the script raise,
+which is what makes an unexpected extra model turn a test failure instead of a
+hang.
+"""
+
+from collections.abc import Sequence
+from typing import Any
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from pydantic import ConfigDict, Field
+
+
+class ScriptedChatModel(BaseChatModel):
+    """Replays `script` one entry per model call, recording what it was sent."""
+
+    script: list[Any]
+    calls: list[list[BaseMessage]] = Field(default_factory=list)
+    bound_tools: list[Any] = Field(default_factory=list)
+    index: int = 0
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> Runnable:
+        # create_agent binds the assembled toolset here; keep the same instance
+        # so `calls` / `index` stay observable from the test's reference.
+        self.bound_tools = list(tools)
+        return self.bind(**kwargs)
+
+    def _next(self) -> AIMessage:
+        if self.index >= len(self.script):
+            msg = (
+                f"ScriptedChatModel exhausted after {len(self.script)} turns — "
+                "the graph asked for one more model call than the test scripted"
+            )
+            raise AssertionError(msg)
+        entry = self.script[self.index]
+        self.index += 1
+        return AIMessage(content=entry) if isinstance(entry, str) else entry
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.calls.append(list(messages))
+        return ChatResult(generations=[ChatGeneration(message=self._next())])

--- a/backend/tests/agents/scripted_model.py
+++ b/backend/tests/agents/scripted_model.py
@@ -36,10 +36,15 @@ class ScriptedChatModel(BaseChatModel):
         return "scripted"
 
     def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> Runnable:
-        # create_agent binds the assembled toolset here; keep the same instance
-        # so `calls` / `index` stay observable from the test's reference.
+        """Bind like a real chat model, and record what was bound.
+
+        `tools` is forwarded onto the binding, not just recorded: it is the
+        binding the graph executes, and middleware that reads tool schemas off
+        the bound model would otherwise see an unbound one. The recording is
+        what lets a test assert which tools the model was actually offered.
+        """
         self.bound_tools = list(tools)
-        return self.bind(**kwargs)
+        return self.bind(tools=list(tools), **kwargs)
 
     def _next(self) -> AIMessage:
         if self.index >= len(self.script):

--- a/backend/tests/agents/test_harness_parity.py
+++ b/backend/tests/agents/test_harness_parity.py
@@ -14,17 +14,19 @@ empty list means the reproduction is exact; anything else is a decision
 someone made on purpose, and this file is where it is recorded.
 """
 
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import deepagents.graph as deepagents_graph
 import pytest
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent
+from deepagents.middleware.subagents import CompiledSubAgent, SubAgentMiddleware
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 
+from app.agents.current_date import CurrentDateMiddleware
 from app.agents.harness import HARNESS_CONFIG
 from app.agents.runtime import build_runnable
 from app.agents.structured_output import (
@@ -122,16 +124,46 @@ def describe(seen: dict) -> dict:
         "tools": [t.name for t in seen["tools"]],
         "system_prompt": _prompt_text(seen["system_prompt"]),
         "response_format": seen["response_format"],
-        "middleware": [
-            {
-                "class": type(m).__name__,
-                "name": m.name,
-                "tools": [t.name for t in getattr(m, "tools", [])],
-                "system_prompt": getattr(m, "system_prompt", None),
-            }
-            for m in seen["middleware"]
-        ],
+        "middleware": [_describe_middleware(m) for m in seen["middleware"]],
     }
+
+
+def _describe_middleware(m) -> dict:
+    described = {
+        "class": type(m).__name__,
+        "name": m.name,
+        "tools": [t.name for t in getattr(m, "tools", [])],
+        "system_prompt": getattr(m, "system_prompt", None),
+    }
+    if isinstance(m, SubAgentMiddleware):
+        # Recurse, or the auto-added general-purpose subagent goes uncompared:
+        # its own todo / filesystem / summarization / prompt-caching stack and
+        # its profile-suffixed prompt are all invisible from the outside, and
+        # dropping any of them would diverge from `create_deep_agent` silently.
+        described["subagents"] = [_describe_subagent(s) for s in m._subagents]
+    return described
+
+
+def _describe_subagent(spec) -> dict:
+    """A subagent spec as the harness handed it over.
+
+    A `CompiledSubAgent` is opaque by design — it carries a built runnable, and
+    the point of the caller-supplied ones is that we do not rebuild them here.
+    A declarative spec (which is what the general-purpose subagent is) still
+    carries its whole stack, so that is what gets compared.
+    """
+    described = {
+        "name": spec["name"],
+        "description": spec["description"],
+        "compiled": "runnable" in spec,
+    }
+    if "runnable" not in spec:
+        described |= {
+            "system_prompt": spec["system_prompt"],
+            "tools": [t.name for t in spec.get("tools") or []],
+            "middleware": [_describe_middleware(m) for m in spec["middleware"]],
+        }
+    return described
 
 
 def _prompt_text(prompt) -> str:
@@ -299,3 +331,53 @@ def test_no_sandbox_means_no_harness():
     assert described["system_prompt"] == "You are a test agent"
     assert described["tools"] == ["add"]
     assert [m["class"] for m in described["middleware"]] == ["ToolErrorMiddleware"]
+
+
+def test_a_caller_supplied_general_purpose_subagent_replaces_the_default():
+    """deepagents treats an explicit `general-purpose` spec as an override, not
+    an addition. Prepending ours unconditionally would give the agent two
+    subagents under one name."""
+    model = MODELS["openai"]()
+    subagents = [
+        CompiledSubAgent(
+            name="general-purpose", description="ours", runnable=_Sentinel()
+        )
+    ]
+
+    deep, ours = _both(model, subagents=subagents)
+
+    task = next(m for m in ours["middleware"] if m["name"] == "SubAgentMiddleware")
+    assert [s["name"] for s in task["subagents"]] == ["general-purpose"]
+    assert task["subagents"][0]["compiled"] is True
+    assert task == next(
+        m for m in deep["middleware"] if m["name"] == "SubAgentMiddleware"
+    )
+
+
+def test_plain_path_wires_subagents_after_the_caller_stack():
+    """The plain path has always put `SubAgentMiddleware` on the far side of the
+    caller's middleware, where the harness puts its own *before*. The position
+    is not cosmetic: a middleware's system-prompt fragment lands in list order,
+    so moving this one rewrites the prompt of every non-sandbox agent that has
+    subagents — and thread prompts are frozen at creation."""
+    seen, patcher = _capture("app.agents.runtime.create_agent")
+    caller = CurrentDateMiddleware(datetime(2026, 1, 1, tzinfo=UTC))
+    with patcher:
+        build_runnable(
+            model=MODELS["openai"](),
+            tools=TOOLS,
+            system_prompt="You are a test agent",
+            base_middleware=[caller],
+            subagents=[
+                CompiledSubAgent(
+                    name="helper", description="helps", runnable=_Sentinel()
+                )
+            ],
+        )
+
+    names = [type(m).__name__ for m in seen["middleware"]]
+    assert names == [
+        "CurrentDateMiddleware",
+        "SubAgentMiddleware",
+        "ToolErrorMiddleware",
+    ]

--- a/backend/tests/agents/test_harness_parity.py
+++ b/backend/tests/agents/test_harness_parity.py
@@ -1,0 +1,301 @@
+"""`build_runnable` must build exactly what `create_deep_agent` built.
+
+The runtime used to have two construction paths: plain agents through
+`create_agent`, sandbox agents through `create_deep_agent`. P2-3 collapsed
+them onto `create_agent` by assembling deepagents' middleware bundle
+explicitly (`app/agents/harness.py`) — which is only safe if the explicit
+assembly is a faithful reproduction. That is what these tests check: both
+paths are built for the same inputs, the `create_agent(**kwargs)` each one
+would issue is captured, and the two are compared middleware for middleware,
+tool for tool, byte for byte on the prompt.
+
+Deliberate deviations are listed in `EXPECTED_DEVIATIONS` with a reason. An
+empty list means the reproduction is exact; anything else is a decision
+someone made on purpose, and this file is where it is recorded.
+"""
+
+from unittest.mock import patch
+
+import deepagents.graph as deepagents_graph
+import pytest
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+from deepagents.middleware.subagents import CompiledSubAgent
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import SystemMessage
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+
+from app.agents.harness import HARNESS_CONFIG
+from app.agents.runtime import build_runnable
+from app.agents.structured_output import (
+    FORMAT_TOOL,
+    DeferredStructuredOutputMiddleware,
+)
+from app.agents.tool_errors import ToolErrorMiddleware
+from app.sandbox.lazy import LazySandboxBackend
+from tests.agents.scripted_model import ScriptedChatModel
+
+
+EXPECTED_DEVIATIONS: list[str] = []
+"""Differences we accept between the two assemblies. Keep it empty."""
+
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+@tool
+def create_sandbox(timeout_minutes: int = 30) -> str:
+    """Stand-in for the sandbox lifecycle tools."""
+    return "ok"
+
+
+TOOLS = [add]
+SANDBOX_TOOLS = [create_sandbox]
+
+
+MODELS = {
+    # A pre-built instance with no resolvable provider: the empty-profile path.
+    "scripted": lambda: ScriptedChatModel(script=[]),
+    # Resolves to a built-in harness profile, so the prompt grows a suffix.
+    "anthropic-profiled": lambda: ChatAnthropic(
+        model_name="claude-sonnet-4-6", api_key="test"
+    ),
+    # An Anthropic model with no registered profile.
+    "anthropic-unprofiled": lambda: ChatAnthropic(
+        model_name="claude-3-5-sonnet-20241022", api_key="test"
+    ),
+    "openai": lambda: ChatOpenAI(model="gpt-4o", api_key="test"),
+}
+
+
+class _Sentinel:
+    """Stands in for the compiled graph so nothing is actually built."""
+
+    def with_config(self, config):
+        self.config = config
+        return self
+
+
+def _capture(target: str):
+    """Patch `create_agent` at `target` and record the kwargs it was called with."""
+    seen: dict = {}
+
+    def fake_create_agent(model=None, **kwargs):
+        seen["model"] = model
+        seen.update(kwargs)
+        return _Sentinel()
+
+    return seen, patch(target, fake_create_agent)
+
+
+def via_deep_agent(model, **kwargs):
+    """What `create_deep_agent` would have handed to `create_agent`."""
+    seen, patcher = _capture("deepagents.graph.create_agent")
+    with patcher:
+        deepagents_graph.create_deep_agent(model=model, checkpointer=None, **kwargs)
+    return seen
+
+
+def via_build_runnable(model, **kwargs):
+    """What `build_runnable` hands to `create_agent` for the same inputs."""
+    seen, patcher = _capture("app.agents.runtime.create_agent")
+    with (
+        patcher,
+        patch("app.sandbox.tools.create_sandbox_tools", return_value=SANDBOX_TOOLS),
+    ):
+        build_runnable(model=model, sandbox_provider=None, **kwargs)
+    return seen
+
+
+def describe(seen: dict) -> dict:
+    """A comparable projection of one `create_agent(**kwargs)` call.
+
+    Middleware instances are not comparable by identity or equality, so each
+    is reduced to what actually reaches the model: its class, its registered
+    name, the tools it injects, and any system-prompt fragment it contributes.
+    """
+    return {
+        "model": seen["model"],
+        "tools": [t.name for t in seen["tools"]],
+        "system_prompt": _prompt_text(seen["system_prompt"]),
+        "response_format": seen["response_format"],
+        "middleware": [
+            {
+                "class": type(m).__name__,
+                "name": m.name,
+                "tools": [t.name for t in getattr(m, "tools", [])],
+                "system_prompt": getattr(m, "system_prompt", None),
+            }
+            for m in seen["middleware"]
+        ],
+    }
+
+
+def _prompt_text(prompt) -> str:
+    if prompt is None or isinstance(prompt, str):
+        return prompt or ""
+    return "".join(
+        block["text"] for block in prompt.content_blocks if block.get("type") == "text"
+    )
+
+
+def _both(
+    model,
+    *,
+    base_middleware=(),
+    subagents=None,
+    instructions="You are a test agent",
+    output_schema=None,
+) -> tuple[dict, dict]:
+    """Build both ways from one set of inputs and project each for comparison.
+
+    The `create_deep_agent` side reproduces the *old call site*, not just the
+    old function: it appended the sandbox tools, dropped its own
+    `PatchToolCallsMiddleware` (deepagents injects one and langchain asserts on
+    duplicates), appended the deferred-formatting middleware when a schema was
+    given, and put `ToolErrorMiddleware` last. That call site is the behaviour
+    P2-3 had to preserve.
+    """
+    backend = LazySandboxBackend()
+    deep_middleware = [
+        m for m in base_middleware if not isinstance(m, PatchToolCallsMiddleware)
+    ]
+    if output_schema is not None:
+        deep_middleware.append(DeferredStructuredOutputMiddleware(FORMAT_TOOL))
+    deep = via_deep_agent(
+        model,
+        tools=[*TOOLS, *SANDBOX_TOOLS],
+        system_prompt=instructions,
+        backend=backend,
+        middleware=[*deep_middleware, ToolErrorMiddleware()],
+        subagents=subagents,
+        response_format=output_schema,
+    )
+    ours = via_build_runnable(
+        model,
+        tools=TOOLS,
+        system_prompt=instructions,
+        sandbox_backend=backend,
+        base_middleware=base_middleware,
+        subagents=subagents,
+        output_schema=output_schema,
+    )
+    return describe(deep), describe(ours)
+
+
+@pytest.mark.parametrize("model_name", list(MODELS))
+def test_sandbox_assembly_matches_create_deep_agent(model_name):
+    """The whole point: same model, same tools, same middleware order, same
+    prompt — whichever assembler built it."""
+    model = MODELS[model_name]()
+
+    deep, ours = _both(model)
+
+    assert EXPECTED_DEVIATIONS == []
+    assert ours == deep
+
+
+@pytest.mark.parametrize("model_name", list(MODELS))
+def test_harness_prompt_is_reproduced_verbatim(model_name):
+    """Called out separately because the prompt is the part a diff of class
+    names would not catch — and the part a per-thread frozen prompt cannot
+    tolerate drifting."""
+    model = MODELS[model_name]()
+
+    deep, ours = _both(model)
+
+    assert ours["system_prompt"] == deep["system_prompt"]
+    assert ours["system_prompt"].startswith("You are a test agent\n\n")
+    assert "You are a deep agent" in ours["system_prompt"]
+
+
+def test_caller_subagents_are_appended_after_the_general_purpose_one():
+    """deepagents inserts its default subagent at index 0 and keeps the
+    caller's after it; the `task` tool description enumerates them in that
+    order, so a swap would be a visible behaviour change."""
+    model = MODELS["openai"]()
+    subagents = [
+        CompiledSubAgent(name="helper", description="helps", runnable=_Sentinel())
+    ]
+
+    deep, ours = _both(model, subagents=subagents)
+
+    task = next(m for m in ours["middleware"] if m["name"] == "SubAgentMiddleware")
+    assert "general-purpose" in task["system_prompt"]
+    assert "helper" in task["system_prompt"]
+    assert task == next(
+        m for m in deep["middleware"] if m["name"] == "SubAgentMiddleware"
+    )
+
+
+def test_caller_middleware_keeps_its_place_in_the_stack():
+    """The caller's stack sits between the harness and prompt caching — which
+    is where deepagents put it, and the reason a parent middleware's hooks fire
+    in the same order on both paths."""
+    model = MODELS["openai"]()
+    schema = {"title": "answer", "type": "object", "properties": {}}
+
+    deep, ours = _both(
+        model, base_middleware=[PatchToolCallsMiddleware()], output_schema=schema
+    )
+
+    names = [m["class"] for m in ours["middleware"]]
+    assert names == [m["class"] for m in deep["middleware"]]
+    assert names.index("PatchToolCallsMiddleware") < names.index(
+        "DeferredStructuredOutputMiddleware"
+    )
+    assert names.index("DeferredStructuredOutputMiddleware") < names.index(
+        "ToolErrorMiddleware"
+    )
+    assert names[-1] == "AnthropicPromptCachingMiddleware"
+
+
+def test_a_system_message_prompt_is_extended_the_same_way():
+    """`build_runnable`'s callers pass a plain string today, but the harness
+    keeps deepagents' `SystemMessage` branch so the two stay interchangeable."""
+    model = MODELS["openai"]()
+    deep, ours = _both(model, instructions=SystemMessage("You are a test agent"))
+
+    assert ours["system_prompt"] == deep["system_prompt"]
+
+
+def test_graph_config_matches_deepagents():
+    """`create_deep_agent` binds a recursion budget and trace metadata onto the
+    graph. Dropping it would silently cut a sandbox subagent's budget from
+    9_999 to langgraph's default of 25."""
+    model = MODELS["openai"]()
+    with (
+        patch("app.sandbox.tools.create_sandbox_tools", return_value=[create_sandbox]),
+        patch("app.agents.runtime.create_agent", return_value=_Sentinel()),
+    ):
+        built = build_runnable(
+            model=model,
+            tools=[add],
+            system_prompt="hi",
+            sandbox_backend=LazySandboxBackend(),
+        )
+
+    assert built.config == HARNESS_CONFIG
+    assert HARNESS_CONFIG["recursion_limit"] == 9_999
+    assert HARNESS_CONFIG["metadata"]["ls_integration"] == "deepagents"
+
+
+def test_no_sandbox_means_no_harness():
+    """The plain path is untouched by all of this: no todos, no filesystem, no
+    prompt caching, and the agent's instructions are the whole prompt."""
+    seen, patcher = _capture("app.agents.runtime.create_agent")
+    with patcher:
+        build_runnable(
+            model=MODELS["openai"](),
+            tools=[add],
+            system_prompt="You are a test agent",
+            base_middleware=[],
+        )
+
+    described = describe(seen)
+    assert described["system_prompt"] == "You are a test agent"
+    assert described["tools"] == ["add"]
+    assert [m["class"] for m in described["middleware"]] == ["ToolErrorMiddleware"]

--- a/backend/tests/agents/test_runtime.py
+++ b/backend/tests/agents/test_runtime.py
@@ -18,10 +18,15 @@ from app.agents.structured_output import (
     DeferredStructuredOutputMiddleware,
 )
 from app.agents.tool_errors import RepairInvalidToolCallsMiddleware, ToolErrorMiddleware
+from tests.agents.scripted_model import ScriptedChatModel
 
 
 def _build_agent(
-    *, sandbox: bool = False, middleware=None, provider: str | None = None
+    *,
+    sandbox: bool = False,
+    middleware=None,
+    provider: str | None = None,
+    model=None,
 ) -> Agent:
     resolved = MagicMock()
     resolved.sandbox = MagicMock() if sandbox else None
@@ -30,7 +35,7 @@ def _build_agent(
     return Agent(
         thread=MagicMock(),
         agent=resolved,
-        model=MagicMock(),
+        model=model if model is not None else MagicMock(),
         middleware=middleware if middleware is not None else [],
         callbacks=[],
         subagents=[],
@@ -118,25 +123,34 @@ def test_build_agent_appends_tool_error_middleware(mock_create_agent):
 
 
 @patch("app.sandbox.tools.create_sandbox_tools", return_value=[])
-@patch("app.agents.runtime.create_deep_agent")
-def test_build_agent_sandbox_dispatches_to_deep_agent(
-    mock_create_deep_agent, _mock_tools
+@patch("app.agents.runtime.create_agent")
+def test_build_agent_sandbox_uses_the_same_create_agent_path(
+    mock_create_agent, _mock_tools
 ):
-    """With a sandbox bound to the agent, the build goes through
-    create_deep_agent: ToolErrorMiddleware is appended and the caller's
-    PatchToolCallsMiddleware is dropped (deepagents injects its own)."""
+    """A sandbox no longer forks the construction path: it adds deepagents'
+    harness middleware to the same `create_agent` call. The caller's
+    PatchToolCallsMiddleware is dropped in favour of the harness's one (langchain
+    asserts against duplicates), and prompt caching closes the stack.
+
+    `tests/agents/test_harness_parity.py` pins the assembly to what
+    `create_deep_agent` built, middleware for middleware; this only checks that
+    the sandbox reaches it."""
     agent = _build_agent(
         sandbox=True,
+        # The harness sizes its summarization thresholds off the model, so this
+        # path needs a real BaseChatModel rather than a mock.
+        model=ScriptedChatModel(script=[]),
         middleware=[PatchToolCallsMiddleware(), DeferredStructuredOutputMiddleware()],
     )
 
     agent._build_agent(checkpointer=None)
 
-    middleware = mock_create_deep_agent.call_args.kwargs["middleware"]
-    # Our PatchToolCallsMiddleware is filtered out (deepagents adds its own).
-    assert not any(isinstance(m, PatchToolCallsMiddleware) for m in middleware)
-    # ToolErrorMiddleware is appended last so tool failures feed back as messages.
-    assert isinstance(middleware[-1], ToolErrorMiddleware)
+    middleware = mock_create_agent.call_args.kwargs["middleware"]
+    names = [type(m).__name__ for m in middleware]
+    assert names.count("PatchToolCallsMiddleware") == 1
+    assert "FilesystemMiddleware" in names
+    assert names[-1] == "AnthropicPromptCachingMiddleware"
+    assert "ToolErrorMiddleware" in names
 
 
 @patch("app.agents.runtime.create_agent")

--- a/backend/tests/agents/test_runtime_behaviour.py
+++ b/backend/tests/agents/test_runtime_behaviour.py
@@ -441,16 +441,61 @@ async def test_regeneration_on_a_first_turn_has_something_to_fork_from(
     ]
 
 
+@pytest.mark.parametrize(
+    "messages",
+    [
+        pytest.param([{"type": "wizard", "content": "hi"}], id="unknown-role"),
+        pytest.param([{"role": "user"}], id="missing-content"),
+        # Not a message at all: `convert_to_messages` raises NotImplementedError
+        # rather than ValueError for these, which would have been a 500.
+        pytest.param([42], id="not-a-message"),
+        pytest.param([None], id="null-message"),
+        pytest.param([["nested"]], id="nested-list"),
+        pytest.param("hi", id="messages-not-a-list"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_a_malformed_input_message_is_a_bad_request(in_memory_runtime):
+async def test_a_malformed_input_message_is_a_bad_request(in_memory_runtime, messages):
     """Run input is client-supplied. An unknown role used to be filed silently
-    as a user turn; it is a validation error now."""
+    as a user turn; every malformed shape is a validation error now, whichever
+    exception the converter picks for it."""
     from app.exceptions import DomainValidationError
 
     agent, _ = build_agent(script=["never reached"])
 
     with pytest.raises(DomainValidationError, match="Invalid run input"):
-        async for _ in agent.stream(
-            agent_input={"messages": [{"type": "wizard", "content": "hi"}]}
-        ):
+        async for _ in agent.stream(agent_input={"messages": messages}):
             pass
+
+
+@pytest.mark.asyncio
+async def test_subagent_wiring_keeps_the_caller_prompt_ahead_of_the_task_block():
+    """A plain agent with subagents assembles its prompt caller-fragments-first.
+    `SubAgentMiddleware` sitting on the wrong side of the caller's stack moves
+    the `task` block ahead of them — a silent prompt rewrite on every
+    non-sandbox agent that has subagents, whose prompts are frozen at creation.
+    """
+    from deepagents.middleware.subagents import CompiledSubAgent
+
+    from app.agents.current_date import CurrentDateMiddleware
+    from app.agents.runtime import build_runnable
+
+    class _Stub:
+        def with_config(self, config):
+            return self
+
+    model = ScriptedChatModel(script=["done"])
+    graph = build_runnable(
+        model=model,
+        tools=[],
+        system_prompt="You are a test agent",
+        base_middleware=[CurrentDateMiddleware(datetime(2026, 1, 1, tzinfo=UTC))],
+        subagents=[
+            CompiledSubAgent(name="helper", description="helps", runnable=_Stub())
+        ],
+    )
+
+    await graph.ainvoke({"messages": [{"role": "user", "content": "hi"}]})
+
+    system = system_text(model)
+    assert system.index("Current date:") < system.index("`task` (subagent spawner)")

--- a/backend/tests/agents/test_runtime_behaviour.py
+++ b/backend/tests/agents/test_runtime_behaviour.py
@@ -1,0 +1,456 @@
+"""Graph-level tests for `Agent.build`/`Agent.stream` (design review §6.2 gap 3).
+
+`test_runtime.py` asserts middleware *lists*: it proves what was configured,
+not what happens. These tests run the real graph against a
+`ScriptedChatModel`, so the assertions are behavioural — a tool ran, a failure
+came back as a message, the recursion fallback persisted something the next
+turn can resume from. They exist to make the P2-3 unification of
+`build_runnable` a refactor with a safety net instead of a leap of faith.
+"""
+
+import json
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+
+from app.agents.run_spec import AgentSpec
+from app.agents.runtime import RECURSION_LIMIT_MESSAGE, Agent, ResolvedAgent
+from app.agents.toolset import PreparedToolset, Toolset
+from tests.agents.scripted_model import ScriptedChatModel
+
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+@tool
+def explode() -> str:
+    """Always fails."""
+    raise RuntimeError("upstream MCP transport died")
+
+
+class LiveToolsetStub:
+    """Stands in for the toolset `Toolset.open` binds to a live MCP session."""
+
+    def __init__(self, tools: list):
+        self.all = tools
+
+
+def _prepared(tools: list) -> PreparedToolset:
+    prepared = PreparedToolset(
+        client=None,
+        server_names=[],
+        tool_settings={},
+        server_id_by_name={},
+        interrupt_on={},
+        apply_ui=False,
+    )
+    # `Agent._setup` replaces `resolved.live` with whatever `Toolset.open`
+    # yields, so the tools a test wants have to travel on the prepared spec.
+    prepared.tools_for_test = tools
+    return prepared
+
+
+def _spec(instructions: str = "You are a test agent") -> AgentSpec:
+    spec = MagicMock(spec=AgentSpec)
+    spec.instructions = instructions
+    spec.name = "Tester"
+    spec.description = "a test agent"
+    spec.sandbox = None
+    return spec
+
+
+def _thread(thread_id: str = "thread-1") -> MagicMock:
+    thread = MagicMock()
+    thread.id = thread_id
+    thread.user_id = "user-1"
+    thread.agent_id = "agent-1"
+    thread.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return thread
+
+
+def build_agent(
+    *,
+    script: list,
+    tools: list | None = None,
+    middleware: list | None = None,
+    interrupt_on: dict | None = None,
+    instructions: str = "You are a test agent",
+) -> tuple[Agent, ScriptedChatModel]:
+    """An `Agent` whose graph is real and whose model is scripted."""
+    from app.agents.runtime import build_parent_middleware
+
+    prepared = _prepared(tools or [])
+    if interrupt_on:
+        prepared.interrupt_on = interrupt_on
+    resolved = ResolvedAgent(config=_spec(instructions), prepared=prepared)
+    resolved.live = LiveToolsetStub(tools or [])
+    model = ScriptedChatModel(script=script)
+    agent = Agent(
+        thread=_thread(),
+        agent=resolved,
+        model=model,
+        middleware=middleware
+        if middleware is not None
+        else build_parent_middleware(datetime(2026, 1, 1, tzinfo=UTC), prepared),
+        callbacks=[],
+        subagents=[],
+        provider="openai",
+    )
+    return agent, model
+
+
+@pytest.fixture
+def in_memory_runtime():
+    """Run `Agent.stream` against an in-memory checkpointer and no MCP sessions."""
+    saver = InMemorySaver()
+
+    @asynccontextmanager
+    async def fake_checkpointer():
+        yield saver
+
+    @asynccontextmanager
+    async def fake_open(prepared):
+        yield LiveToolsetStub(prepared.tools_for_test)
+
+    with (
+        patch("app.agents.runtime.get_checkpointer", fake_checkpointer),
+        patch.object(Toolset, "open", fake_open),
+    ):
+        yield saver
+
+
+async def collect(agent: Agent, text: str = "hello", **kwargs) -> list[str]:
+    chunks = []
+    async for chunk in agent.stream(
+        agent_input={"messages": [{"type": "human", "content": text}]}, **kwargs
+    ):
+        chunks.append(chunk)
+    return chunks
+
+
+def sse_events(chunks: list[str]) -> list[tuple[str, object]]:
+    """Parse the adapter's SSE strings back into (event, data) pairs."""
+    events = []
+    for chunk in chunks:
+        event = data = None
+        for line in chunk.splitlines():
+            if line.startswith("event: "):
+                event = line[len("event: ") :]
+            elif line.startswith("data: "):
+                data = line[len("data: ") :]
+        if event is not None:
+            events.append((event, json.loads(data) if data else None))
+    return events
+
+
+def system_text(model: ScriptedChatModel, call: int = 0) -> str:
+    """The system prompt as the model saw it, flattened across content blocks."""
+    content = model.calls[call][0].content
+    if isinstance(content, str):
+        return content
+    return "\n\n".join(
+        block["text"] for block in content if block.get("type") == "text"
+    )
+
+
+def final_messages(saver: InMemorySaver, thread_id: str = "thread-1") -> list:
+    config = {"configurable": {"thread_id": thread_id}}
+    checkpoint = saver.get(config)
+    return checkpoint["channel_values"]["messages"] if checkpoint else []
+
+
+@pytest.mark.asyncio
+async def test_stream_runs_the_graph_and_emits_the_model_answer(in_memory_runtime):
+    """The baseline: a scripted turn reaches the SSE stream and the checkpoint."""
+    agent, model = build_agent(script=["42 is the answer"])
+
+    chunks = await collect(agent, "what is the answer?")
+
+    assert any("42 is the answer" in chunk for chunk in chunks)
+    assert [m.content for m in final_messages(in_memory_runtime)][-1] == (
+        "42 is the answer"
+    )
+    # The instructions reached the model as its system prompt.
+    assert model.calls[0][0].type == "system"
+    assert system_text(model).startswith("You are a test agent")
+
+
+@pytest.mark.asyncio
+async def test_stream_executes_a_tool_and_feeds_the_result_back(in_memory_runtime):
+    """A tool call round-trips: the tool runs, its ToolMessage is in the next
+    model call, and the second turn's text is what the user sees."""
+    agent, model = build_agent(
+        script=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "add", "args": {"a": 2, "b": 3}, "id": "call-1"}],
+            ),
+            "the sum is 5",
+        ],
+        tools=[add],
+    )
+
+    chunks = await collect(agent, "add 2 and 3")
+
+    assert any("the sum is 5" in chunk for chunk in chunks)
+    tool_messages = [m for m in model.calls[1] if m.type == "tool"]
+    assert [m.content for m in tool_messages] == ["5"]
+
+
+@pytest.mark.asyncio
+async def test_tool_failure_comes_back_as_a_message_instead_of_killing_the_run(
+    in_memory_runtime,
+):
+    """ToolErrorMiddleware's contract: an exception inside a tool must reach the
+    model as an error ToolMessage. Without it langgraph re-raises and one dead
+    MCP transport ends the whole run."""
+    agent, model = build_agent(
+        script=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "explode", "args": {}, "id": "call-1"}],
+            ),
+            "that tool is down, sorry",
+        ],
+        tools=[explode],
+    )
+
+    chunks = await collect(agent, "please explode")
+
+    assert any("that tool is down" in chunk for chunk in chunks)
+    tool_messages = [m for m in model.calls[1] if m.type == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].status == "error"
+
+
+@pytest.mark.asyncio
+async def test_recursion_limit_persists_a_resumable_synthetic_message(
+    in_memory_runtime, monkeypatch
+):
+    """When the graph blows its recursion limit the run must end visibly: a
+    synthetic AI message is written to the checkpoint (so the next turn resumes)
+    and streamed to the client (so the UI stops spinning)."""
+    monkeypatch.setattr("app.agents.settings.agent_settings.recursion_limit", 3)
+    looping = AIMessage(
+        content="",
+        tool_calls=[{"name": "add", "args": {"a": 1, "b": 1}, "id": "call-x"}],
+    )
+    agent, _ = build_agent(script=[looping] * 6, tools=[add])
+
+    chunks = await collect(agent, "loop forever")
+
+    # The SSE payload is JSON-encoded, so match the unescaped prefix.
+    assert any("I reached my step limit" in chunk for chunk in chunks)
+    assert final_messages(in_memory_runtime)[-1].content == RECURSION_LIMIT_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_hitl_interrupts_before_an_approval_gated_tool_runs(in_memory_runtime):
+    """An approval-gated tool must not execute before the interrupt: the stream
+    ends on the interrupt and the tool's result never reaches the model."""
+    agent, model = build_agent(
+        script=[
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "add", "args": {"a": 2, "b": 3}, "id": "call-1"}],
+            ),
+            "unreachable",
+        ],
+        tools=[add],
+        interrupt_on={"add": True},
+    )
+
+    await collect(agent, "add 2 and 3")
+
+    # One model call only — the graph stopped at the approval gate.
+    assert len(model.calls) == 1
+    state = in_memory_runtime.get_tuple({"configurable": {"thread_id": "thread-1"}})
+    assert state is not None
+    assert not [m for m in final_messages(in_memory_runtime) if m.type == "tool"]
+
+
+@pytest.mark.asyncio
+async def test_model_failure_ends_the_turn_visibly_and_still_persists_the_sandbox(
+    in_memory_runtime,
+):
+    """A model that keeps failing must not crash the run: ModelRetryMiddleware
+    exhausts its retries and persists the failure as an AIMessage. `stream`'s
+    `finally` is the only turn-end hook a sandbox gets, so the snapshot has to
+    run on that path too."""
+    agent, model = build_agent(script=[])  # exhausted script -> every call raises
+
+    with patch.object(Agent, "_persist_sandbox") as persist:
+        await collect(agent, "boom")
+
+    persist.assert_called_once()
+    assert len(model.calls) > 1, "the failure was not retried"
+    last = final_messages(in_memory_runtime)[-1]
+    assert last.type == "ai"
+    assert "Model call failed" in last.content
+
+
+@pytest.mark.asyncio
+async def test_stale_structured_response_is_cleared_before_a_new_run(in_memory_runtime):
+    """`structured_response` is a persistent channel: a turn that never reaches
+    its formatting step must not read back the previous turn's object."""
+    schema = {
+        "title": "answer",
+        "type": "object",
+        "properties": {"answer": {"type": "integer"}},
+        "required": ["answer"],
+    }
+    agent, _ = build_agent(script=["ignored"])
+    config = {"configurable": {"thread_id": "thread-1"}}
+
+    # Seed a previous turn's structured response.
+    with patch("app.agents.runtime.get_checkpointer"):
+        pass
+    graph = agent._build_agent(in_memory_runtime, output_schema=schema)
+    await graph.aupdate_state(config, {"structured_response": {"answer": 1}})
+
+    agent2, _ = build_agent(script=["fresh"])
+    with patch.object(Agent, "_build_agent", return_value=graph):
+        await collect(agent2, "again", output_schema=schema)
+
+    state = await graph.aget_state(config)
+    assert state.values.get("structured_response") is None
+
+
+# --- The sandbox path -------------------------------------------------------
+#
+# These pin what a sandbox-bound agent is actually offered today, which is the
+# contract P2-3 has to preserve when `build_runnable` stops dispatching to
+# `create_deep_agent`. `test_harness_parity.py` proves the two assemblies match
+# instruction-for-instruction; these prove the result runs.
+
+
+def build_sandbox_agent(*, script: list, tools: list | None = None):
+    """An `Agent` with a sandbox binding, i.e. the deepagents-harness path."""
+    from app.agents.runtime import ResolvedSandbox, build_parent_middleware
+
+    prepared = _prepared(tools or [])
+    resolved = ResolvedAgent(config=_spec(), prepared=prepared)
+    resolved.sandbox = ResolvedSandbox(provider=MagicMock(), tools=None)
+    resolved.live = LiveToolsetStub(tools or [])
+    model = ScriptedChatModel(script=script)
+    agent = Agent(
+        thread=_thread("thread-sandbox"),
+        agent=resolved,
+        model=model,
+        middleware=build_parent_middleware(datetime(2026, 1, 1, tzinfo=UTC), prepared),
+        callbacks=[],
+        subagents=[],
+        provider="openai",
+    )
+    return agent, model
+
+
+@pytest.mark.asyncio
+async def test_sandbox_agent_is_offered_the_full_harness_toolset(in_memory_runtime):
+    """A sandbox agent gets deepagents' harness: todo, filesystem, `execute`,
+    the `task` tool (from the auto-added general-purpose subagent) and our own
+    sandbox lifecycle tools — plus the harness prompt appended to the agent's
+    instructions."""
+    agent, model = build_sandbox_agent(script=["done"], tools=[add])
+
+    await collect(agent, "hello")
+
+    names = {t.name for t in model.bound_tools}
+    assert {"add", "create_sandbox", "connect_sandbox"} <= names
+    assert {"write_todos", "ls", "read_file", "write_file", "execute"} <= names
+    assert "task" in names
+    system = system_text(model)
+    assert system.startswith("You are a test agent")
+    assert "You are a deep agent" in system
+
+
+@pytest.mark.asyncio
+async def test_sandbox_agent_persists_the_sandbox_at_turn_end(in_memory_runtime):
+    """The snapshot hook runs once per turn, on the way out of `stream`."""
+    agent, _ = build_sandbox_agent(script=["done"])
+
+    with patch.object(Agent, "_persist_sandbox") as persist:
+        await collect(agent, "hello")
+
+    persist.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_plain_agent_is_offered_only_its_own_tools(in_memory_runtime):
+    """The counterpart to the harness test: without a sandbox the agent gets
+    no filesystem, no todos and no `task` tool, and its instructions are the
+    whole system prompt."""
+    agent, model = build_agent(script=["done"], tools=[add])
+
+    await collect(agent, "hello")
+
+    assert {t.name for t in model.bound_tools} == {"add"}
+    system = system_text(model)
+    assert system.startswith("You are a test agent")
+    assert "You are a deep agent" not in system
+
+
+# --- Regeneration and input resolution --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_regeneration_forks_from_before_the_last_user_message(in_memory_runtime):
+    """Regenerating replays the last turn: it forks from the checkpoint the
+    user's message was applied to, so the thread ends with one answer, not two
+    questions."""
+    agent, _ = build_agent(script=["first answer"])
+    await collect(agent, "question one")
+    agent, _ = build_agent(script=["second answer"])
+    await collect(agent, "question two")
+
+    agent, _ = build_agent(script=["a different second answer"])
+    await collect(agent, "question two", trigger="regenerate-message")
+
+    kinds = [(m.type, m.content) for m in final_messages(in_memory_runtime)]
+    assert kinds == [
+        ("human", "question one"),
+        ("ai", "first answer"),
+        ("human", "question two"),
+        ("ai", "a different second answer"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_regeneration_on_a_first_turn_has_something_to_fork_from(
+    in_memory_runtime,
+):
+    """The very first turn's input checkpoint is the empty state; regenerating
+    it must replace the answer rather than fail or append."""
+    agent, _ = build_agent(script=["first answer"])
+    await collect(agent, "only question")
+
+    agent, _ = build_agent(script=["better answer"])
+    await collect(agent, "only question", trigger="regenerate-message")
+
+    assert [(m.type, m.content) for m in final_messages(in_memory_runtime)] == [
+        ("human", "only question"),
+        ("ai", "better answer"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_input_message_is_a_bad_request(in_memory_runtime):
+    """Run input is client-supplied. An unknown role used to be filed silently
+    as a user turn; it is a validation error now."""
+    from app.exceptions import DomainValidationError
+
+    agent, _ = build_agent(script=["never reached"])
+
+    with pytest.raises(DomainValidationError, match="Invalid run input"):
+        async for _ in agent.stream(
+            agent_input={"messages": [{"type": "wizard", "content": "hi"}]}
+        ):
+            pass

--- a/backend/tests/agents/test_toolset.py
+++ b/backend/tests/agents/test_toolset.py
@@ -14,6 +14,7 @@ from app.agents.toolset import (
     _sanitize_tools_in_place,
     sanitize_tool_name,
 )
+from app.utils.encryption import encrypt_value
 
 
 # ---------------------------------------------------------------------------
@@ -735,3 +736,102 @@ class TestSessionSupervisor:
             await supervisor.reopen("a")
         assert supervisor.replaced == set()
         await supervisor.close()
+
+
+# ---------------------------------------------------------------------------
+# MCPResolutionScope — one server read for a whole run graph
+# ---------------------------------------------------------------------------
+
+
+class _CountingDB:
+    """A DB that answers both queries `prepare` makes, and counts them."""
+
+    def __init__(self, servers, api_key_rows):
+        self._servers = servers
+        self._api_key_rows = api_key_rows
+        self.server_queries = 0
+        self.api_key_queries = 0
+
+    async def execute(self, stmt):
+        table = stmt.get_final_froms()[0].name
+        if table == "mcp_servers":
+            self.server_queries += 1
+            return _FakeResult(self._servers)
+        self.api_key_queries += 1
+        return _ScalarOneResult(self._api_key_rows)
+
+
+class _ScalarOneResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
+class TestMCPResolutionScope:
+    """A run graph is a parent plus subagents, usually over the same servers.
+    Resolving each agent independently cost one server read and one API-key
+    decrypt per agent; the shared scope makes both O(1) for the graph."""
+
+    @staticmethod
+    def _fixture():
+        from types import SimpleNamespace
+
+        from app.mcp.servers.models import MCPAuthType, MCPServerDB
+
+        server_id = uuid4()
+        server = MCPServerDB(
+            id=server_id,
+            name="sheets",
+            url="http://mcp.example.com",
+            auth_type=MCPAuthType.api_key,
+        )
+        binding = SimpleNamespace(mcp_server_id=server_id, tools=None)
+        key_row = SimpleNamespace(key_encrypted=encrypt_value("s3cret"))
+        return server, binding, key_row
+
+    @pytest.mark.asyncio
+    async def test_a_shared_scope_reads_each_server_once(self):
+        from app.agents.toolset import MCPResolutionScope
+
+        server, binding, key_row = self._fixture()
+        db = _CountingDB([server], [key_row])
+
+        scope = await MCPResolutionScope.build([binding, binding], db, "u1")
+        for _ in range(3):  # a parent and two subagents on the same server
+            prepared = await Toolset.prepare(
+                [binding], db=db, user_id="u1", apply_ui=False, scope=scope
+            )
+            assert prepared.server_names == ["sheets"]
+
+        assert db.server_queries == 1
+        assert db.api_key_queries == 1
+
+    @pytest.mark.asyncio
+    async def test_without_a_scope_each_agent_reads_for_itself(self):
+        """The default stays per-agent, so the API paths that prepare a single
+        agent don't have to build a scope to call `prepare`."""
+        from app.agents.toolset import MCPResolutionScope  # noqa: F401
+
+        server, binding, key_row = self._fixture()
+        db = _CountingDB([server], [key_row])
+
+        for _ in range(3):
+            await Toolset.prepare([binding], db=db, user_id="u1", apply_ui=False)
+
+        assert db.server_queries == 3
+        assert db.api_key_queries == 3
+
+    @pytest.mark.asyncio
+    async def test_the_shared_key_still_reaches_the_client_config(self):
+        """Sharing the decrypted key must not change what the client is given."""
+        from app.agents.toolset import MCPResolutionScope
+
+        server, binding, key_row = self._fixture()
+        db = _CountingDB([server], [key_row])
+
+        scope = await MCPResolutionScope.build([binding], db, "u1")
+        config = await scope.config(server)
+
+        assert config["headers"] == {"Authorization": "Bearer s3cret"}


### PR DESCRIPTION
Phase 2 of the backend cleanup ([`backend-cleanup-todo.md`](../blob/main/backend-cleanup-todo.md)), all seven tasks. Does the runtime unification **before** the deepagents 0.7 / langchain upgrades, which is the point — it shrinks that upgrade's surface to three middleware classes and one prompt constant, in one file, with a test that says whether the upgrade changed behaviour.

## The problem

`build_runnable` branched: plain agents through `create_agent`, sandbox agents through `create_deep_agent`. Consequences, all of them accidental:

- Middleware added to the parent stack behaved differently depending on whether the agent happened to have a sandbox bound.
- Sandbox agents silently got summarization, prompt caching and a todo harness; plain agents got none. A per-agent behavioural fork nobody chose per agent.
- The sandbox path needed a strip-hack to drop the `PatchToolCallsMiddleware` deepagents injects on top of ours, because langchain asserts on duplicates.
- Two system-prompt shapes, with a comment admitting the second existed only "to avoid a prompt-shape change".

## The change

`build_runnable` always calls `create_agent`. `app/agents/harness.py` assembles deepagents' bundle by hand, so a sandbox **adds middleware and tools to the same list** rather than dispatching to a second builder:

| # | Middleware | Adds |
|---|---|---|
| 1 | `TodoListMiddleware` | `write_todos` |
| 2 | `FilesystemMiddleware` | `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `execute` |
| 3 | `SubAgentMiddleware` | `task` |
| 4 | `SummarizationMiddleware` | — |
| 5 | `PatchToolCallsMiddleware` | — |
| … | *the caller's stack* | our parent middleware + `ToolErrorMiddleware` |
| n | `AnthropicPromptCachingMiddleware` | — |

## Why you can trust the sandbox path is behaviour-preserving

`tests/agents/test_harness_parity.py` builds a sandbox agent **both ways** for four model shapes, captures the `create_agent(**kwargs)` each path would issue, and asserts they match — middleware for middleware, tool for tool, byte for byte on the system prompt. It carries an `EXPECTED_DEVIATIONS: list[str] = []` that the test asserts is empty, so any future divergence has to be written down rather than discovered.

Full spike write-up: `backend-harness-parity-finding.md`.

## Two behaviours this surfaced

Both were true in production and visible nowhere at the call site:

- **Every sandbox agent already has a `task` tool.** deepagents auto-adds a `general-purpose` subagent whenever the caller supplies none by that name — which we never do. It inherits the parent's full toolset and runs its own todo/filesystem/summarization/prompt-caching stack. Agents with no subagents configured are not subagent-free.
- **`recursion_limit=9_999` is what a sandbox *subagent* runs under**, not langgraph's default of 25. The `task` tool invokes a `CompiledSubAgent` with a fresh config, so the `.with_config` bound at build time is the budget that applies. Dropping it would have cut it 400× silently; `HARNESS_CONFIG` keeps it and a test pins it.

## Also in this phase

- **P2-4** — one `build_agent_middleware` for parent and subagent. They differ in exactly two documented ways, both forced by the subagent having no checkpointer: no approval gate and no tool-call patcher, and a tool budget sized to langgraph's default recursion limit rather than ours.
- **P2-6** — `MCPResolutionScope` reads every MCP server the run graph names in one `IN` query and shares the decrypted API keys. It was one `list_by_ids` **and** one key decrypt per agent per server. Resolution stays sequential on one `AsyncSession`: the queries went away, the concurrency hazard was never worth taking. Only reads are shared — the OAuth branch still builds a fresh `WebOAuthClientProvider` per agent, because it is stateful and the graph's sessions are opened concurrently.
- **P2-7** — `convert_to_messages` replaces the hand-rolled `_dicts_to_lc_messages`; it rejects an unknown role instead of filing it silently as a user turn, so `_resolve_input` raises `DomainValidationError` on malformed client input. `get_regeneration_checkpoint_id` asks the checkpointer for the last `source="input"` checkpoint instead of counting human messages backwards — one state load, verified equal to the old walk across a three-turn thread with tool calls.
- **P2-5** — the two silent product gaps are now tracked: #301 and #302, cross-referenced from the code comments that used to document them in silence.

## Tests

Coverage for the file this refactors went from six `isinstance` assertions on middleware lists to 13 tests that **run the real graph** against a scripted model (`tests/agents/scripted_model.py`, which raises on an unscripted extra turn): tool round-trip, tool failure returning as an error ToolMessage, the recursion fallback persisting a resumable message, the HITL gate stopping before the tool executes, a model failure ending the turn visibly with the sandbox still persisted, the stale-`structured_response` reset, regeneration, and the harness/no-harness toolsets.

840 pass. ruff, `ruff format --check` and mypy clean.

## Reviewer notes

**One prompt shape did change, deliberately.** `ResolvedAgent.compile` used to wrap a *subagent's* prompt as a single `{"type": "text"}` content block and now passes the string. Same content, one less shape; parent bytes are unchanged, since `create_agent` normalises a `str` to `SystemMessage(content=str)`. This is outside the parity test's scope, which covers the sandbox assembly — so "exact reproduction" is a claim about that path, not a blanket one.

**The plain path is unchanged, including where `SubAgentMiddleware` sits.** It goes *after* the caller's stack there and *before* it inside the harness, because those are the two positions the two assemblers used. Not cosmetic: a middleware's system-prompt fragment lands in list order, so moving it rewrites the prompt of every non-sandbox agent that has subagents. The first version of this PR got that wrong — cubic caught it, and two tests now pin it (one on the middleware list, one on the prompt the model receives).

**`harness.py` imports four symbols deepagents does not treat as public** (`BASE_AGENT_PROMPT`, `__version__`, `_apply_profile_prompt`, `_harness_profile_for_model`). That is the price of reproducing the assembly, and it is guarded twice: the parity test fails if any of them stops producing what `create_deep_agent` produces, and `harness._profile` raises if a resolved profile starts using a feature we do not reproduce, rather than dropping it silently.

**No deliberate deviations were taken.** Now that the stack is one list, three product calls are one-line diffs — drop the auto-added `general-purpose` subagent, settle summarization and prompt caching for *all* agents, trim the ~2.2 KB harness prompt. Each changes a frozen-per-thread system prompt, so they are owner calls, not refactor side-effects. They are listed un-taken at the end of the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the agent runtime on one construction path: `build_runnable` always calls `create_agent`, and `app/agents/harness.py` assembles deepagents' bundle by hand, so a sandbox adds middleware and tools to the same stack instead of dispatching to `create_deep_agent`. A parity test builds sandbox agents both ways for four model shapes and asserts the resulting `create_agent(**kwargs)` match — middleware for middleware, tool for tool, byte for byte — so behaviour is preserved. Review follow-ups fixed one real defect it missed: the plain-path `SubAgentMiddleware` had slipped ahead of the caller's stack, silently rewriting prompts on non-sandbox agents with subagents; it's back on the far side, pinned by two tests (middleware list and the prompt the model receives). The parity projection now recurses into each subagent spec, so the auto-added `general-purpose` subagent's own stack is compared too.

**Two accidental behaviours, now explicit:**
- Every sandbox agent already has a `task` tool: deepagents auto-adds a `general-purpose` subagent that inherits the parent's full toolset.
- Sandbox subagents run under `recursion_limit=9_999`, not langgraph's default of 25; `HARNESS_CONFIG` keeps it and a test pins it.

**Also in this phase:**
- Parent and subagent share one `build_agent_middleware`, differing in exactly two documented ways forced by the subagent having no checkpointer.
- `MCPResolutionScope` reads a run graph's MCP servers in one query and shares decrypted API keys across parent and subagents.
- `convert_to_messages` replaces the hand-rolled converter — any malformed input shape (unknown role, missing content, a non-message item) now raises `DomainValidationError` instead of being filed as a user turn or a 500 — and regeneration finds the last `source="input"` checkpoint in one state load.
- A subagent's system prompt shape changed from a `{"type": "text"}` content block to a string; content is identical.
- `harness.py` imports four deepagents symbols that aren't public API; the parity test and a guard in `harness._profile` cover them.
- The silent product gaps (subagent approval gates dropped, subagent sandboxes never persist) are now tracked as #301 and #302.
- Runtime test coverage went from six `isinstance` assertions to 13 tests that run the real graph against a scripted model.

<sup>Written for commit a8f98bcf04272d34a90d55b4880b1fbd088b25b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


