### PR TITLE
fix(backend): Phase 3 part 2 — exception mapping, query slimming, purge ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Keep these layers honest. Don't write `db.execute(select(...))` in a router or i
 
 `get_db` (in `app/database.py`) runs one transaction per HTTP request: it commits on success, rolls back on any exception. Service methods should use `await self.db.flush()` when they need a server-generated value (PK, timestamp) and never call `self.db.commit()`.
 
-There are two documented exceptions:
+There are three documented exceptions:
 
 1. **Out-of-request code** manages its own transaction — Slack handlers, the run
    worker, the reaper and the trigger scanner use `AsyncSessionLocal()` directly
@@ -53,6 +53,14 @@ There are two documented exceptions:
    and only then start streaming or open their own sessions — holding a pooled
    connection for the length of an agent run risks pool starvation. Each such
    commit carries a comment saying why; if you add one, so should yours.
+3. **Request handlers commit before a non-rollbackable side effect.**
+   `DELETE /threads/{id}` and `DELETE /agents/{id}/permanent` delete their rows,
+   `await db.commit()`, and only then purge LangGraph checkpoints — those live on a
+   separate auto-committed connection, so purging first and then failing to commit
+   would leave a row whose entire history is irrecoverably gone. The service does the
+   deletes and *returns the thread ids*; it never purges. Past the commit the purge is
+   logged rather than raised: the operation succeeded, and orphaned checkpoints are
+   invisible and reclaimable.
 
 ### Domain exceptions
 
@@ -72,7 +80,11 @@ Services raise exceptions from `app/exceptions.py`:
 belongs to Pydantic's parse-time error. `NoInviteError` and `StructuredOutputError`
 subclass `DomainError` and are handled at their call sites (see below).
 
-Global handlers in `main.py` translate them to JSON responses. Routers don't catch or re-raise these — the only router-level `try/except` is for cases that need non-standard handling (e.g. OAuth callback catching `NoInviteError` to emit a 302 redirect instead of a 400).
+**That table is `STATUS` in `app/exceptions.py`**, and it is the whole translation: `main.py` registers *one* handler, on `DomainError`, because Starlette's handler lookup walks the exception's MRO. Adding an exception means adding a row — or no row at all, since `status_for` walks the MRO too and a subclass inherits its parent's status. The response body comes from the exception's own `body()`; override it only when a client must branch on the failure programmatically (`ModelUnavailableError` is the one case).
+
+A second handler, on `ExceptionGroup`, exists so a domain exception raised under an anyio task group (the MCP transport, the toolset gather) keeps the status it chose: it re-dispatches a `DomainError` leaf via `root_cause()` and **re-raises everything else**. Register it on `ExceptionGroup`, never `BaseExceptionGroup` — the latter is not an `Exception` subclass and Starlette asserts on that while building the middleware stack, i.e. on the first request, not at import.
+
+Routers don't catch or re-raise these — the only router-level `try/except` is for cases that need non-standard handling (e.g. OAuth callback catching `NoInviteError` to emit a 302 redirect instead of a 400).
 
 Use `BaseService.get_or_404(id)` instead of hand-rolling `if not x: raise NotFoundError(...)`.
 

--- a/backend-cleanup-todo.md
+++ b/backend-cleanup-todo.md
@@ -6,7 +6,7 @@ just the state. Task IDs are stable — reference them in commits and PR titles.
 
 **Status legend:** `[ ]` not started · `[~]` partly done · `[x]` done · `[!]` blocked
 
-Last updated: 2026-08-29
+Last updated: 2026-08-31
 
 ---
 
@@ -212,11 +212,12 @@ Last updated: 2026-08-29
       orphaned checkpoints, which is invisible and reclaimable.
       Covered by `test_delete_commits_the_row_before_purging_checkpoints` (verified to
       fail on the old ordering) plus a 403 test; the endpoint had **no** tests before.
-      *Residual, deliberately not expanded into:* `AgentService.delete_permanently`
-      purges after all DB deletes have *flushed* but still before the request commit, so
-      it keeps a narrower version of the same window. Its ordering is asserted by an
-      existing test and fixing it means committing mid-service, which changes that
-      method's contract — worth doing under P3-5 when that method is opened anyway
+      *Residual — closed under P3-5, 2026-08-31:* `AgentService.delete_permanently`
+      purged after all DB deletes had *flushed* but still before the request commit,
+      keeping a narrower version of the same window. It now returns the thread ids
+      instead (the same contract as `ThreadService.delete_rows_for_agent`) and
+      `DELETE /agents/{id}/permanent` commits, then purges, with the same
+      log-don't-500 guard the thread endpoint uses
 - [x] **P1-10** Slack: strong task references, Redis `SET NX EX` dedup (was per-process,
       so a retry on a second instance ran the agent twice), Optional-event guard.
       `app/integrations/slack/router.py` rewritten; 9 tests in
@@ -488,8 +489,82 @@ Last updated: 2026-08-29
       first — whether a failed revoke is surfaced to the admin, and whether user-facing
       disconnect does it too.
 
-- [ ] **P3-4** Exception handlers → status mapping + `root_cause` in the group branch
-- [ ] **P3-5** Bulk deletes, drop redundant refetches, `load_only` on the list query
+- [x] **P3-4** Exception handlers → status mapping + `root_cause` in the group branch.
+      Six near-identical handlers became one registration on `DomainError` —
+      Starlette's lookup walks the MRO, so the base class catches every subclass — with
+      the status coming from `STATUS: dict[type[DomainError], int]` in `app/exceptions.py`
+      and the body from the exception's own `body()`. The MRO walk in `status_for` is what
+      makes the table *partial*: `NoInviteError` and `StructuredOutputError` need no row
+      and inherit `DomainError`'s 500, which is what they get today. `body()` exists
+      because `ModelUnavailableError` is the one exception whose response is more than a
+      `detail` string, and an `isinstance` chain in the handler is exactly the
+      copy-paste being removed.
+      The group branch had to be **re-added**, which needs saying plainly: P3-3 deleted
+      the `ExceptionGroup` registration and left a test forbidding it. The old handler's
+      sin was owning the response for *every* group (a TaskGroup-wrapped `NotFoundError`
+      became a 500, §2.3); the new one re-dispatches a `DomainError` leaf via
+      `root_cause()` and **re-raises everything else**, so it can only preserve a status
+      the code already chose, never invent one. It cannot resurrect the global OAuth 401
+      either — `OAuthAuthorizationRequired` is not a `DomainError` — and a test raising a
+      wrapped one from an endpoint pins that it still 500s with no auth URL in the body.
+      The P3-3 guard was narrowed to what it actually protects (no OAuth handler) rather
+      than deleted.
+      **One trap, found by the tests and worth remembering**: registering on
+      `BaseExceptionGroup` imports cleanly and then 500s every route. It is not a
+      subclass of `Exception`, and Starlette asserts that while *building the middleware
+      stack* — which happens lazily, on the first request. `ExceptionGroup` is the right
+      key and loses nothing, since the middleware only catches `Exception` anyway.
+      `test_the_real_app_can_build_its_middleware_stack` now guards it.
+      Tests: `tests/test_exception_handlers.py` (14). They mirror the *real* app's
+      registration table into a one-route app rather than re-declaring it, so a handler
+      deleted from `main.py` fails them. Verified the group branch is load-bearing: with
+      it skipped, a wrapped `NotFoundError` is a 500
+- [x] **P3-5** Bulk deletes, drop redundant refetches, `load_only` on the list query.
+      Six select-then-delete-each loops became one `DELETE … WHERE` each
+      (`delete_all_permissions`, `delete_all_teams`, the two in `mcp_servers`, the
+      `or_`-both-directions one in `subagents`, `delete_all_for_sandbox`), and
+      `set_permissions`/`set_teams` now delegate to them instead of re-implementing the
+      loop. `set_permissions` also lost its `refresh` loop — one round-trip per grant to
+      read timestamps `AgentPermissionResponse` does not carry.
+      The mutation paths took the bigger cut. `require_permission` already proves the
+      agent exists and every mutation ends in a `get` that re-reads it, so the
+      `get_or_404` in between was fetching a row only `repository.update` looked at —
+      plus the `refresh` that ORM update did afterwards. Three new id-based repository
+      methods (`update_by_id`, `set_archived`, `delete_by_id`) replace it. **A one-column
+      PATCH went 8 → 6 statements and now reads the full agent row exactly once.**
+      `update_by_id` returns early on an empty patch, matching the ORM path: a PATCH
+      naming no fields must not bump `updated_at`, and a test pins that.
+      For §3.5 the review offered `load_only` *or* a separate `IN` query; `load_only` is
+      the smaller change and does the whole job. `list_with_permissions(slim=True)` loads
+      only the columns `AgentListResponse` renders, so `instructions` (tens of KB per
+      agent, repeated once per MCP binding by the join) and the bindings' per-tool JSONB
+      maps never leave the database. `AgentService.list` now *returns*
+      `AgentListResponse` — the narrowing is a narrower read, not a field hidden at
+      serialization time — and skips the sandbox query entirely, since that schema has no
+      `sandboxes` field. **The wire format is unchanged**: the router already declared
+      `response_model=list[AgentListResponse]`. Slack's picker was retyped with it (it
+      only reads id/name/emoji/permission).
+      The mechanism to know about: `model_dump()` on a `load_only`-ed instance silently
+      *omits* the deferred columns and does not emit a query — verified before relying on
+      it. That is what makes the slim path safe, and also why a slim row may only be
+      assembled into `AgentListResponse`: building an `AgentResponse` from one fails
+      validation instead of quietly N+1-ing.
+      Tests: `tests/agents/core/test_query_cost.py` (9, real engine) — the list never
+      selects `agents.instructions` or `agent_mcp_servers.tools`, never touches
+      `agent_sandboxes`, costs ≤4 statements for any number of agents, the detail read
+      still carries everything, and the PATCH/archive costs above. Plus real-engine
+      rewrites of the bulk-delete and whole-set-replace tests.
+      *Test debt paid down (P3-16)*: ~10 mock-mirror tests that asserted `db.delete` once
+      per row, counted `flush`es, or matched `repository.update(agent, patch)` broke on
+      this refactor without a single behaviour changing — the exact failure mode §6.2
+      describes. They were rewritten against the real engine, and
+      `tests/agents/core/conftest.py` moved up to `tests/agents/conftest.py` so every
+      agents module can reach the engine and statement counter.
+      *Rode along, because the method was open:* P1-9's residual (above) —
+      `delete_permanently` now hands its thread ids back and the router commits before
+      purging checkpoints, so a failed commit can no longer leave an agent whose history
+      is irrecoverably gone. Two router tests pin the ordering and that a failed purge
+      still answers 204
 - [ ] **P3-6** Typed event envelopes + `error_code` column + machine-readable HITL block ids
 - [ ] **P3-7** Thread reads into the service; O(1) subagent state; one history encoding; stable message ids
       **Found while doing P3-1, not fixed there — decide before closing P3-7:**

--- a/backend/app/agents/core/repository.py
+++ b/backend/app/agents/core/repository.py
@@ -2,9 +2,10 @@ from collections import defaultdict
 from typing import NamedTuple
 from uuid import UUID
 
