### PR TITLE
refactor(agents): typed event envelopes for run delivery

### DIFF
--- a/backend-cleanup-todo.md
+++ b/backend-cleanup-todo.md
@@ -6,7 +6,7 @@ just the state. Task IDs are stable — reference them in commits and PR titles.
 
 **Status legend:** `[ ]` not started · `[~]` partly done · `[x]` done · `[!]` blocked
 
-Last updated: 2026-08-31
+Last updated: 2026-09-01
 
 ---
 
@@ -565,7 +565,36 @@ Last updated: 2026-08-31
       purging checkpoints, so a failed commit can no longer leave an agent whose history
       is irrecoverably gone. Two router tests pin the ordering and that a failed purge
       still answers 204
-- [ ] **P3-6** Typed event envelopes + `error_code` column + machine-readable HITL block ids
+- [~] **P3-6** Typed event envelopes + `error_code` column + machine-readable HITL block ids.
+      **HITL third done** (PR #307, merged 2026-09-01) — and keyed on the checkpoint's
+      `Interrupt.id` rather than an invented id: new leaf module `app/agents/hitl.py`
+      (moved out of `threads/serialization.py`, id no longer discarded), addressed
+      resume canonicalized + stale-checked in `RunService.create`
+      (`StaleApprovalError` → 409 `{"error": "stale_interrupt"}`), Slack `block_id`
+      protocol `hitl:<interrupt_id>:<tool_call_id>[:<decision>]` with the emoji
+      demoted to presentation, web echoes the id. The legacy emoji scan survives
+      only for id-less checkpoints and pre-deploy cards — delete it (and the
+      positional-resume acceptance) once those drain. Design + status:
+      `hitl-durability-assessment.md`.
+      **Typed-envelopes third done** (2026-09-01, uncommitted): `SlackStreamEvent`
+      tagged union in `app/agents/stream.py` (text / tool_start / error / end,
+      with `end.status` parsed into `RunStatus` — an unknown status from a newer
+      producer degrades to `None`/generic notice, never a crash); `SlackDelivery`
+      TypedDict shared by `build_slack_delivery` and the consumer;
+      `MultitaskStrategy` Literal shared by column, schema and service; consumer
+      dispatch narrowed by the Literal tag and compared as enum members, no
+      `.value` strings. Both `app.agents.stream` and
+      `app.integrations.slack.consumer` sit outside the mypy ratchet exemptions,
+      so the contracts are enforced (first run caught `SLACK_CHANNEL` needing
+      `Final`). Encoder↔decoder pinned by a round-trip test against
+      `events.end_sentinel`. **Deliberately not done:** §1.3's fuller "store
+      typed JSON in Redis, SSE-encode at the HTTP edge" — that changes the event
+      log format (reattach + rolling-deploy hazard) for no additional checking;
+      the one decode of our own SSE lives beside its encoder in
+      `app/agents/stream.py`, contract-tested, and no `app/integrations` code
+      parses SSE.
+      **Still open:** the `RunDB.error_code` column (+ one nullable-VARCHAR
+      migration) replacing exact-string `MCP_REAUTH_ERROR` matching
 - [ ] **P3-7** Thread reads into the service; O(1) subagent state; one history encoding; stable message ids
       **Found while doing P3-1, not fixed there — decide before closing P3-7:**
       `POST /threads` takes an `agent_id` from the body and checks nothing, and the

--- a/backend/app/agents/runs/models.py
+++ b/backend/app/agents/runs/models.py
@@ -11,7 +11,7 @@ from sqlalchemy import JSON, Enum as SAEnum, Index, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Column, Field, SQLModel, String, Text
 
-from app.agents.runs.state import RunStatus
+from app.agents.runs.state import MultitaskStrategy, RunStatus
 from app.models import TimestampMixin
 
 
@@ -65,7 +65,7 @@ class RunDB(TimestampMixin, SQLModel, table=True):
             nullable=False,
         ),
     )
-    multitask_strategy: str = Field(
+    multitask_strategy: MultitaskStrategy = Field(
         default="reject", sa_column=Column(String, nullable=False)
     )
 

--- a/backend/app/agents/runs/schemas.py
+++ b/backend/app/agents/runs/schemas.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-from typing import Literal
 
 from pydantic import BaseModel
 
 from app.agents.runs.models import RunDB
-from app.agents.runs.state import RunStatus
+from app.agents.runs.state import MultitaskStrategy, RunStatus
 
 
 class RunCreate(BaseModel):
@@ -17,7 +16,7 @@ class RunCreate(BaseModel):
     input: dict | None = None
     command: dict | None = None
     config: dict | None = None
-    multitask_strategy: Literal["reject", "enqueue"] = "reject"
+    multitask_strategy: MultitaskStrategy = "reject"
 
 
 class RunResponse(BaseModel):

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -26,7 +26,7 @@ from app.agents.runs.liveness import RunLiveness
 from app.agents.runs.models import RunDB
 from app.agents.runs.repository import RunRepository
 from app.agents.runs.settings import run_settings
-from app.agents.runs.state import RunStatus, is_terminal
+from app.agents.runs.state import MultitaskStrategy, RunStatus, is_terminal
 from app.database import AsyncSessionLocal, get_checkpointer
 from app.exceptions import DomainValidationError, NotFoundError
 from app.model_providers.service import ModelService
@@ -53,7 +53,7 @@ class RunService:
         config_overrides: dict | None = None,
         output_schema: dict | None = None,
         delivery: dict | None = None,
-        multitask_strategy: str = "reject",
+        multitask_strategy: MultitaskStrategy = "reject",
     ) -> RunDB:
         """Create a pending run. Caller has already authorized the thread.
 

--- a/backend/app/agents/runs/state.py
+++ b/backend/app/agents/runs/state.py
@@ -6,6 +6,14 @@ state stays in the LangGraph checkpoint.
 """
 
 from enum import Enum
+from typing import Literal
+
+
+#: What `create` does when the thread already has an active run: `reject`
+#: raises, `enqueue` waits for the per-thread mutex. One alias shared by the
+#: column, the API schema, and the service so the type checker sees a single
+#: vocabulary instead of three `str`s that happen to agree.
+MultitaskStrategy = Literal["reject", "enqueue"]
 
 
 class RunStatus(str, Enum):

--- a/backend/app/agents/stream.py
+++ b/backend/app/agents/stream.py
@@ -9,12 +9,13 @@ import dataclasses
 import json
 import logging
 from collections.abc import AsyncGenerator, AsyncIterator
-from typing import Any
+from typing import Any, Literal, TypedDict
 
 from langchain_core.messages import BaseMessage
 from langgraph.errors import GraphRecursionError
 from langgraph.types import Overwrite
 
+from app.agents.runs.state import RunStatus
 from app.exceptions import root_cause
 
 
@@ -272,15 +273,52 @@ def _chunk_text(content: Any) -> str:
     return ""
 
 
+class TextEvent(TypedDict):
+    """A user-visible text delta from the AI message stream."""
+
+    type: Literal["text"]
+    content: str
+
+
+class ToolStartEvent(TypedDict):
+    """A tool call began (emitted once per tool_call_id)."""
+
+    type: Literal["tool_start"]
+    tool_call_id: str
+    tool_name: str
+
+
+class ErrorEvent(TypedDict):
+    """The run emitted an error event; `content` is the message."""
+
+    type: Literal["error"]
+    content: str
+
+
+class EndEvent(TypedDict):
+    """The run's terminal event. `status` is None when the sentinel carried
+    an unknown status (a newer producer during a rolling deploy)."""
+
+    type: Literal["end"]
+    status: RunStatus | None
+
+
+#: The typed envelope a delivery consumer dispatches on. A tagged union, so
+#: `event["type"] == "text"` narrows for the type checker — misspell a tag or
+#: read a field off the wrong variant and mypy fails instead of a KeyError in
+#: the Slack worker.
+SlackStreamEvent = TextEvent | ToolStartEvent | ErrorEvent | EndEvent
+
+
 class SlackStreamAdapter:
-    """Adapts the run's LangGraph SSE event log to typed Slack event dicts.
+    """Adapts the run's LangGraph SSE event log to typed `SlackStreamEvent`s.
 
     Reads the same byte-identical SSE the HTTP `/runs/stream` consumer relays