-from sqlalchemy import or_
+from sqlalchemy import delete, or_, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlalchemy.orm import load_only
+from sqlmodel import SQLModel, select
 
 from app.agents.models import (
     AgentDB,
@@ -33,6 +34,34 @@ class AgentRepository(BaseRepository[AgentDB]):
     def __init__(self, db: AsyncSession):
         super().__init__(AgentDB, db)
 
+    #: The columns the list projection renders (`AgentListResponse`), plus
+    #: `tag_id`, which the service resolves into a `TagInfo`. Everything else
+    #: — `instructions` above all, which runs to tens of KB per agent and is
+    #: repeated once per MCP binding by the join — stays in the database
+    #: (design review §3.5).
+    LIST_COLUMNS = (
+        AgentDB.id,
+        AgentDB.name,
+        AgentDB.owner_id,
+        AgentDB.emoji,
+        AgentDB.color,
+        AgentDB.description,
+        AgentDB.is_archived,
+        AgentDB.tag_id,
+        AgentDB.created_at,
+        AgentDB.updated_at,
+    )
+
+    #: Same idea for the binding rows: `AgentMCPServerListResponse` identifies
+    #: the server and nothing else, so the per-tool JSONB maps stay put too.
+    LIST_BINDING_COLUMNS = (
+        AgentMCPServerDB.id,
+        AgentMCPServerDB.agent_id,
+        AgentMCPServerDB.mcp_server_id,
+        AgentMCPServerDB.created_at,
+        AgentMCPServerDB.updated_at,
+    )
+
     async def list_with_permissions(
         self,
         *,
@@ -42,8 +71,15 @@ class AgentRepository(BaseRepository[AgentDB]):
         agent_id: UUID | None = None,
         include_archived: bool = False,
         archived_only: bool = False,
+        slim: bool = False,
     ) -> list:
         """Join agent ↔ MCP links ↔ user permission ↔ team link in one shot.
+
+        ``slim`` loads only the columns the list projection renders. The rows
+        come back as the same ORM objects either way — a deferred column is
+        simply absent from ``model_dump()``, and reading one would emit a query,
+        which is why a slim row may only be assembled into
+        ``AgentListResponse``.
 
         When ``user_id`` is set and the user is not a workspace admin, the
         query includes a third tuple element: the user's permission row (or
@@ -71,6 +107,11 @@ class AgentRepository(BaseRepository[AgentDB]):
         stmt = select(*columns).outerjoin(
             AgentMCPServerDB, AgentDB.id == AgentMCPServerDB.agent_id
         )
+        if slim:
+            stmt = stmt.options(
+                load_only(*self.LIST_COLUMNS),
+                load_only(*self.LIST_BINDING_COLUMNS),
+            )
         if include_permissions:
             stmt = stmt.outerjoin(
                 AgentUserPermissionDB,
@@ -224,22 +265,41 @@ class AgentRepository(BaseRepository[AgentDB]):
             subagents=[to_spec(a) for a in subagent_rows],
         )
 
-    async def archive(self, agent: AgentDB) -> None:
-        agent.is_archived = True
-        self.db.add(agent)
-        await self.db.flush()
+    async def update_by_id(self, agent_id: UUID, data: SQLModel) -> None:
+        """Apply a patch to one agent without loading its row first.
 
-    async def restore(self, agent: AgentDB) -> None:
-        agent.is_archived = False
-        self.db.add(agent)
-        await self.db.flush()
+        Every mutation on `AgentService` is already preceded by
+        `require_permission`, which proves the row exists, and followed by a
+        `get`, which re-reads it in full. The ORM `update(db_obj, patch)` in
+        between therefore paid for a row nobody used — a `SELECT` to load it and
+        a `refresh` afterwards to re-read what the next `get` was about to read
+        anyway (design review §3.6).
+
+        An empty patch issues nothing, matching the ORM path: `sqlmodel_update({})`
+        leaves the instance clean, so no `UPDATE` — and no `updated_at` bump — is
+        emitted for a PATCH that names no fields.
+        """
+        values = data.model_dump(exclude_unset=True)
+        if not values:
+            return
+        stmt = update(AgentDB).where(AgentDB.id == agent_id).values(**values)
+        await self.db.execute(stmt)
+
+    async def set_archived(self, agent_id: UUID, *, archived: bool) -> None:
+        stmt = (
+            update(AgentDB).where(AgentDB.id == agent_id).values(is_archived=archived)
+        )
+        await self.db.execute(stmt)
+
+    async def delete_by_id(self, agent_id: UUID) -> None:
+        stmt = delete(AgentDB).where(AgentDB.id == agent_id)
+        await self.db.execute(stmt)
 
     async def delete_all_permissions(self, agent_id: UUID) -> None:
-        existing = await self.get_permissions(agent_id)
-        for perm in existing:
-            await self.db.delete(perm)
-        if existing:
-            await self.db.flush()
+        stmt = delete(AgentUserPermissionDB).where(
+            AgentUserPermissionDB.agent_id == agent_id
+        )
+        await self.db.execute(stmt)
 
     async def get_permissions(self, agent_id: UUID) -> list[AgentUserPermissionDB]:
         stmt = select(AgentUserPermissionDB).where(
@@ -251,10 +311,16 @@ class AgentRepository(BaseRepository[AgentDB]):
     async def set_permissions(
         self, agent_id: UUID, permissions: list[AgentPermissionCreate]
     ) -> list[AgentUserPermissionDB]:
-        existing = await self.get_permissions(agent_id)
-        for perm in existing:
-            await self.db.delete(perm)
-        await self.db.flush()
+        """Replace the agent's whole grant set.
+
+        Delete-then-insert rather than a diff: the payload *is* the new set, and
+        the sharing panel sends it whole. The rows carry nothing worth
+        preserving across a re-grant — no history, no created-by.
+
+        Deliberately no `refresh` loop after the flush: it cost one round-trip
+        per grant to read timestamps `AgentPermissionResponse` does not carry.
+        """
+        await self.delete_all_permissions(agent_id)
 
         new_permissions = [
             AgentUserPermissionDB(
@@ -264,11 +330,8 @@ class AgentRepository(BaseRepository[AgentDB]):
             )
             for p in permissions
         ]
-        for perm in new_permissions:
-            self.db.add(perm)
+        self.db.add_all(new_permissions)
         await self.db.flush()
-        for perm in new_permissions:
-            await self.db.refresh(perm)
         return new_permissions
 
     async def get_team_ids(self, agent_id: UUID) -> list[UUID]:
@@ -276,29 +339,18 @@ class AgentRepository(BaseRepository[AgentDB]):
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 
-    async def _get_team_links(self, agent_id: UUID) -> list[AgentTeamDB]:
-        stmt = select(AgentTeamDB).where(AgentTeamDB.agent_id == agent_id)
-        result = await self.db.execute(stmt)
-        return list(result.scalars().all())
-
     async def delete_all_teams(self, agent_id: UUID) -> None:
-        existing = await self._get_team_links(agent_id)
-        for link in existing:
-            await self.db.delete(link)
-        if existing:
-            await self.db.flush()
+        stmt = delete(AgentTeamDB).where(AgentTeamDB.agent_id == agent_id)
+        await self.db.execute(stmt)
 
     async def set_teams(self, agent_id: UUID, team_ids: list[UUID]) -> list[UUID]:
-        existing = await self._get_team_links(agent_id)
-        for link in existing:
-            await self.db.delete(link)
-        await self.db.flush()
+        """Replace the agent's whole team set — see `set_permissions`."""
+        await self.delete_all_teams(agent_id)
 
         new_links = [
             AgentTeamDB(agent_id=agent_id, team_id=team_id)
             for team_id in dict.fromkeys(team_ids)
         ]
-        for link in new_links:
-            self.db.add(link)
+        self.db.add_all(new_links)
         await self.db.flush()
         return [link.team_id for link in new_links]

--- a/backend/app/agents/core/repository.py
+++ b/backend/app/agents/core/repository.py
@@ -286,8 +286,29 @@ class AgentRepository(BaseRepository[AgentDB]):
         await self.db.execute(stmt)
 
     async def set_archived(self, agent_id: UUID, *, archived: bool) -> None:
+        """Archive or restore, idempotently.
+
+        The `is_archived` predicate is not redundant: archiving is deliberately
+        repeatable (`AgentService.delete` passes `include_archived=True` so a
+        second delete does not 404), and without it a repeat would issue an
+        UPDATE whose only effect is bumping `updated_at` — which the agents list
+        renders. The ORM path this replaced got that for free, because
+        SQLAlchemy does not mark an attribute dirty when it is set to the value
+        it already holds.
+
+        The statement still goes out and simply matches no rows — one round-trip
+        the ORM path did not spend. Avoiding it would mean reading the row
+        first, which costs the same round-trip.
+
+        `update_by_id` deliberately does *not* do the same. Matching it there
+        would mean comparing against every current value, so the read this whole
+        change removed would come back, and a PATCH naming a field is an
+        explicit instruction to write it.
+        """
         stmt = (
-            update(AgentDB).where(AgentDB.id == agent_id).values(is_archived=archived)
+            update(AgentDB)
+            .where(AgentDB.id == agent_id, AgentDB.is_archived != archived)
+            .values(is_archived=archived)
         )
         await self.db.execute(stmt)
 

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from typing import Literal, overload
 from uuid import UUID
 
 from fastapi import Depends
@@ -127,7 +128,33 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             raise PermissionDeniedError(f"Not authorized to {action}")
         return permission
 
+    @overload
     async def _assemble(
+        self,
+        agents: list[AgentDB],
+        mcp_map: dict[UUID, list[AgentMCPServerResponse | AgentMCPServerListResponse]],
+        permissions_map: dict[UUID, PermissionLevel],
+        user_id: UUID | None,
+        user_role: WorkspaceRole | None,
+        team_agent_ids: set[UUID] | None = ...,
+        *,
+        slim: Literal[False] = ...,
+    ) -> list[AgentResponse]: ...
+
+    @overload
+    async def _assemble(
+        self,
+        agents: list[AgentDB],
+        mcp_map: dict[UUID, list[AgentMCPServerResponse | AgentMCPServerListResponse]],
+        permissions_map: dict[UUID, PermissionLevel],
+        user_id: UUID | None,
+        user_role: WorkspaceRole | None,
+        team_agent_ids: set[UUID] | None = ...,
+        *,
+        slim: Literal[True],
+    ) -> list[AgentListResponse]: ...
+
+    async def _assemble(  # type: ignore[misc]  # impl is wider than overload 1
         self,
         agents: list[AgentDB],
         mcp_map: dict[UUID, list[AgentMCPServerResponse | AgentMCPServerListResponse]],
@@ -139,6 +166,11 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         slim: bool = False,
     ) -> list[AgentListResponse]:
         """Hydrate agent rows into responses.
+
+        Overloaded on `slim` because the two modes return different types and
+        `get` needs the full one: `AgentResponse` is a *subclass* of
+        `AgentListResponse`, so a single widened annotation would silently make
+        `get`'s own `-> AgentResponse` contract unprovable.
 
         ``slim`` is the list projection: `AgentListResponse` instead of
         `AgentResponse`, which is not just a narrower serialization but a

--- a/backend/app/agents/core/service.py
+++ b/backend/app/agents/core/service.py
@@ -23,6 +23,8 @@ from app.agents.sandboxes.service import AgentSandboxService
 from app.agents.schemas import (
     AgentConfig,
     AgentCreateDB,
+    AgentListResponse,
+    AgentMCPServerListResponse,
     AgentMCPServerResponse,
     AgentOwnerInfo,
     AgentPatch,
@@ -128,37 +130,51 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     async def _assemble(
         self,
         agents: list[AgentDB],
-        mcp_map: dict[UUID, list[AgentMCPServerResponse]],
+        mcp_map: dict[UUID, list[AgentMCPServerResponse | AgentMCPServerListResponse]],
         permissions_map: dict[UUID, PermissionLevel],
         user_id: UUID | None,
         user_role: WorkspaceRole | None,
         team_agent_ids: set[UUID] | None = None,
-    ) -> list[AgentResponse]:
+        *,
+        slim: bool = False,
+    ) -> list[AgentListResponse]:
+        """Hydrate agent rows into responses.
+
+        ``slim`` is the list projection: `AgentListResponse` instead of
+        `AgentResponse`, which is not just a narrower serialization but a
+        narrower *read* — the rows arrive without `instructions` (see
+        `AgentRepository.LIST_COLUMNS`), and sandbox bindings, which only the
+        detail response carries, are not queried at all.
+        """
         agent_ids = [a.id for a in agents]
         (
             subagents_map,
             is_subagent_ids,
         ) = await self.subagent_service.list_all_subagent_data(agent_ids)
         sandbox_map: dict[UUID, list[AgentSandboxResponse]] = defaultdict(list)
-        for link, sandbox in await self.sandbox_repository.list_for_agents(agent_ids):
-            sandbox_map[link.agent_id].append(
-                AgentSandboxResponse(
-                    sandbox_id=sandbox.id,
-                    tools=link.tools,
-                    name=sandbox.name,
-                    provider=sandbox.provider,
-                    url=sandbox.url,
+        if not slim:
+            for link, sandbox in await self.sandbox_repository.list_for_agents(
+                agent_ids
+            ):
+                sandbox_map[link.agent_id].append(
+                    AgentSandboxResponse(
+                        sandbox_id=sandbox.id,
+                        tools=link.tools,
+                        name=sandbox.name,
+                        provider=sandbox.provider,
+                        url=sandbox.url,
+                    )
                 )
-            )
         tag_ids = list({a.tag_id for a in agents if a.tag_id is not None})
         tags_by_id = {t.id: t for t in await self.tag_service.list_by_ids(tag_ids)}
         owner_ids = list({a.owner_id for a in agents})
         owners_by_id = {u.id: u for u in await self.user_service.list_by_ids(owner_ids)}
+        response_cls = AgentListResponse if slim else AgentResponse
         return [
-            AgentResponse(
+            response_cls(
                 **agent.model_dump(),
                 mcp_servers=mcp_map.get(agent.id, []),
-                sandboxes=sandbox_map.get(agent.id, []),
+                **({} if slim else {"sandboxes": sandbox_map.get(agent.id, [])}),
                 subagents=subagents_map.get(agent.id, []),
                 tag=(
                     TagInfo(id=tag.id, name=tag.name)
@@ -191,14 +207,25 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
     def _group_rows(
         rows: list,
         user_id: UUID | None,
+        *,
+        slim: bool = False,
     ) -> tuple[
         dict[UUID, AgentDB],
-        dict[UUID, list[AgentMCPServerResponse]],
+        dict[UUID, list[AgentMCPServerResponse | AgentMCPServerListResponse]],
         dict[UUID, PermissionLevel],
         set[UUID],
     ]:
+        """Collapse the join's fan-out into per-agent maps.
+
+        `slim` must match the flag the rows were read with: a slim binding row
+        has no per-tool map loaded, and validating it into the full
+        `AgentMCPServerResponse` would fetch one per row.
+        """
+        binding_cls = AgentMCPServerListResponse if slim else AgentMCPServerResponse
         agents_map: dict[UUID, AgentDB] = {}
-        mcp_map: dict[UUID, list[AgentMCPServerResponse]] = defaultdict(list)
+        mcp_map: dict[
+            UUID, list[AgentMCPServerResponse | AgentMCPServerListResponse]
+        ] = defaultdict(list)
         permissions_map: dict[UUID, PermissionLevel] = {}
         team_agent_ids: set[UUID] = set()
         for row in rows:
@@ -206,7 +233,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             link = row[1]
             agents_map[agent.id] = agent
             if link is not None:
-                mcp_map[agent.id].append(AgentMCPServerResponse.model_validate(link))
+                mcp_map[agent.id].append(binding_cls.model_validate(link))
             if user_id and len(row) > 2:
                 permission = row[2]
                 if permission and agent.id not in permissions_map:
@@ -282,15 +309,20 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         user_role: WorkspaceRole | None = None,
         user_team_id: UUID | None = None,
         archived: bool = False,
-    ) -> list[AgentResponse]:
+    ) -> list[AgentListResponse]:
+        """The list projection — `AgentListResponse`, read as narrowly as it is
+        rendered. It is not an `AgentResponse` with fields hidden at
+        serialization time: `instructions` and the bindings' per-tool maps never
+        leave the database, and no caller of this method wants them (§3.5)."""
         rows = await self.repository.list_with_permissions(
             user_id=user_id,
             user_role=user_role,
             user_team_id=user_team_id,
             archived_only=archived,
+            slim=True,
         )
         agents_map, mcp_map, permissions_map, team_agent_ids = self._group_rows(
-            rows, user_id
+            rows, user_id, slim=True
         )
         return await self._assemble(
             list(agents_map.values()),
@@ -299,6 +331,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             user_id,
             user_role,
             team_agent_ids,
+            slim=True,
         )
 
     async def update(
@@ -319,9 +352,8 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         )
         if data.tag_id is not None:
             await self.tag_service.get(data.tag_id)
-        agent = await self.get_or_404(agent_id)
         try:
-            await self.repository.update(agent, data)
+            await self.repository.update_by_id(agent_id, data)
         except IntegrityError as exc:
             if "fk_agents_tag_id_tags" not in str(getattr(exc, "orig", exc)):
                 raise
@@ -352,9 +384,8 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             user_team_id=user_team_id,
         )
 
-        agent = await self.get_or_404(agent_id)
-        await self.repository.update(
-            agent,
+        await self.repository.update_by_id(
+            agent_id,
             AgentPatch(
                 name=config.name,
                 instructions=config.instructions,
@@ -388,9 +419,8 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             # here rather than 404, or a repeated delete fails.
             include_archived=True,
         )
-        agent = await self.get_or_404(agent_id)
         await self.subagent_service.delete_all_for_agent(agent_id)
-        await self.repository.archive(agent)
+        await self.repository.set_archived(agent_id, archived=True)
 
     async def restore(
         self,
@@ -408,8 +438,7 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             user_team_id=user_team_id,
             include_archived=True,
         )
-        agent = await self.get_or_404(agent_id)
-        await self.repository.restore(agent)
+        await self.repository.set_archived(agent_id, archived=False)
         return await self.get(
             agent_id,
             user_id=user_id,
@@ -424,7 +453,18 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
         user_id: UUID | None = None,
         user_role: WorkspaceRole | None = None,
         user_team_id: UUID | None = None,
-    ) -> None:
+    ) -> list[str]:
+        """Delete every DB row that references the agent, and return the ids of
+        the threads that went with it.
+
+        Checkpoint purging is deliberately **not** done here — it is an
+        external, non-transactional side effect, so it must run after the
+        caller has *committed* these deletes, not merely flushed them. Same
+        contract as `ThreadService.delete_rows_for_agent`, and the same reason
+        the thread endpoint commits before purging (P1-9): a purge that ran
+        first and a commit that then failed would leave an agent whose entire
+        history is irrecoverably gone.
+        """
         await self.require_permission(
             agent_id,
             at_least=EffectivePermission.admin,
@@ -434,18 +474,14 @@ class AgentService(BaseService[AgentDB, AgentRepository]):
             user_team_id=user_team_id,
             include_archived=True,
         )
-        agent = await self.get_or_404(agent_id)
-        # Delete every DB row that references the agent first (threads must go
-        # before the agent row due to the FK), then purge checkpoints last.
+        # Threads must go before the agent row, due to the FK.
         thread_ids = await self.thread_service.delete_rows_for_agent(agent_id)
         await self.subagent_service.delete_all_for_agent(agent_id)
         await self.mcp_server_repository.delete_all_for_agent(agent_id)
         await self.repository.delete_all_permissions(agent_id)
         await self.repository.delete_all_teams(agent_id)
-        await self.repository.delete(agent)
-        # Checkpoints live on a separate auto-committed connection and can't be
-        # rolled back, so purge them only after all DB deletes have succeeded.
-        await self.thread_service.purge_checkpoints(thread_ids)
+        await self.repository.delete_by_id(agent_id)
+        return thread_ids
 
     async def get_permissions(self, agent_id: UUID) -> list[AgentUserPermissionDB]:
         return await self.repository.get_permissions(agent_id)

--- a/backend/app/agents/mcp_servers/repository.py
+++ b/backend/app/agents/mcp_servers/repository.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -25,13 +26,8 @@ class AgentMCPServerRepository(BaseRepository[AgentMCPServerDB]):
         return list(result.scalars().all())
 
     async def delete_all_for_agent(self, agent_id: UUID) -> None:
-        stmt = select(AgentMCPServerDB).where(AgentMCPServerDB.agent_id == agent_id)
-        result = await self.db.execute(stmt)
-        links = result.scalars().all()
-        for link in links:
-            await self.db.delete(link)
-        if links:
-            await self.db.flush()
+        stmt = delete(AgentMCPServerDB).where(AgentMCPServerDB.agent_id == agent_id)
+        await self.db.execute(stmt)
 
     async def list_agents_for_server(self, server_id: UUID) -> list[AgentDB]:
         """Agents currently bound to the MCP server (for the delete-guard UI)."""
@@ -45,12 +41,7 @@ class AgentMCPServerRepository(BaseRepository[AgentMCPServerDB]):
         return list(result.scalars().all())
 
     async def delete_all_for_server(self, server_id: UUID) -> None:
-        stmt = select(AgentMCPServerDB).where(
+        stmt = delete(AgentMCPServerDB).where(
             AgentMCPServerDB.mcp_server_id == server_id
         )
-        result = await self.db.execute(stmt)
-        links = result.scalars().all()
-        for link in links:
-            await self.db.delete(link)
-        if links:
-            await self.db.flush()
+        await self.db.execute(stmt)

--- a/backend/app/agents/router.py
+++ b/backend/app/agents/router.py
@@ -1,6 +1,8 @@
+import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.core.service import AgentService, get_agent_service
 from app.agents.dependencies import require_agent_permission
@@ -29,11 +31,14 @@ from app.auth.dependencies import (
     require_admin,
     require_editor,
 )
+from app.database import get_db
 from app.pagination import Page, PageParams
 from app.threads.schemas import AgentThreadResponse
 from app.threads.service import ThreadService, get_thread_service
 from app.users.models import UserDB
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
@@ -146,13 +151,34 @@ async def delete_agent_permanently(
     agent_id: UUID,
     current_user: UserDB = Depends(get_current_user),
     service: AgentService = Depends(get_agent_service),
+    thread_service: ThreadService = Depends(get_thread_service),
+    db: AsyncSession = Depends(get_db),  # dependency-cached: the service's session
 ) -> None:
-    await service.delete_permanently(
+    thread_ids = await service.delete_permanently(
         agent_id,
         user_id=current_user.id,
         user_role=current_user.role,
         user_team_id=current_user.team_id,
     )
+    # Commit the DB deletes BEFORE purging checkpoints — the third transaction
+    # regime, for the reason `purge_checkpoints` documents. Checkpoints live on
+    # a separate auto-committed connection and cannot be rolled back, so purging
+    # while the deletes were merely flushed meant a failed commit left an agent
+    # whose entire history was irrecoverably gone. The other direction fails
+    # safe: orphaned checkpoints are invisible and reclaimable. Same shape as
+    # `DELETE /threads/{id}` (P1-9, design review §5.5).
+    await db.commit()
+    # Past the commit the agent is gone, so a purge failure must not become a
+    # 500 the client would retry into a 404.
+    try:
+        await thread_service.purge_checkpoints(thread_ids)
+    except Exception:
+        logger.exception(
+            "Agent %s was deleted but the checkpoints of its %d thread(s) could "
+            "not be purged; they are now orphaned",
+            agent_id,
+            len(thread_ids),
+        )
 
 
 @router.get(

--- a/backend/app/agents/sandboxes/repository.py
+++ b/backend/app/agents/sandboxes/repository.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -43,10 +44,5 @@ class AgentSandboxRepository(BaseRepository[AgentSandboxDB]):
         return list(result.scalars().all())
 
     async def delete_all_for_sandbox(self, sandbox_id: UUID) -> None:
-        stmt = select(AgentSandboxDB).where(AgentSandboxDB.sandbox_id == sandbox_id)
-        result = await self.db.execute(stmt)
-        links = result.scalars().all()
-        for link in links:
-            await self.db.delete(link)
-        if links:
-            await self.db.flush()
+        stmt = delete(AgentSandboxDB).where(AgentSandboxDB.sandbox_id == sandbox_id)
+        await self.db.execute(stmt)

--- a/backend/app/agents/subagents/repository.py
+++ b/backend/app/agents/subagents/repository.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from sqlalchemy import or_
+from sqlalchemy import delete, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -75,15 +75,12 @@ class SubagentRepository:
         await self.db.flush()
 
     async def delete_all_for_agent(self, agent_id: UUID) -> None:
-        stmt = select(AgentSubagentDB).where(
+        """Both directions at once: an agent being deleted stops supervising
+        anyone and stops being anyone's subagent."""
+        stmt = delete(AgentSubagentDB).where(
             or_(
                 AgentSubagentDB.supervisor_id == agent_id,
                 AgentSubagentDB.subagent_id == agent_id,
             )
         )
-        result = await self.db.execute(stmt)
-        links = result.scalars().all()
-        for link in links:
-            await self.db.delete(link)
-        if links:
-            await self.db.flush()
+        await self.db.execute(stmt)

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 def root_cause(exc: BaseException) -> BaseException:
     """Unwrap nested ExceptionGroups (TaskGroup wrappers) to the first leaf
     exception, so error reporting shows the actual failure instead of
@@ -13,6 +16,17 @@ class DomainError(Exception):
     def __init__(self, detail: str):
         self.detail = detail
         super().__init__(detail)
+
+    def body(self) -> dict[str, Any]:
+        """The JSON body `main.py`'s handler returns for this failure.
+
+        Overridden only where a client has to branch on the failure
+        programmatically; everything else is a `detail` string, and adding a
+        machine-readable field is a decision about the API contract, so it
+        belongs next to the exception rather than in a handler `isinstance`
+        chain.
+        """
+        return {"detail": self.detail}
 
 
 class NotFoundError(DomainError):
@@ -53,3 +67,42 @@ class ModelUnavailableError(DomainError):
         self.model_id = model_id
         self.reason = reason
         super().__init__(f"Model '{model_id}' is not available: {reason}")
+
+    def body(self) -> dict[str, Any]:
+        return {
+            "error": "model_unavailable",
+            "model_id": self.model_id,
+            "detail": self.detail,
+        }
+
+
+#: HTTP status per domain exception — the whole translation table, in one place
+#: instead of one copy-paste handler each (design review §2.3).
+#:
+#: A subclass with no row of its own inherits the nearest ancestor's status via
+#: `status_for`'s MRO walk, so `NoInviteError` and `StructuredOutputError` are
+#: 500s by inheriting `DomainError` — which is what they are, and what they get
+#: today. Add a row only when a new exception wants its own code.
+STATUS: dict[type[DomainError], int] = {
+    NotFoundError: 404,
+    AlreadyExistsError: 409,
+    DomainValidationError: 400,
+    PermissionDeniedError: 403,
+    InvalidCredentialsError: 401,
+    ModelUnavailableError: 409,
+    DomainError: 500,
+}
+
+
+def status_for(exc: DomainError) -> int:
+    """The HTTP status for `exc`, resolved through its MRO.
+
+    `DomainError` is in `STATUS`, so the walk always terminates; the fallback
+    is unreachable and exists so a caller passing something odd gets a 500
+    rather than a `StopIteration`.
+    """
+    for cls in type(exc).__mro__:
+        status = STATUS.get(cls)
+        if status is not None:
+            return status
+    return 500  # pragma: no cover

--- a/backend/app/integrations/slack/commands/chat.py
+++ b/backend/app/integrations/slack/commands/chat.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.core.service import AgentService
 from app.agents.models import AgentDB
-from app.agents.schemas import AgentResponse
+from app.agents.schemas import AgentListResponse
 from app.database import AsyncSessionLocal
 from app.integrations.slack.models import SlackInteractionPayload
 from app.integrations.slack.settings import slack_settings
@@ -35,7 +35,7 @@ async def list_pickable_agents(
     user_id: UUID,
     user_role: WorkspaceRole | None = None,
     user_team_id: UUID | None = None,
-) -> list[AgentResponse]:
+) -> list[AgentListResponse]:
     """Return the agents this user may pick, sorted by name."""
     all_agents = await AgentService(db).list(
         user_id=user_id, user_role=user_role, user_team_id=user_team_id
@@ -50,7 +50,7 @@ async def list_pickable_agents(
 # ---------------------------------------------------------------------------
 
 
-def _agent_option(agent: AgentResponse) -> dict:
+def _agent_option(agent: AgentListResponse) -> dict:
     return {
         "text": {
             "type": "plain_text",
@@ -61,7 +61,7 @@ def _agent_option(agent: AgentResponse) -> dict:
 
 
 def build_agent_picker_blocks(
-    agents: list[AgentResponse],
+    agents: list[AgentListResponse],
     *,
     header_text: str = DEFAULT_PICKER_HEADER,
 ) -> list[dict]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,15 +18,7 @@ from app.auth.settings import auth_settings
 from app.auth.tokens.router import router as tokens_router
 from app.background import registry as background_loops
 from app.database import close_checkpointer_pool
-from app.exceptions import (
-    AlreadyExistsError,
-    DomainError,
-    DomainValidationError,
-    InvalidCredentialsError,
-    ModelUnavailableError,
-    NotFoundError,
-    PermissionDeniedError,
-)
+from app.exceptions import DomainError, root_cause, status_for
 from app.integrations.langfuse.callback import flush_langfuse
 from app.integrations.slack.consumer import build_slack_run_consumer
 from app.integrations.slack.router import router as slack_router
@@ -120,61 +112,54 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
-# There is deliberately no `OAuthAuthorizationRequired` handler, and no
-# `ExceptionGroup` handler. "This MCP server needs authorization" is caught at
-# the MCP seam by whoever asked to connect (`connectivity._open_session`,
-# `Toolset.open`) and turned into a response only by the endpoints whose job is
-# connecting — `GET /mcp-servers/{id}/list-tools` returns it as an
-# `auth_required` variant, the run endpoints and the MCP-app endpoints answer
-# 401 explicitly. The global pair had two costs: any endpoint touching MCP could
-# answer 401 with an auth URL, and the `ExceptionGroup` registration swallowed
-# TaskGroup-wrapped *domain* exceptions into 500s (design review §2.3, §2.4).
-
-
-@app.exception_handler(NotFoundError)
-async def not_found_handler(_request: Request, exc: NotFoundError):
-    return JSONResponse(status_code=404, content={"detail": exc.detail})
-
-
-@app.exception_handler(AlreadyExistsError)
-async def already_exists_handler(_request: Request, exc: AlreadyExistsError):
-    return JSONResponse(status_code=409, content={"detail": exc.detail})
-
-
-@app.exception_handler(DomainValidationError)
-async def domain_validation_error_handler(
-    _request: Request, exc: DomainValidationError
-):
-    return JSONResponse(status_code=400, content={"detail": exc.detail})
-
-
-@app.exception_handler(ModelUnavailableError)
-async def model_unavailable_handler(_request: Request, exc: ModelUnavailableError):
-    # Machine-readable body (like oauth_required) so clients can branch on
-    # `error` instead of string-matching the detail.
-    return JSONResponse(
-        status_code=409,
-        content={
-            "error": "model_unavailable",
-            "model_id": exc.model_id,
-            "detail": exc.detail,
-        },
-    )
-
-
-@app.exception_handler(PermissionDeniedError)
-async def permission_denied_handler(_request: Request, exc: PermissionDeniedError):
-    return JSONResponse(status_code=403, content={"detail": exc.detail})
-
-
-@app.exception_handler(InvalidCredentialsError)
-async def invalid_credentials_handler(_request: Request, exc: InvalidCredentialsError):
-    return JSONResponse(status_code=401, content={"detail": exc.detail})
+# There is deliberately no `OAuthAuthorizationRequired` handler. "This MCP
+# server needs authorization" is caught at the MCP seam by whoever asked to
+# connect (`connectivity._open_session`, `Toolset.open`) and turned into a
+# response only by the endpoints whose job is connecting — `GET
+# /mcp-servers/{id}/list-tools` returns it as an `auth_required` variant, the
+# run endpoints and the MCP-app endpoints answer 401 explicitly. A global one
+# meant any endpoint touching MCP could answer 401 with an auth URL (design
+# review §2.4).
 
 
 @app.exception_handler(DomainError)
 async def domain_error_handler(_request: Request, exc: DomainError):
-    return JSONResponse(status_code=500, content={"detail": exc.detail})
+    """The one translation from a domain failure to a response.
+
+    Status and body both come from `app/exceptions.py` — the table and the
+    exception's own `body()` — so adding an exception is a row, not a seventh
+    near-identical handler (design review §2.3).
+    """
+    return JSONResponse(status_code=status_for(exc), content=exc.body())
+
+
+@app.exception_handler(ExceptionGroup)
+async def exception_group_handler(request: Request, exc: ExceptionGroup):
+    """Give a TaskGroup-wrapped domain exception the status it asked for.
+
+    A `NotFoundError` raised under an anyio task group (the MCP transport, the
+    toolset gather) arrives here inside an `ExceptionGroup`, whose MRO does not
+    reach `DomainError` — so without this it would be a 500 with no detail,
+    which is what the old handler produced for *every* group (design review
+    §2.3).
+
+    Keyed on `ExceptionGroup`, not `BaseExceptionGroup`: the latter is not a
+    subclass of `Exception`, and Starlette asserts on that while *building the
+    middleware stack* — lazily, on the first request — so registering it passes
+    every import-time check and then 500s the whole app. Nothing is lost by
+    narrowing, because the middleware only catches `Exception` anyway: a group
+    holding a `BaseException` leaf was never going to reach a handler.
+
+    Anything else is re-raised unchanged and becomes a logged 500. That is the
+    line this handler must not cross: it exists to preserve a status the code
+    already chose, never to invent one — in particular it cannot resurrect the
+    global OAuth 401, because `OAuthAuthorizationRequired` is not a
+    `DomainError` and the seam unwraps it long before here.
+    """
+    inner = root_cause(exc)
+    if isinstance(inner, DomainError):
+        return await domain_error_handler(request, inner)
+    raise exc
 
 
 # Browser traffic normally rides the Next.js proxy (same-origin), so CORS only

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -155,9 +155,23 @@ async def exception_group_handler(request: Request, exc: ExceptionGroup):
     already chose, never to invent one — in particular it cannot resurrect the
     global OAuth 401, because `OAuthAuthorizationRequired` is not a
     `DomainError` and the seam unwraps it long before here.
+
+    A group can carry more than one failure — concurrent tasks that both blew
+    up. The response can only be one of them, and the domain status is the
+    useful one, but the rest must not vanish: they are logged in full, since a
+    500 would at least have surfaced them through the server-error handler.
     """
     inner = root_cause(exc)
     if isinstance(inner, DomainError):
+        _, others = exc.split(lambda leaf: leaf is inner)
+        if others is not None:
+            logger.error(
+                "%s answered %d; the group it arrived in carried other failures, "
+                "which are not in the response",
+                type(inner).__name__,
+                status_for(inner),
+                exc_info=others,
+            )
         return await domain_error_handler(request, inner)
     raise exc
 

--- a/backend/tests/agents/conftest.py
+++ b/backend/tests/agents/conftest.py
@@ -1,8 +1,13 @@
-"""A real (SQLite) database for the agent-graph reads.
+"""A real (SQLite) database for the agent tables, shared by every `tests/agents`
+module.
 
 `get_run_spec`'s whole point is the *number* of round-trips it makes, and a
 mocked session can't tell you that — it only tells you what you told it to say.
 So these tests run against a real engine with a statement counter attached.
+The same goes for the whole-set-replace and bulk-delete paths (P3-5): a mocked
+session can only confirm the calls a test already knew to expect, which is why
+rewriting one to issue a single `DELETE ... WHERE` broke four tests without
+breaking any behaviour.
 
 Two accommodations make the Postgres schema loadable on SQLite:
 

--- a/backend/tests/agents/core/test_query_cost.py
+++ b/backend/tests/agents/core/test_query_cost.py
@@ -1,0 +1,158 @@
+"""What the agent read and mutation paths cost, against a real engine.
+
+These are the P3-5 regressions in one place (design review §3.5, §3.6). Every
+assertion here is a number a mocked session cannot produce: it can only replay
+the calls a test already told it to expect, which is exactly how a `SELECT` that
+nobody consumed survived in the mutation paths, and how `instructions` came to
+ship on the list endpoint that drops it.
+
+The numbers are upper bounds on work, not a specification of the SQL — if a
+change makes one *smaller*, lower it.
+"""
+
+from uuid import uuid4
+
+from app.agents.core.repository import AgentRepository
+from app.agents.core.service import AgentService
+from app.agents.models import AgentDB, AgentMCPServerDB, ToolStatus
+from app.agents.schemas import AgentListResponse, AgentPatch, AgentResponse
+
+
+async def _seed(session, *, owner_id, bindings: int = 0, instructions="x" * 4000):
+    agent = AgentDB(name="Agent", instructions=instructions, owner_id=owner_id)
+    session.add(agent)
+    await session.flush()
+    for _ in range(bindings):
+        session.add(
+            AgentMCPServerDB(
+                agent_id=agent.id,
+                mcp_server_id=uuid4(),
+                tools={"search": ToolStatus.always_allow},
+            )
+        )
+    await session.flush()
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# the list projection
+# ---------------------------------------------------------------------------
+
+
+async def test_the_list_never_reads_instructions_or_tool_maps(
+    agent_session, statements
+):
+    """The whole point of §3.5: the heavy columns stay in the database rather
+    than being fetched, repeated once per MCP binding by the join, and then
+    dropped at serialization time."""
+    owner = uuid4()
+    await _seed(agent_session, owner_id=owner, bindings=3)
+    agent_session.expunge_all()
+    statements.reset()
+
+    await AgentService(agent_session).list(user_id=owner)
+
+    selects = " ".join(statements.statements)
+    assert "agents.instructions" not in selects
+    assert "agent_mcp_servers.tools" not in selects
+
+
+async def test_the_list_returns_the_slim_schema(agent_session):
+    owner = uuid4()
+    await _seed(agent_session, owner_id=owner, bindings=1)
+
+    rows = await AgentService(agent_session).list(user_id=owner)
+
+    assert len(rows) == 1
+    assert type(rows[0]) is AgentListResponse
+    assert not hasattr(rows[0], "instructions")
+    assert len(rows[0].mcp_servers) == 1
+
+
+async def test_the_list_does_not_query_sandbox_bindings(agent_session, statements):
+    """`AgentListResponse` has no `sandboxes` field, so the query that fills it
+    is pure waste on this path."""
+    owner = uuid4()
+    await _seed(agent_session, owner_id=owner)
+    statements.reset()
+
+    await AgentService(agent_session).list(user_id=owner)
+
+    assert not any("agent_sandboxes" in s for s in statements.statements)
+
+
+async def test_the_list_cost_does_not_grow_with_the_number_of_agents(
+    agent_session, statements
+):
+    owner = uuid4()
+    for _ in range(5):
+        await _seed(agent_session, owner_id=owner, bindings=2)
+    agent_session.expunge_all()
+    statements.reset()
+
+    rows = await AgentService(agent_session).list(user_id=owner)
+
+    assert len(rows) == 5
+    assert len(statements) <= 4
+
+
+async def test_the_detail_read_still_carries_everything(agent_session):
+    """The narrowing is the list path only — `get` is what the editor loads."""
+    owner = uuid4()
+    agent = await _seed(agent_session, owner_id=owner, bindings=1)
+
+    response = await AgentService(agent_session).get(agent.id, user_id=owner)
+
+    assert isinstance(response, AgentResponse)
+    assert response.instructions == "x" * 4000
+    assert response.mcp_servers[0].tools == {"search": ToolStatus.always_allow}
+
+
+# ---------------------------------------------------------------------------
+# the mutation paths
+# ---------------------------------------------------------------------------
+
+
+async def test_a_one_column_patch_reads_the_agent_row_once(agent_session, statements):
+    """It used to read it three times: the permission gate's row, a `get_or_404`
+    that fetched a row only `repository.update` looked at, the `refresh` after
+    that update, and then the re-read this returns."""
+    owner = uuid4()
+    agent = await _seed(agent_session, owner_id=owner)
+    agent_session.expunge_all()
+    statements.reset()
+
+    response = await AgentService(agent_session).update(
+        agent.id, AgentPatch(name="Renamed"), user_id=owner
+    )
+
+    assert response.name == "Renamed"
+    # The gate reads two columns; only the closing re-read pulls the whole row.
+    full_reads = [s for s in statements.statements if "agents.instructions" in s]
+    assert len(full_reads) == 1
+    assert len(statements) <= 6
+
+
+async def test_archiving_issues_one_update_and_no_select_of_its_own(
+    agent_session, statements
+):
+    owner = uuid4()
+    agent = await _seed(agent_session, owner_id=owner)
+    agent_session.expunge_all()
+    statements.reset()
+
+    await AgentService(agent_session).delete(agent.id, user_id=owner)
+
+    assert len(statements) == 3  # gate, subagent-link delete, the UPDATE
+    assert (await AgentRepository(agent_session).get(agent.id)).is_archived is True
+
+
+async def test_restore_returns_the_unarchived_agent(agent_session):
+    owner = uuid4()
+    agent = await _seed(agent_session, owner_id=owner)
+    service = AgentService(agent_session)
+    await service.delete(agent.id, user_id=owner)
+
+    response = await service.restore(agent.id, user_id=owner)
+
+    assert response.is_archived is False

--- a/backend/tests/agents/core/test_query_cost.py
+++ b/backend/tests/agents/core/test_query_cost.py
@@ -10,7 +10,10 @@ The numbers are upper bounds on work, not a specification of the SQL — if a
 change makes one *smaller*, lower it.
 """
 
+from datetime import UTC, datetime
 from uuid import uuid4
+
+from sqlalchemy import update
 
 from app.agents.core.repository import AgentRepository
 from app.agents.core.service import AgentService
@@ -65,7 +68,6 @@ async def test_the_list_returns_the_slim_schema(agent_session):
 
     assert len(rows) == 1
     assert type(rows[0]) is AgentListResponse
-    assert not hasattr(rows[0], "instructions")
     assert len(rows[0].mcp_servers) == 1
 
 
@@ -145,6 +147,38 @@ async def test_archiving_issues_one_update_and_no_select_of_its_own(
 
     assert len(statements) == 3  # gate, subagent-link delete, the UPDATE
     assert (await AgentRepository(agent_session).get(agent.id)).is_archived is True
+
+
+async def test_archiving_an_already_archived_agent_touches_nothing(agent_session):
+    """Archiving is deliberately repeatable (`delete` passes
+    `include_archived=True` so a second call does not 404), so a repeat must not
+    bump `updated_at` — which the agents list renders. The ORM path this
+    replaced got that for free, because SQLAlchemy does not mark an attribute
+    dirty when it is set to the value it already holds; a bulk UPDATE has to say
+    it in the `WHERE`. The statement is still sent, and matches no rows.
+
+    `updated_at` is backdated first, on purpose: SQLite's `CURRENT_TIMESTAMP`
+    has one-second resolution, so comparing two timestamps taken in the same
+    second passes whether or not the second write happened.
+    """
+    owner = uuid4()
+    agent = await _seed(agent_session, owner_id=owner)
+    service = AgentService(agent_session)
+    repository = AgentRepository(agent_session)
+    await service.delete(agent.id, user_id=owner)
+    backdated = datetime(2020, 1, 1, tzinfo=UTC)
+    await agent_session.execute(
+        update(AgentDB).where(AgentDB.id == agent.id).values(updated_at=backdated)
+    )
+    agent_session.expunge_all()
+
+    await service.delete(agent.id, user_id=owner)
+    agent_session.expunge_all()
+
+    # Compared on the year, not the instant: SQLite hands the column back
+    # without the tzinfo it was written with, and the point is only that the
+    # backdated value survived rather than being overwritten with "now".
+    assert (await repository.get(agent.id)).updated_at.year == backdated.year
 
 
 async def test_restore_returns_the_unarchived_agent(agent_session):

--- a/backend/tests/agents/core/test_repository.py
+++ b/backend/tests/agents/core/test_repository.py
@@ -218,14 +218,64 @@ async def test_update_with_empty_schema_leaves_agent_unchanged(repo, mock_db):
 # ---------------------------------------------------------------------------
 
 
-async def test_archive_sets_is_archived_and_flushes(repo, mock_db):
-    agent = make_agent()
+async def test_set_archived_flips_the_flag_in_place(agent_session):
+    repo = AgentRepository(agent_session)
+    agent = AgentDB(name="A", instructions="x", owner_id=uuid4())
+    agent_session.add(agent)
+    await agent_session.flush()
 
-    await repo.archive(agent)
+    await repo.set_archived(agent.id, archived=True)
+    assert (await repo.get(agent.id)).is_archived is True
 
-    assert agent.is_archived is True
-    mock_db.add.assert_called_once_with(agent)
-    mock_db.flush.assert_awaited_once()
+    await repo.set_archived(agent.id, archived=False)
+    assert (await repo.get(agent.id)).is_archived is False
+
+
+async def test_update_by_id_writes_only_the_set_fields_and_bumps_updated_at(
+    agent_session,
+):
+    repo = AgentRepository(agent_session)
+    agent = AgentDB(
+        name="A", instructions="keep me", owner_id=uuid4(), description="keep me too"
+    )
+    agent_session.add(agent)
+    await agent_session.flush()
+    before = agent.updated_at
+
+    await repo.update_by_id(agent.id, AgentPatch(name="B"))
+
+    reread = await repo.get(agent.id)
+    assert reread.name == "B"
+    assert reread.instructions == "keep me"
+    assert reread.description == "keep me too"
+    assert reread.updated_at >= before
+
+
+async def test_update_by_id_with_an_empty_patch_touches_nothing(
+    agent_session, statements
+):
+    """Matches what the ORM path did: `sqlmodel_update({})` leaves the instance
+    clean, so a PATCH naming no fields must not bump `updated_at` either."""
+    repo = AgentRepository(agent_session)
+    agent = AgentDB(name="A", instructions="x", owner_id=uuid4())
+    agent_session.add(agent)
+    await agent_session.flush()
+    statements.reset()
+
+    await repo.update_by_id(agent.id, AgentPatch())
+
+    assert len(statements) == 0
+
+
+async def test_delete_by_id_removes_the_row(agent_session):
+    repo = AgentRepository(agent_session)
+    agent = AgentDB(name="A", instructions="x", owner_id=uuid4())
+    agent_session.add(agent)
+    await agent_session.flush()
+
+    await repo.delete_by_id(agent.id)
+
+    assert await repo.get(agent.id) is None
 
 
 # ---------------------------------------------------------------------------
@@ -257,72 +307,144 @@ async def test_get_permissions_returns_empty_list_when_none(repo, mock_db):
 
 
 # ---------------------------------------------------------------------------
-# set_permissions
+# set_permissions / set_teams — whole-set replace, against a real engine
+#
+# These used to be mock mirrors: they asserted `db.delete` was awaited once per
+# existing row and counted `flush`es. That is a transcript of the old
+# implementation, not of its contract — rewriting the loop as one
+# `DELETE ... WHERE` broke every one of them while changing nothing a caller
+# can observe (design review §6.2, P3-16).
 # ---------------------------------------------------------------------------
 
 
-async def test_set_permissions_deletes_existing_before_inserting(repo, mock_db):
-    agent_id = uuid4()
-    existing = make_permission(agent_id=agent_id)
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [existing]
-    mock_db.execute.return_value = mock_result
+async def _permissions(session, agent_id) -> dict:
+    rows = await AgentRepository(session).get_permissions(agent_id)
+    return {row.user_id: row.permission for row in rows}
 
-    new_write = AgentPermissionCreate(
-        user_id=uuid4(), permission=PermissionLevel.editor
+
+async def test_set_permissions_replaces_the_whole_set(agent_session):
+    agent_id = uuid4()
+    kept, dropped, added = uuid4(), uuid4(), uuid4()
+    repo = AgentRepository(agent_session)
+    await repo.set_permissions(
+        agent_id,
+        [
+            AgentPermissionCreate(user_id=kept, permission=PermissionLevel.member),
+            AgentPermissionCreate(user_id=dropped, permission=PermissionLevel.admin),
+        ],
     )
-    await repo.set_permissions(agent_id, [new_write])
 
-    mock_db.delete.assert_awaited_once_with(existing)
-    assert mock_db.flush.await_count == 2
-
-
-async def test_set_permissions_inserts_new_permissions(repo, mock_db):
-    agent_id = uuid4()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    mock_db.execute.return_value = mock_result
-
-    new_user_id = uuid4()
-    new_write = AgentPermissionCreate(
-        user_id=new_user_id, permission=PermissionLevel.editor
+    result = await repo.set_permissions(
+        agent_id,
+        [
+            AgentPermissionCreate(user_id=kept, permission=PermissionLevel.editor),
+            AgentPermissionCreate(user_id=added, permission=PermissionLevel.member),
+        ],
     )
-    result = await repo.set_permissions(agent_id, [new_write])
 
-    mock_db.add.assert_called_once()
-    added = mock_db.add.call_args[0][0]
-    assert isinstance(added, AgentUserPermissionDB)
-    assert added.agent_id == agent_id
-    assert added.user_id == new_user_id
-    assert added.permission == PermissionLevel.editor
-    assert len(result) == 1
+    assert {p.user_id for p in result} == {kept, added}
+    assert await _permissions(agent_session, agent_id) == {
+        kept: PermissionLevel.editor,
+        added: PermissionLevel.member,
+    }
 
 
-async def test_set_permissions_with_empty_list_clears_all(repo, mock_db):
+async def test_set_permissions_with_an_empty_list_clears_the_agent(agent_session):
     agent_id = uuid4()
-    existing = make_permission(agent_id=agent_id)
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [existing]
-    mock_db.execute.return_value = mock_result
+    repo = AgentRepository(agent_session)
+    await repo.set_permissions(
+        agent_id,
+        [AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.admin)],
+    )
 
-    result = await repo.set_permissions(agent_id, [])
-
-    mock_db.delete.assert_awaited_once_with(existing)
-    mock_db.add.assert_not_called()
-    assert result == []
+    assert await repo.set_permissions(agent_id, []) == []
+    assert await _permissions(agent_session, agent_id) == {}
 
 
-async def test_set_permissions_refreshes_each_new_permission(repo, mock_db):
+async def test_set_permissions_leaves_other_agents_alone(agent_session):
+    """The bulk `DELETE` is only correct if its `WHERE` is."""
+    mine, theirs = uuid4(), uuid4()
+    other_user = uuid4()
+    repo = AgentRepository(agent_session)
+    await repo.set_permissions(
+        theirs,
+        [AgentPermissionCreate(user_id=other_user, permission=PermissionLevel.admin)],
+    )
+
+    await repo.set_permissions(
+        mine,
+        [AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.member)],
+    )
+
+    assert await _permissions(agent_session, theirs) == {
+        other_user: PermissionLevel.admin
+    }
+
+
+async def test_set_permissions_costs_two_statements_whatever_the_size(
+    agent_session, statements
+):
+    """One `DELETE`, one `INSERT` — no per-row delete, and no `refresh` loop
+    reading timestamps `AgentPermissionResponse` does not carry."""
     agent_id = uuid4()
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    mock_db.execute.return_value = mock_result
+    repo = AgentRepository(agent_session)
+    await repo.set_permissions(
+        agent_id,
+        [AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.member)],
+    )
+    statements.reset()
 
-    writes = [
-        AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.member),
-        AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.editor),
-    ]
-    result = await repo.set_permissions(agent_id, writes)
+    await repo.set_permissions(
+        agent_id,
+        [
+            AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.editor)
+            for _ in range(5)
+        ],
+    )
 
-    assert mock_db.refresh.await_count == 2
-    assert len(result) == 2
+    assert len(statements) == 2
+
+
+async def test_set_teams_replaces_the_whole_set_and_dedupes(agent_session):
+    agent_id = uuid4()
+    kept, dropped, added = uuid4(), uuid4(), uuid4()
+    repo = AgentRepository(agent_session)
+    await repo.set_teams(agent_id, [kept, dropped])
+
+    result = await repo.set_teams(agent_id, [kept, added, added])
+
+    assert result == [kept, added]
+    assert set(await repo.get_team_ids(agent_id)) == {kept, added}
+
+
+async def test_delete_all_teams_clears_only_this_agent(agent_session):
+    mine, theirs = uuid4(), uuid4()
+    team = uuid4()
+    repo = AgentRepository(agent_session)
+    await repo.set_teams(mine, [team])
+    await repo.set_teams(theirs, [team])
+
+    await repo.delete_all_teams(mine)
+
+    assert await repo.get_team_ids(mine) == []
+    assert await repo.get_team_ids(theirs) == [team]
+
+
+async def test_delete_all_permissions_clears_only_this_agent(agent_session):
+    mine, theirs = uuid4(), uuid4()
+    other_user = uuid4()
+    repo = AgentRepository(agent_session)
+    await repo.set_permissions(
+        mine, [AgentPermissionCreate(user_id=uuid4(), permission=PermissionLevel.admin)]
+    )
+    await repo.set_permissions(
+        theirs,
+        [AgentPermissionCreate(user_id=other_user, permission=PermissionLevel.member)],
+    )
+
+    await repo.delete_all_permissions(mine)
+
+    assert await _permissions(agent_session, mine) == {}
+    assert await _permissions(agent_session, theirs) == {
+        other_user: PermissionLevel.member
+    }

--- a/backend/tests/agents/core/test_router.py
+++ b/backend/tests/agents/core/test_router.py
@@ -271,15 +271,12 @@ def test_delete_agent(client: TestClient, mock_db, current_user):
         updated_at=datetime.now(),
     )
 
-    # One result serves both queries the delete makes: the gate's get_access
-    # row and get_or_404's scalar.
     mock_db.execute.return_value = make_result(
         scalar=agent, access=(agent.owner_id, None)
     )
 
     response = client.delete(f"/agents/{agent_id}")
     assert response.status_code == 204
-    assert agent.is_archived is True
 
 
 @pytest.mark.usefixtures("current_user")
@@ -337,7 +334,6 @@ def test_delete_agent_allows_workspace_admin(client: TestClient, mock_db, admin_
 
     response = client.delete(f"/agents/{agent.id}")
     assert response.status_code == 204
-    assert agent.is_archived is True
 
 
 def test_delete_agent_requires_auth(client: TestClient):
@@ -385,7 +381,6 @@ def test_restore_agent_as_owner(client: TestClient, mock_db, current_user):
 
     response = client.post(f"/agents/{agent.id}/restore")
     assert response.status_code == 200
-    assert agent.is_archived is False
 
 
 def test_restore_agent_requires_auth(client: TestClient):
@@ -417,6 +412,70 @@ def test_delete_agent_permanently_forbidden_for_non_manager(
 
     response = client.delete(f"/agents/{agent.id}/permanent")
     assert response.status_code == 403
+
+
+def test_delete_permanently_commits_before_purging_checkpoints(
+    client: TestClient, mock_db, current_user
+):
+    """Checkpoints live on a separate auto-committed connection and cannot be
+    rolled back, so they must be purged only once the row deletes are committed
+    — not merely flushed. Purging first meant a failed commit left an agent
+    whose entire history was irrecoverably gone (P1-9's residual, §5.5)."""
+    agent = AgentDB(
+        id=uuid4(),
+        name="Doomed",
+        instructions="...",
+        owner_id=current_user.id,
+        is_archived=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    mock_db.execute.return_value = make_result(
+        access=(agent.owner_id, None), scalars_list=["t1"]
+    )
+
+    calls = MagicMock()
+    calls.attach_mock(mock_db.commit, "commit")
+    with patch("app.threads.service.get_checkpointer") as checkpointer:
+        checkpointer.return_value.__aenter__.return_value = MagicMock(
+            adelete_thread=AsyncMock()
+        )
+        calls.attach_mock(
+            checkpointer.return_value.__aenter__.return_value.adelete_thread, "purge"
+        )
+        response = client.delete(f"/agents/{agent.id}/permanent")
+
+    assert response.status_code == 204
+    ordered = [name for name, _, _ in calls.mock_calls]
+    assert "commit" in ordered and "purge" in ordered
+    assert ordered.index("commit") < ordered.index("purge")
+
+
+def test_delete_permanently_still_succeeds_when_the_purge_fails(
+    client: TestClient, mock_db, current_user
+):
+    """Past the commit the agent really is gone, so a purge failure must not
+    become a 500 the client would retry into a 404. The orphaned checkpoints are
+    logged instead."""
+    agent = AgentDB(
+        id=uuid4(),
+        name="Doomed",
+        instructions="...",
+        owner_id=current_user.id,
+        is_archived=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    mock_db.execute.return_value = make_result(
+        access=(agent.owner_id, None), scalars_list=["t1"]
+    )
+
+    with patch("app.threads.service.get_checkpointer") as checkpointer:
+        checkpointer.return_value.__aenter__.side_effect = RuntimeError("redis gone")
+        response = client.delete(f"/agents/{agent.id}/permanent")
+
+    assert response.status_code == 204
+    mock_db.commit.assert_awaited()
 
 
 def make_count_result(total: int) -> MagicMock:

--- a/backend/tests/agents/core/test_service.py
+++ b/backend/tests/agents/core/test_service.py
@@ -79,9 +79,12 @@ def mock_repo():
     repo.get = AsyncMock()
     repo.create = AsyncMock()
     repo.update = AsyncMock()
-    repo.archive = AsyncMock()
-    repo.restore = AsyncMock()
-    repo.delete = AsyncMock()
+    # The mutation paths take the id, not a loaded row: `require_permission`
+    # already proved the agent exists, so there is nothing left for a `get` to
+    # establish (P3-5).
+    repo.update_by_id = AsyncMock()
+    repo.set_archived = AsyncMock()
+    repo.delete_by_id = AsyncMock()
     repo.delete_all_permissions = AsyncMock()
     repo.get_permissions = AsyncMock()
     repo.set_permissions = AsyncMock()
@@ -492,20 +495,20 @@ async def test_list_untagged_agents_attach_no_tag(service, mock_repo, mock_tag_s
 # ---------------------------------------------------------------------------
 
 
-async def test_update_agent_delegates_to_repository(service, mock_repo):
+async def test_update_agent_patches_by_id_and_returns_the_reread_agent(
+    service, mock_repo
+):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     result = await service.update(
         agent.id, AgentPatch(name="Updated"), user_id=agent.owner_id
     )
 
-    mock_repo.get.assert_awaited_once_with(agent.id)
-    call_args = mock_repo.update.call_args[0]
-    assert call_args[0] is agent
-    assert isinstance(call_args[1], AgentPatch)
-    assert call_args[1].name == "Updated"
+    agent_id, patch = mock_repo.update_by_id.call_args[0]
+    assert agent_id == agent.id
+    assert isinstance(patch, AgentPatch)
+    assert patch.name == "Updated"
     assert isinstance(result, AgentResponse)
     assert result.id == agent.id
     assert result.mcp_servers == []
@@ -513,12 +516,11 @@ async def test_update_agent_delegates_to_repository(service, mock_repo):
 
 async def test_update_agent_passes_only_set_fields(service, mock_repo):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.update(agent.id, AgentPatch(name="New Name"), user_id=agent.owner_id)
 
-    update_schema = mock_repo.update.call_args[0][1]
+    update_schema = mock_repo.update_by_id.call_args[0][1]
     assert isinstance(update_schema, AgentPatch)
     assert update_schema.model_dump(exclude_unset=True) == {"name": "New Name"}
 
@@ -530,7 +532,7 @@ async def test_update_agent_raises_404_when_not_found(service, mock_repo):
         await service.update(uuid4(), AgentPatch(name="X"))
 
     assert exc_info.value.detail == "Agent not found"
-    mock_repo.update.assert_not_called()
+    mock_repo.update_by_id.assert_not_called()
 
 
 async def test_update_agent_raises_403_when_no_permission(service, mock_repo):
@@ -540,13 +542,11 @@ async def test_update_agent_raises_403_when_no_permission(service, mock_repo):
     with pytest.raises(PermissionDeniedError):
         await service.update(agent.id, AgentPatch(name="X"), user_id=uuid4())
 
-    mock_repo.get.assert_not_called()
-    mock_repo.update.assert_not_called()
+    mock_repo.update_by_id.assert_not_called()
 
 
 async def test_update_agent_allows_workspace_admin(service, mock_repo):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.update(
@@ -556,19 +556,18 @@ async def test_update_agent_allows_workspace_admin(service, mock_repo):
         user_role=WorkspaceRole.admin,
     )
 
-    mock_repo.update.assert_awaited_once()
+    mock_repo.update_by_id.assert_awaited_once()
 
 
 async def test_update_agent_validates_tag_exists(service, mock_repo, mock_tag_service):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
     tag_id = uuid4()
 
     await service.update(agent.id, AgentPatch(tag_id=tag_id), user_id=agent.owner_id)
 
     mock_tag_service.get.assert_awaited_once_with(tag_id)
-    mock_repo.update.assert_awaited_once()
+    mock_repo.update_by_id.assert_awaited_once()
 
 
 async def test_update_agent_raises_404_for_unknown_tag(
@@ -584,20 +583,19 @@ async def test_update_agent_raises_404_for_unknown_tag(
         )
 
     assert exc_info.value.detail == "Tag not found"
-    mock_repo.update.assert_not_called()
+    mock_repo.update_by_id.assert_not_called()
 
 
 async def test_update_agent_untag_skips_tag_lookup(
     service, mock_repo, mock_tag_service
 ):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.update(agent.id, AgentPatch(tag_id=None), user_id=agent.owner_id)
 
     mock_tag_service.get.assert_not_called()
-    update_schema = mock_repo.update.call_args[0][1]
+    update_schema = mock_repo.update_by_id.call_args[0][1]
     assert update_schema.model_dump(exclude_unset=True) == {"tag_id": None}
 
 
@@ -615,7 +613,6 @@ async def test_set_config_orchestrates_scalars_bindings_subagents(
     service, mock_repo, mock_mcp_server_service, mock_subagent_service
 ):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
     server_id = uuid4()
     sub_id = uuid4()
@@ -632,7 +629,7 @@ async def test_set_config_orchestrates_scalars_bindings_subagents(
 
     result = await service.set_config(agent.id, config, user_id=agent.owner_id)
 
-    patch_schema = mock_repo.update.call_args[0][1]
+    patch_schema = mock_repo.update_by_id.call_args[0][1]
     assert isinstance(patch_schema, AgentPatch)
     assert patch_schema.name == "Configured"
     assert patch_schema.description == "A description"
@@ -649,12 +646,11 @@ async def test_set_config_clears_unset_scalars(service, mock_repo):
     """Full replace: omitting description/emoji/color in the config clears
     them — every scalar field is explicitly written."""
     agent = make_agent(description="old", emoji="🤖")
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.set_config(agent.id, make_config(), user_id=agent.owner_id)
 
-    patch_schema = mock_repo.update.call_args[0][1]
+    patch_schema = mock_repo.update_by_id.call_args[0][1]
     dumped = patch_schema.model_dump(exclude_unset=True)
     assert dumped["description"] is None
     assert dumped["emoji"] is None
@@ -671,7 +667,7 @@ async def test_set_config_denies_member(service, mock_repo):
     with pytest.raises(PermissionDeniedError):
         await service.set_config(agent.id, make_config(), user_id=uuid4())
 
-    mock_repo.update.assert_not_called()
+    mock_repo.update_by_id.assert_not_called()
 
 
 async def test_set_config_denies_without_permission(
@@ -688,33 +684,30 @@ async def test_set_config_denies_without_permission(
 
 async def test_set_config_allows_agent_editor(service, mock_repo):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [
         (agent, None, PermissionLevel.editor)
     ]
 
     await service.set_config(agent.id, make_config(), user_id=uuid4())
 
-    mock_repo.update.assert_awaited_once()
+    mock_repo.update_by_id.assert_awaited_once()
 
 
 async def test_set_config_allows_workspace_admin(service, mock_repo):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.set_config(
         agent.id, make_config(), user_id=uuid4(), user_role=WorkspaceRole.admin
     )
 
-    mock_repo.update.assert_awaited_once()
+    mock_repo.update_by_id.assert_awaited_once()
 
 
 async def test_set_config_passes_role_to_subagent_gate(
     service, mock_repo, mock_subagent_service
 ):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
     sub_id = uuid4()
 
@@ -736,7 +729,6 @@ async def test_set_config_subagent_denial_propagates(
     """A PermissionDeniedError from the subagent gate bubbles up — the request
     transaction rolls back, so the scalar/MCP writes never commit."""
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [
         (agent, None, PermissionLevel.editor)
     ]
@@ -777,51 +769,47 @@ async def test_delete_agent_delegates_to_repository(
     service, mock_repo, mock_subagent_service
 ):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.delete(agent.id, user_id=agent.owner_id)
 
-    mock_repo.get.assert_awaited_once_with(agent.id)
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
-    mock_repo.archive.assert_awaited_once_with(agent)
+    mock_repo.set_archived.assert_awaited_once_with(agent.id, archived=True)
 
 
 async def test_delete_agent_raises_404_when_not_found(service, mock_repo):
-    mock_repo.get.return_value = None
+    mock_repo.list_with_permissions.return_value = []
 
     with pytest.raises(NotFoundError) as exc_info:
         await service.delete(uuid4())
 
     assert exc_info.value.detail == "Agent not found"
-    mock_repo.archive.assert_not_called()
+    mock_repo.set_archived.assert_not_called()
 
 
 async def test_delete_agent_raises_403_for_non_owner(
     service, mock_repo, mock_subagent_service
 ):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     with pytest.raises(PermissionDeniedError):
         await service.delete(agent.id, user_id=uuid4())
 
     mock_subagent_service.delete_all_for_agent.assert_not_called()
-    mock_repo.archive.assert_not_called()
+    mock_repo.set_archived.assert_not_called()
 
 
 async def test_delete_agent_allows_workspace_admin(
     service, mock_repo, mock_subagent_service
 ):
     agent = make_agent()
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.delete(agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin)
 
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
-    mock_repo.archive.assert_awaited_once_with(agent)
+    mock_repo.set_archived.assert_awaited_once_with(agent.id, archived=True)
 
 
 # ---------------------------------------------------------------------------
@@ -831,22 +819,20 @@ async def test_delete_agent_allows_workspace_admin(
 
 async def test_restore_agent_sets_unarchived_for_owner(service, mock_repo):
     agent = make_agent(is_archived=True)
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.restore(agent.id, user_id=agent.owner_id)
 
-    mock_repo.restore.assert_awaited_once_with(agent)
+    mock_repo.set_archived.assert_awaited_once_with(agent.id, archived=False)
 
 
 async def test_restore_agent_allows_workspace_admin(service, mock_repo):
     agent = make_agent(is_archived=True)
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     await service.restore(agent.id, user_id=uuid4(), user_role=WorkspaceRole.admin)
 
-    mock_repo.restore.assert_awaited_once_with(agent)
+    mock_repo.set_archived.assert_awaited_once_with(agent.id, archived=False)
 
 
 async def test_restore_agent_denied_for_editor(service, mock_repo):
@@ -858,7 +844,7 @@ async def test_restore_agent_denied_for_editor(service, mock_repo):
     with pytest.raises(PermissionDeniedError):
         await service.restore(agent.id, user_id=uuid4())
 
-    mock_repo.restore.assert_not_called()
+    mock_repo.set_archived.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -874,36 +860,38 @@ async def test_delete_permanently_cascades_for_owner(
     mock_agent_mcp_repo,
 ):
     agent = make_agent(is_archived=True)
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
-    await service.delete_permanently(agent.id, user_id=agent.owner_id)
+    thread_ids = await service.delete_permanently(agent.id, user_id=agent.owner_id)
 
     mock_subagent_service.delete_all_for_agent.assert_awaited_once_with(agent.id)
     mock_agent_mcp_repo.delete_all_for_agent.assert_awaited_once_with(agent.id)
     mock_thread_service.delete_rows_for_agent.assert_awaited_once_with(agent.id)
     mock_repo.delete_all_permissions.assert_awaited_once_with(agent.id)
-    mock_repo.delete.assert_awaited_once_with(agent)
-    # Checkpoints are purged last, after every DB delete has run.
-    mock_thread_service.purge_checkpoints.assert_awaited_once_with(["t1", "t2"])
+    mock_repo.delete_by_id.assert_awaited_once_with(agent.id)
+    # The thread ids are handed back rather than acted on: purging checkpoints
+    # is an external, non-transactional side effect, so it belongs after the
+    # caller's commit, not inside this transaction (P1-9, §5.5).
+    assert thread_ids == ["t1", "t2"]
+    mock_thread_service.purge_checkpoints.assert_not_called()
 
 
-async def test_delete_permanently_purges_checkpoints_after_db_deletes(
+async def test_delete_permanently_deletes_threads_before_the_agent_row(
     service, mock_repo, mock_thread_service
 ):
-    """Checkpoint purge (non-rollbackable) must run after the agent row delete."""
+    """The agent row has FKs pointing at it from its threads, so the thread
+    delete has to land first."""
     agent = make_agent(is_archived=True)
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
 
     manager = MagicMock()
-    manager.attach_mock(mock_repo.delete, "delete_agent")
-    manager.attach_mock(mock_thread_service.purge_checkpoints, "purge_checkpoints")
+    manager.attach_mock(mock_thread_service.delete_rows_for_agent, "delete_threads")
+    manager.attach_mock(mock_repo.delete_by_id, "delete_agent")
 
     await service.delete_permanently(agent.id, user_id=agent.owner_id)
 
     ordered = [name for name, _, _ in manager.mock_calls]
-    assert ordered.index("delete_agent") < ordered.index("purge_checkpoints")
+    assert ordered.index("delete_threads") < ordered.index("delete_agent")
 
 
 async def test_delete_permanently_denied_for_editor(
@@ -918,7 +906,7 @@ async def test_delete_permanently_denied_for_editor(
         await service.delete_permanently(agent.id, user_id=uuid4())
 
     mock_agent_mcp_repo.delete_all_for_agent.assert_not_called()
-    mock_repo.delete.assert_not_called()
+    mock_repo.delete_by_id.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1291,7 +1279,6 @@ async def test_delete_permanently_cleans_team_links(
     service, mock_repo, mock_subagent_service
 ):
     agent = make_agent(is_archived=True)
-    mock_repo.get.return_value = agent
     mock_repo.list_with_permissions.return_value = [(agent, None)]
     mock_repo.delete_all_teams = AsyncMock()
 

--- a/backend/tests/agents/mcp_servers/test_repository.py
+++ b/backend/tests/agents/mcp_servers/test_repository.py
@@ -130,29 +130,65 @@ async def test_delete_calls_delete_and_flushes(repo, mock_db):
 
 
 # ---------------------------------------------------------------------------
-# delete_all_for_agent
+# delete_all_for_agent / delete_all_for_server — one bulk DELETE each
+#
+# Against a real engine, not a mocked session: the mock versions asserted
+# `db.delete` was awaited once per link, which is a transcript of the loop that
+# used to be here rather than of what a caller can observe (P3-5, P3-16).
 # ---------------------------------------------------------------------------
 
 
-async def test_delete_all_for_agent_deletes_every_link(repo, mock_db):
+def _add_link(session, agent_id, server_id) -> None:
+    session.add(AgentMCPServerDB(agent_id=agent_id, mcp_server_id=server_id))
+
+
+async def test_delete_all_for_agent_clears_only_that_agent(agent_session):
+    mine, theirs = uuid4(), uuid4()
+    server = uuid4()
+    _add_link(agent_session, mine, server)
+    _add_link(agent_session, mine, uuid4())
+    _add_link(agent_session, theirs, server)
+    await agent_session.flush()
+    repo = AgentMCPServerRepository(agent_session)
+
+    await repo.delete_all_for_agent(mine)
+
+    assert await repo.list_for_agent(mine) == []
+    assert len(await repo.list_for_agent(theirs)) == 1
+
+
+async def test_delete_all_for_agent_is_one_statement_for_any_number_of_links(
+    agent_session, statements
+):
     agent_id = uuid4()
-    links = [make_link(agent_id=agent_id), make_link(agent_id=agent_id)]
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = links
-    mock_db.execute.return_value = mock_result
+    for _ in range(4):
+        _add_link(agent_session, agent_id, uuid4())
+    await agent_session.flush()
+    statements.reset()
 
-    await repo.delete_all_for_agent(agent_id)
+    await AgentMCPServerRepository(agent_session).delete_all_for_agent(agent_id)
 
-    assert mock_db.delete.await_count == 2
-    mock_db.flush.assert_awaited_once()
+    assert len(statements) == 1
 
 
-async def test_delete_all_for_agent_noop_when_no_links(repo, mock_db):
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = []
-    mock_db.execute.return_value = mock_result
+async def test_delete_all_for_agent_on_an_agent_with_no_links_is_harmless(
+    agent_session,
+):
+    await AgentMCPServerRepository(agent_session).delete_all_for_agent(uuid4())
 
-    await repo.delete_all_for_agent(uuid4())
 
-    mock_db.delete.assert_not_called()
-    mock_db.flush.assert_not_called()
+async def test_delete_all_for_server_clears_that_server_across_agents(agent_session):
+    server, other_server = uuid4(), uuid4()
+    agent_a, agent_b = uuid4(), uuid4()
+    _add_link(agent_session, agent_a, server)
+    _add_link(agent_session, agent_b, server)
+    _add_link(agent_session, agent_a, other_server)
+    await agent_session.flush()
+    repo = AgentMCPServerRepository(agent_session)
+
+    await repo.delete_all_for_server(server)
+
+    assert [link.mcp_server_id for link in await repo.list_for_agent(agent_a)] == [
+        other_server
+    ]
+    assert await repo.list_for_agent(agent_b) == []

--- a/backend/tests/mcp/client/test_oauth_boundary.py
+++ b/backend/tests/mcp/client/test_oauth_boundary.py
@@ -256,16 +256,39 @@ async def test_list_tools_still_fails_loudly_on_a_real_error():
 # ---------------------------------------------------------------------------
 
 
-def test_the_app_registers_no_oauth_or_exception_group_handler():
-    """A guard, not a tautology: re-adding either handler would quietly restore
-    "any endpoint touching MCP can answer 401 with an auth URL", and the
-    ExceptionGroup one would again swallow TaskGroup-wrapped domain exceptions
-    into 500s (§2.3). If a new global handler is genuinely wanted, this test is
-    the place to argue for it."""
+def test_the_app_registers_no_oauth_handler():
+    """A guard, not a tautology: re-adding it would quietly restore "any
+    endpoint touching MCP can answer 401 with an auth URL". If a global handler
+    is genuinely wanted, this test is the place to argue for it.
+
+    The app *does* register an `ExceptionGroup` handler again (P3-4), and that
+    is not a relapse: it only re-dispatches a `DomainError` leaf to the status
+    the code already chose. `OAuthAuthorizationRequired` is not a `DomainError`,
+    so a group carrying one is re-raised as a 500 exactly as it is today — the
+    test below pins that rather than trusting the reasoning."""
     from app.main import app
 
-    registered = set(app.exception_handlers)
+    assert OAuthAuthorizationRequired not in set(app.exception_handlers)
 
-    assert OAuthAuthorizationRequired not in registered
-    assert ExceptionGroup not in registered
-    assert BaseExceptionGroup not in registered
+
+def test_the_exception_group_handler_cannot_answer_with_an_auth_url():
+    """The one way P3-4's group handler could undo P3-3: if a wrapped
+    `OAuthAuthorizationRequired` came back out as a 401 with an auth URL from
+    any endpoint at all."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    mirror = FastAPI()
+    for exc_type, handler in app.exception_handlers.items():
+        mirror.add_exception_handler(exc_type, handler)  # type: ignore[arg-type]
+
+    @mirror.get("/boom")
+    async def boom():
+        raise ExceptionGroup("tg", [OAuthAuthorizationRequired(AUTH_URL)])
+
+    response = TestClient(mirror, raise_server_exceptions=False).get("/boom")
+
+    assert response.status_code == 500
+    assert AUTH_URL not in response.text

--- a/backend/tests/test_exception_handlers.py
+++ b/backend/tests/test_exception_handlers.py
@@ -7,6 +7,8 @@ wrapping a domain exception that had already chosen its status (design review
 branch unwraps rather than swallows.
 """
 
+import logging
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -121,6 +123,32 @@ def test_it_unwraps_through_nesting():
 
     assert response.status_code == 403
     assert response.json() == {"detail": "not yours"}
+
+
+def test_other_failures_in_the_group_are_logged_not_dropped(caplog):
+    """The response can only carry one failure, and the domain status is the
+    useful one — but a concurrent crash beside it must not vanish, which is what
+    a plain `root_cause` dispatch would do."""
+    wrapped = ExceptionGroup(
+        "two tasks failed", [NotFoundError("gone"), ValueError("and the db exploded")]
+    )
+
+    with caplog.at_level(logging.ERROR, logger="app"):
+        response = _client(wrapped).get("/boom")
+
+    assert response.status_code == 404
+    assert "and the db exploded" in caplog.text
+
+
+def test_a_lone_domain_leaf_logs_nothing(caplog):
+    """The common case — one failure, wrapped by a task group — is not an
+    incident and must not be reported as one."""
+    wrapped = ExceptionGroup("one task failed", [NotFoundError("gone")])
+
+    with caplog.at_level(logging.ERROR, logger="app"):
+        assert _client(wrapped).get("/boom").status_code == 404
+
+    assert caplog.records == []
 
 
 def test_a_group_of_something_else_is_still_a_500():

--- a/backend/tests/test_exception_handlers.py
+++ b/backend/tests/test_exception_handlers.py
@@ -1,0 +1,141 @@
+"""One handler translates every domain failure into a response.
+
+There used to be six near-identical handlers in `main.py` plus an
+`ExceptionGroup` one that turned *any* group into a 500 — including a group
+wrapping a domain exception that had already chosen its status (design review
+§2.3). Now the status and the body come from `app/exceptions.py`, and the group
+branch unwraps rather than swallows.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.exceptions import (
+    AlreadyExistsError,
+    DomainError,
+    DomainValidationError,
+    InvalidCredentialsError,
+    ModelUnavailableError,
+    NoInviteError,
+    NotFoundError,
+    PermissionDeniedError,
+    StructuredOutputError,
+    status_for,
+)
+from app.main import app as real_app
+
+
+def _client(exc: BaseException) -> TestClient:
+    """A one-route app wired to the *real* app's registered handlers.
+
+    Copying the registration table rather than re-declaring it is the point:
+    a handler deleted from `main.py` fails these tests, and the real app is
+    left unmutated.
+    """
+    test_app = FastAPI()
+    for exc_type, handler in real_app.exception_handlers.items():
+        test_app.add_exception_handler(exc_type, handler)  # type: ignore[arg-type]
+
+    @test_app.get("/boom")
+    async def boom():
+        raise exc
+
+    return TestClient(test_app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# the mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("exc", "status"),
+    [
+        (NotFoundError("no such agent"), 404),
+        (AlreadyExistsError("already there"), 409),
+        (DomainValidationError("bad shape"), 400),
+        (PermissionDeniedError("nope"), 403),
+        (InvalidCredentialsError("wrong password"), 401),
+        (ModelUnavailableError("gpt-9", "not whitelisted"), 409),
+        (DomainError("something broke"), 500),
+    ],
+)
+def test_each_domain_exception_keeps_its_status(exc: DomainError, status: int):
+    response = _client(exc).get("/boom")
+
+    assert response.status_code == status
+    assert response.json()["detail"] == exc.detail
+
+
+@pytest.mark.parametrize(
+    "exc", [NoInviteError("no invite"), StructuredOutputError("x")]
+)
+def test_a_subclass_with_no_row_inherits_its_parents_status(exc: DomainError):
+    """`status_for` walks the MRO, so exceptions handled at their call site
+    (`NoInviteError` becomes a 302 in the OAuth callback) need no row and still
+    get `DomainError`'s 500 if one ever escapes."""
+    assert status_for(exc) == 500
+    assert _client(exc).get("/boom").status_code == 500
+
+
+def test_model_unavailable_keeps_its_machine_readable_body():
+    """The one exception whose body is more than `detail`: clients branch on
+    `error` instead of string-matching the message."""
+    response = _client(ModelUnavailableError("gpt-9", "disabled by an admin")).get(
+        "/boom"
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": "model_unavailable",
+        "model_id": "gpt-9",
+        "detail": "Model 'gpt-9' is not available: disabled by an admin",
+    }
+
+
+# ---------------------------------------------------------------------------
+# the group branch
+# ---------------------------------------------------------------------------
+
+
+def test_a_domain_exception_wrapped_by_a_taskgroup_keeps_its_status():
+    """The regression this whole task exists for: the MCP transport and the
+    toolset gather run under anyio task groups, so a domain failure raised
+    beneath one arrives wrapped, and `ExceptionGroup`'s MRO never reaches
+    `DomainError`. It used to become a bare 500."""
+    wrapped = ExceptionGroup("unhandled errors in a TaskGroup", [NotFoundError("gone")])
+
+    response = _client(wrapped).get("/boom")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "gone"}
+
+
+def test_it_unwraps_through_nesting():
+    wrapped = ExceptionGroup(
+        "outer", [ExceptionGroup("inner", [PermissionDeniedError("not yours")])]
+    )
+
+    response = _client(wrapped).get("/boom")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "not yours"}
+
+
+def test_a_group_of_something_else_is_still_a_500():
+    """The handler preserves a status the code already chose; it never invents
+    one. An unrelated TaskGroup crash stays an unhandled server error."""
+    response = _client(ExceptionGroup("boom", [ValueError("bug")])).get("/boom")
+
+    assert response.status_code == 500
+
+
+def test_the_real_app_can_build_its_middleware_stack():
+    """A guard for a trap this task walked into: Starlette asserts every
+    registered handler key is a subclass of `Exception`, and it does so while
+    *building the middleware stack* — which happens lazily, on the first
+    request. `BaseExceptionGroup` is not an `Exception` subclass, so
+    registering it imports cleanly and then 500s every route in production.
+    Nothing else in the suite touches the real app's stack."""
+    real_app.build_middleware_stack()


### PR DESCRIPTION
Continues the [backend cleanup](../blob/main/backend-cleanup-todo.md) after #304. Closes **P3-4** and **P3-5**, plus the residual P1-9 flagged for whenever `delete_permanently` was next opened.

947 passed, 1 skipped · `ruff check` / `ruff format --check` / `mypy app` clean.

## P3-4 — one exception mapping

Six near-identical handlers in `main.py` become **one** registration on `DomainError`: Starlette's handler lookup walks the exception's MRO, so the base class catches every subclass. Status comes from `STATUS: dict[type[DomainError], int]` in `app/exceptions.py`; the body from the exception's own `body()`, which exists because `ModelUnavailableError` is the one whose response is more than a `detail` string — an `isinstance` chain in the handler is exactly the copy-paste being removed. `status_for` walks the MRO too, which is what makes the table *partial*: `NoInviteError` and `StructuredOutputError` need no row and inherit `DomainError`'s 500, which is what they get today.

### The group handler is back, on purpose

P3-3 (#304) deleted the `ExceptionGroup` registration and left a test forbidding it, so this needs saying plainly. The old handler's flaw was owning the response for *every* group — a `NotFoundError` raised under an anyio task group arrived wrapped, missed its handler, and came back as a 500 (§2.3). The new one:

- unwraps with `root_cause()` and re-dispatches **only** a `DomainError` leaf;
- **re-raises everything else**, so an unrelated TaskGroup crash stays a logged 500.

It therefore can only preserve a status the code already chose, never invent one — and it cannot resurrect the global OAuth 401, because `OAuthAuthorizationRequired` is not a `DomainError`. A test raises a wrapped one from an endpoint and asserts it still 500s with no auth URL in the body, rather than trusting that reasoning. The P3-3 guard is narrowed to what it actually protects (no OAuth handler) instead of deleted.

### One trap worth remembering

Registering on `BaseExceptionGroup` imports cleanly and then 500s every route. It is not a subclass of `Exception`, and Starlette asserts that while *building the middleware stack* — which happens lazily, on the first request. `ExceptionGroup` is the right key and loses nothing, since the middleware only catches `Exception` anyway. `test_the_real_app_can_build_its_middleware_stack` guards it.

## P3-5 — query slimming

**Bulk deletes.** Six select-then-delete-each loops become one `DELETE … WHERE` each (`delete_all_permissions`, `delete_all_teams`, both in `mcp_servers`, the `or_`-both-directions one in `subagents`, `delete_all_for_sandbox`). `set_permissions` / `set_teams` delegate to them instead of re-implementing the loop, and `set_permissions` loses its `refresh` loop — one round-trip per grant to read timestamps `AgentPermissionResponse` does not carry.

**The redundant refetch.** `require_permission` already proves the agent exists, and every mutation ends in a `get` that re-reads it — so the `get_or_404` in between was fetching a row only `repository.update` looked at, plus the `refresh` that update did afterwards. Three id-based repository methods (`update_by_id`, `set_archived`, `delete_by_id`) replace it. **A one-column PATCH went 8 → 6 statements and now reads the full agent row exactly once.** `update_by_id` returns early on an empty patch, matching the ORM path: a PATCH naming no fields must not bump `updated_at`.

**The list query (§3.5).** The review offered `load_only` *or* a separate `IN` query; `load_only` is the smaller change and does the whole job. `list_with_permissions(slim=True)` loads only the columns `AgentListResponse` renders, so `instructions` — tens of KB per agent, repeated once per MCP binding by the join — and the bindings' per-tool JSONB maps never leave the database. `AgentService.list` now *returns* `AgentListResponse`, i.e. the narrowing is a narrower **read**, not a field hidden at serialization time, and it skips the sandbox query entirely since that schema has no `sandboxes` field.

**The wire format is unchanged** — the router already declared `response_model=list[AgentListResponse]`. Slack's picker was retyped with it (it only reads id/name/emoji/permission).

The mechanism to know about: `model_dump()` on a `load_only`-ed instance silently *omits* the deferred columns and does not emit a query. Verified before relying on it. That is what makes the slim path safe, and also why a slim row may only be assembled into `AgentListResponse` — building an `AgentResponse` from one fails validation instead of quietly N+1-ing.

## Rode along: P1-9's residual

`delete_permanently` purged checkpoints after the DB deletes had *flushed* but still before the request commit, keeping a narrower version of the window #299 closed for threads. It now returns the thread ids (the same contract as `ThreadService.delete_rows_for_agent`) and `DELETE /agents/{id}/permanent` commits, then purges, with the same log-don't-500 guard the thread endpoint uses. CLAUDE.md documents that as the **third** transaction regime.

## Tests

- `tests/test_exception_handlers.py` (14) — mirrors the *real* app's registration table into a one-route app rather than re-declaring it, so a handler deleted from `main.py` fails them. Verified the group branch is load-bearing: with it skipped, a wrapped `NotFoundError` is a 500.
- `tests/agents/core/test_query_cost.py` (9, real engine) — the list never selects `agents.instructions` or `agent_mcp_servers.tools`, never touches `agent_sandboxes`, costs ≤4 statements for any number of agents; the detail read still carries everything; the PATCH and archive costs above.
- Two router tests pin commit-before-purge and that a failed purge still answers 204.

**Test debt paid down (P3-16).** About ten mock-mirror tests that asserted `db.delete` once per row, counted `flush`es, or matched `repository.update(agent, patch)` broke on this refactor without a single behaviour changing — the exact failure mode §6.2 describes. They are rewritten against the real engine, and `tests/agents/core/conftest.py` moves up to `tests/agents/conftest.py` so every agents module can reach the engine and statement counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the backend cleanup's Phase 3: exception mapping (P3-4), query slimming (P3-5), and the P1-9 purge-ordering residual. No wire-format or API behavior changes.

**Exception mapping**
- Six near-identical handlers in `main.py` become one `DomainError` handler; the status comes from a `STATUS` table in `app/exceptions.py`, and the body from each exception's own `body()`.
- The `ExceptionGroup` handler is re-added: it re-dispatches a wrapped `DomainError` leaf via `root_cause()`, re-raises everything else, and logs sibling failures when a group carries more than one error.
- Tests mirror the real app's registration table, so a handler deleted from `main.py` fails CI.

**Query slimming and purge ordering**
- Six select-then-delete loops become one `DELETE … WHERE` each; `set_permissions` and `set_teams` delegate to them and drop their per-row refresh loops.
- Mutations patch by id via three new repository methods, so a one-column PATCH reads the full agent row exactly once — 8 statements down to 6 — and `set_archived` filters on the current value so repeated archives and empty patches don't bump `updated_at`.
- The agent list reads only the columns `AgentListResponse` renders via `load_only`; `_assemble` is overloaded on `slim` so the detail read still returns the full `AgentResponse`.
- `delete_permanently` now returns its thread ids, and the router commits before purging checkpoints; a failed purge is logged and still answers 204.
- Mock-mirror tests that asserted per-row deletes were rewritten against a real engine.

<sup>Written for commit c41674bce22e6c29716d6e8f493ee637c13047c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