-    (so the worker publishes one canonical format) and yields:
-    - {"type": "text", "content": "..."}
-    - {"type": "tool_start", "tool_call_id": "...", "tool_name": "..."}
-    - {"type": "error", "content": "..."}
-    - {"type": "end", "status": "success" | "interrupted" | ...}
+    (so the worker publishes one canonical format) and yields the
+    `SlackStreamEvent` union — the decode of our own SSE happens here, in the
+    module that also *encodes* it (`_encode_lg_sse` / `decode_sse_blocks`),
+    never in a delivery consumer. The `end` status is parsed into `RunStatus`
+    so consumers compare enum members, not `.value` strings.
 
     Only top-level (non-namespaced) `messages` events are surfaced — subagent
     tokens stream under a `messages|<ns>` event and are intentionally skipped.
@@ -294,24 +332,28 @@ class SlackStreamAdapter:
 
     async def stream(
         self, sse_stream: AsyncIterator[str]
-    ) -> AsyncGenerator[dict[str, Any], None]:
+    ) -> AsyncGenerator[SlackStreamEvent, None]:
         async for sse in sse_stream:
             for event, data in decode_sse_blocks(sse):
                 for out in self._process(event, data):
                     yield out
 
-    def _process(self, event: str, data: Any) -> list[dict[str, Any]]:
+    def _process(self, event: str, data: Any) -> list[SlackStreamEvent]:
         if event == "messages":
             return self._process_message(data)
         if event == "error":
             message = data.get("message") if isinstance(data, dict) else str(data)
-            return [{"type": "error", "content": message or "Unknown error"}]
+            return [ErrorEvent(type="error", content=message or "Unknown error")]
         if event == "end":
-            status = data.get("status") if isinstance(data, dict) else None
-            return [{"type": "end", "status": status}]
+            raw = data.get("status") if isinstance(data, dict) else None
+            try:
+                status: RunStatus | None = RunStatus(raw)
+            except ValueError:
+                status = None
+            return [EndEvent(type="end", status=status)]
         return []
 
-    def _process_message(self, data: Any) -> list[dict[str, Any]]:
+    def _process_message(self, data: Any) -> list[SlackStreamEvent]:
         """Turn a top-level `messages` event ([chunk, metadata]) into events."""
         if not isinstance(data, list) or not data:
             return []
@@ -325,16 +367,18 @@ class SlackStreamAdapter:
         if chunk.get("type") not in ("AIMessageChunk", "ai", "AIMessage"):
             return []
 
-        events: list[dict[str, Any]] = []
+        events: list[SlackStreamEvent] = []
         for tc in chunk.get("tool_call_chunks") or chunk.get("tool_calls") or []:
             tc_id, name = tc.get("id"), tc.get("name")
             if tc_id and name and tc_id not in self._tools_started:
                 self._tools_started.add(tc_id)
                 events.append(
-                    {"type": "tool_start", "tool_call_id": tc_id, "tool_name": name}
+                    ToolStartEvent(
+                        type="tool_start", tool_call_id=tc_id, tool_name=name
+                    )
                 )
 
         text = _chunk_text(chunk.get("content", ""))
         if text:
-            events.append({"type": "text", "content": text})
+            events.append(TextEvent(type="text", content=text))
         return events

--- a/backend/app/integrations/slack/consumer.py
+++ b/backend/app/integrations/slack/consumer.py
@@ -10,6 +10,7 @@ enqueues the run (see `router.py`).
 """
 
 import logging
+from typing import Final, Literal, TypedDict, cast
 
 from redis.asyncio import Redis
 from slack_sdk.web.async_client import AsyncWebClient
@@ -33,7 +34,24 @@ from app.threads.models import ThreadDB
 
 logger = logging.getLogger(__name__)
 
-SLACK_CHANNEL = "slack"
+# Final, so mypy sees Literal["slack"] and the SlackDelivery construction checks.
+SLACK_CHANNEL: Final = "slack"
+
+
+class SlackDelivery(TypedDict):
+    """The delivery descriptor stored on a Slack-bound run (`RunDB.delivery`).
+
+    Written by `build_slack_delivery`, read back as JSONB — the shape is a
+    contract between the enqueue path and this consumer, so it is a TypedDict
+    rather than an opaque dict: mistype a key on either side and mypy fails
+    instead of a KeyError mid-delivery.
+    """
+
+    channel: Literal["slack"]
+    channel_id: str
+    thread_ts: str
+    slack_user_id: str
+    team_id: str | None
 
 
 def build_slack_run_consumer(record: RunDB) -> "SlackRunConsumer | None":
@@ -46,8 +64,8 @@ def build_slack_run_consumer(record: RunDB) -> "SlackRunConsumer | None":
 
 def build_slack_delivery(
     *, channel_id: str, thread_ts: str, slack_user_id: str, team_id: str | None
-) -> dict:
-    """The opaque delivery descriptor stored on a Slack-bound run."""
+) -> SlackDelivery:
+    """The delivery descriptor stored on a Slack-bound run."""
     return {
         "channel": SLACK_CHANNEL,
         "channel_id": channel_id,
@@ -62,7 +80,9 @@ class SlackRunConsumer(DeliveryConsumer):
 
     def __init__(self, record: RunDB, redis: Redis | None = None):
         self.record = record
-        self.delivery = record.delivery or {}
+        # The factory only builds this consumer for a record whose delivery
+        # carries channel == "slack", so the JSONB dict is a SlackDelivery.
+        self.delivery = cast(SlackDelivery, record.delivery or {})
         self.redis = redis
         self.client = AsyncWebClient(token=slack_settings.slack_bot_token)
 
@@ -88,19 +108,19 @@ class SlackRunConsumer(DeliveryConsumer):
             status,
             text_chars,
         )
-        if status == RunStatus.interrupted.value:
+        if status is RunStatus.interrupted:
             await self._post_approvals(channel_id, thread_ts)
-        elif status == RunStatus.success.value:
+        elif status is RunStatus.success:
             await self._post_auxilia_link(channel_id, thread_ts)
         elif status in (
-            RunStatus.error.value,
-            RunStatus.timeout.value,
+            RunStatus.error,
+            RunStatus.timeout,
         ) and not await self._post_reauth_prompt_if_gated(channel_id, thread_ts):
             await self._post_failure_notice(channel_id, thread_ts)
 
     async def _stream_to_slack(
         self, channel_id: str, thread_ts: str
-    ) -> tuple[str | None, int]:
+    ) -> tuple[RunStatus | None, int]:
         """Relay the event log into a Slack streaming message.
 
         Returns the run's terminal status and how many characters of text were
@@ -115,25 +135,26 @@ class SlackRunConsumer(DeliveryConsumer):
             recipient_user_id=self.delivery.get("slack_user_id"),
         )
         adapter = SlackStreamAdapter()
-        status: str | None = None
+        status: RunStatus | None = None
         text_chars = 0
         try:
             async for event in adapter.stream(
                 RunService(self.redis).stream(self.record.id)
             ):
-                kind = event["type"]
-                if kind == "text":
+                # Tagged-union dispatch: comparing the Literal tag narrows the
+                # event, so each branch's field reads are type-checked.
+                if event["type"] == "text":
                     text_chars += len(event["content"])
                     await streamer.append(markdown_text=event["content"])
-                elif kind == "tool_start":
+                elif event["type"] == "tool_start":
                     await streamer.append(
                         markdown_text=format_tool_streamer_label(event["tool_name"])
                     )
-                elif kind == "error":
+                elif event["type"] == "error":
                     await streamer.append(
                         markdown_text=f"**`Error: {event['content']}`**\n\n"
                     )
-                elif kind == "end":
+                elif event["type"] == "end":
                     status = event["status"]
         finally:
             await streamer.stop()

--- a/backend/app/integrations/slack/consumer.py
+++ b/backend/app/integrations/slack/consumer.py
@@ -108,7 +108,14 @@ class SlackRunConsumer(DeliveryConsumer):
             status,
             text_chars,
         )
-        if status is RunStatus.interrupted:
+        if status is None:
+            # No recognizable terminal status (an unknown status from a newer
+            # producer, or a stream that ended without an end event): the
+            # streaming message is already stopped, so say *something* rather
+            # than leaving the thread hanging. `cancelled` stays silent below
+            # on purpose — the user stopped the run themselves.
+            await self._post_failure_notice(channel_id, thread_ts)
+        elif status is RunStatus.interrupted:
             await self._post_approvals(channel_id, thread_ts)
         elif status is RunStatus.success:
             await self._post_auxilia_link(channel_id, thread_ts)

--- a/backend/tests/agents/test_stream.py
+++ b/backend/tests/agents/test_stream.py
@@ -1,5 +1,7 @@
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 
+from app.agents.runs.events import end_sentinel
+from app.agents.runs.state import RunStatus
 from app.agents.stream import (
     LangGraphStreamAdapter,
     SlackStreamAdapter,
@@ -164,11 +166,35 @@ async def test_slack_tool_message_content_is_not_streamed():
 
 
 async def test_slack_end_event_carries_status():
-    """The terminal sentinel is surfaced as an `end` event with its status."""
+    """The terminal sentinel is surfaced as an `end` event whose status is the
+    parsed `RunStatus` member (P3-6 typed envelopes) — consumers dispatch on
+    the enum, never on `.value` strings. Pinned with `is`, since the str-enum
+    would also `==` its raw string."""
     sentinel = 'event: end\ndata: {"status": "interrupted"}\n\n'
     events = await _collect(SlackStreamAdapter().stream(_async_gen([sentinel])))
 
-    assert events == [{"type": "end", "status": "interrupted"}]
+    assert events == [{"type": "end", "status": RunStatus.interrupted}]
+    assert events[0]["status"] is RunStatus.interrupted
+
+
+async def test_slack_end_event_round_trips_the_producers_sentinel():
+    """Encoder↔decoder contract: the exact chunk `events.end_sentinel` publishes
+    (the one producer) decodes back to the same `RunStatus` — the two sides
+    live in different modules and must not drift."""
+    events = await _collect(
+        SlackStreamAdapter().stream(_async_gen([end_sentinel(RunStatus.success)]))
+    )
+    assert events == [{"type": "end", "status": RunStatus.success}]
+
+
+async def test_slack_end_event_with_unknown_status_is_none():
+    """A status this build doesn't know (a newer producer mid-deploy) must not
+    crash the delivery — it surfaces as `None`, which falls through to the
+    generic failure notice rather than a wrong affordance."""
+    sentinel = 'event: end\ndata: {"status": "brand-new-status"}\n\n'
+    events = await _collect(SlackStreamAdapter().stream(_async_gen([sentinel])))
+
+    assert events == [{"type": "end", "status": None}]
 
 
 async def test_slack_error_event():

--- a/backend/tests/integrations/slack/test_consumer.py
+++ b/backend/tests/integrations/slack/test_consumer.py
@@ -250,5 +250,25 @@ async def test_consumer_posts_failure_notice_when_stream_crashes(monkeypatch):
     assert any("something went wrong" in p["text"].lower() for p in fake.posts)
 
 
+async def test_unknown_terminal_status_posts_the_failure_notice(monkeypatch):
+    """cubic P2 on #308: an end sentinel this build can't parse (a newer
+    producer mid-deploy) must not leave the thread with only a stopped
+    streaming message — `None` dispatches to the generic failure notice."""
+    monkeypatch.setattr(
+        consumer_mod.RunService,
+        "stream",
+        _sse_stream('event: end\ndata: {"status": "brand-new-status"}\n\n'),
+    )
+
+    consumer = SlackRunConsumer(_record(_slack_delivery()))
+    fake = _FakeClient()
+    consumer.client = fake
+    await consumer.run()
+
+    assert fake.streamer.stopped
+    assert len(fake.posts) == 1
+    assert "something went wrong" in fake.posts[0]["text"]
+
+
 async def _async(value):
     return value


### PR DESCRIPTION
## Summary

Second third of **P3-6** (design review §4.2 "stringly-typed state where it hurts most"): the run-delivery and Slack contracts were strings the type checker couldn't see — `{"type": "text"}` event dicts, `status == RunStatus.x.value` comparisons, an opaque `delivery` dict, and three independent `str`s standing in for the multitask strategy. No behavior change intended; no migration (`multitask_strategy` was already VARCHAR).

- **`SlackStreamEvent` tagged union** (`app/agents/stream.py`): `TextEvent | ToolStartEvent | ErrorEvent | EndEvent` instead of `dict[str, Any]`. `end.status` is parsed into `RunStatus` at the seam — consumers dispatch on enum members, and an unknown status (a newer producer during a rolling deploy) degrades to `None` → generic failure notice, never a crash or a wrong affordance.
- **`SlackDelivery` TypedDict** shared by `build_slack_delivery` and `SlackRunConsumer` — the enqueue path and the worker-side consumer now share one checked shape; mistyping a key on either side is a mypy error instead of a `KeyError` mid-delivery. `SLACK_CHANNEL` is `Final` so the `Literal["slack"]` checks (mypy caught exactly this on its first run over the change).
- **Consumer dispatch narrowed by the Literal tag** — each branch's field reads are type-checked; `.value` string comparisons are gone.
- **One `MultitaskStrategy` Literal** (`runs/state.py`) shared by the `RunDB` column, `RunCreate`, and `RunService.create`.

Both `app.agents.stream` and `app.integrations.slack.consumer` sit **outside** the mypy ratchet's exemption list, so these contracts are enforced from now on, not aspirational.

**Deliberately not done** (recorded in the tracker): §1.3's fuller "store typed JSON in Redis, SSE-encode only at the HTTP edge" — that changes the event-log format, a reattach + rolling-deploy hazard, for no additional type safety. The single decode of our own SSE lives beside its encoder in `app/agents/stream.py`, round-trip tested; nothing under `app/integrations` parses SSE.

Remaining P3-6 item after this: the `RunDB.error_code` column (one nullable-VARCHAR migration), tracked in `backend-cleanup-todo.md`.

## Test plan

- [x] `uv run pytest` — 998 passed, 1 skipped (3 new/updated stream tests)
- [x] End-status test pins the **enum with `is`** — the str-enum would `==` its raw string, which would have hidden a regression to string statuses
- [x] Encoder↔decoder round trip: the exact chunk `events.end_sentinel` publishes decodes back to the same `RunStatus`, so the producer and the adapter can't drift across modules
- [x] Unknown terminal status degrades to `None` (generic notice), not an exception
- [x] `uv run mypy app` / `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the stringly-typed Slack run-delivery contracts with type-checked ones, so mypy catches contract violations before they reach the Slack worker: the run stream yields a `SlackStreamEvent` tagged union instead of `dict[str, Any]`, terminal status is parsed into `RunStatus`, the `SlackDelivery` TypedDict is shared by the enqueue and consume paths, and one `MultitaskStrategy` Literal is used by the column, API schema, and service. No migration needed (`multitask_strategy` was already `VARCHAR`); behavior for normal runs is unchanged.

- `end.status` is parsed into `RunStatus`; consumers compare enum members instead of `.value` strings, and an unknown status from a newer producer degrades to `None`.
- A follow-up fix changes one edge behavior: `None` now posts the generic failure notice instead of falling through silently and leaving the Slack thread with only a stopped streaming message (`cancelled` stays silent — the user stopped the run).
- The consumer dispatch narrows on the Literal tag, so each branch's field reads are type-checked; `SLACK_CHANNEL` is `Final` so the `Literal["slack"]` checks hold.
- Tests pin the end status with `is`, cover an encoder↔decoder round trip via `events.end_sentinel`, and verify the `None` degrade.
- Deliberately not done: storing typed JSON in Redis and SSE-encoding only at the HTTP edge — it changes the event-log format (reattach + rolling-deploy hazard) for no extra type safety, and the single decode of our own SSE stays beside its encoder.
- The remaining P3-6 item is the `RunDB.error_code` column (one nullable-VARCHAR migration).

<sup>Written for commit cb28d96069562554152edda79e1d49cc16f2dc3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

