### PR TITLE
perf(web): cut streaming memory churn — memoized conversation body, SDK throttle, values trim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ coverage.xml
 # next.js
 .next/
 .next-demo/
+.next-mem/
 out/
 
 # production

--- a/backend/app/agents/stream.py
+++ b/backend/app/agents/stream.py
@@ -94,6 +94,14 @@ def _serialize_state(state: dict[str, Any]) -> dict[str, Any]:
     """Serialize a LangGraph state dict for the values SSE event."""
     result: dict[str, Any] = {}
     for key, value in state.items():
+        # The deepagents virtual filesystem is re-sent in every values
+        # snapshot (one per superstep) and can be megabytes on sandbox-heavy
+        # threads, but no stream consumer reads it: the web client uses only
+        # `messages` / `todos` / `__interrupt__` from stream values, and the
+        # Slack adapter ignores values entirely. History reads (GET
+        # /threads/{id}) come from the checkpoint, not this path.
+        if key == "files":
+            continue
         # Unwrap Overwrite wrapper (used by deep agents)
         if isinstance(value, Overwrite):
             value = value.value

--- a/backend/tests/agents/test_stream.py
+++ b/backend/tests/agents/test_stream.py
@@ -216,6 +216,39 @@ async def test_slack_subagent_messages_are_skipped():
     assert events == []
 
 
+# ── LangGraph adapter values trimming ─────────────────────────────────────
+
+
+async def test_values_events_strip_the_deepagents_files_dict():
+    """`values` snapshots re-send the whole graph state every superstep; the
+    deepagents virtual filesystem can be megabytes and no stream consumer
+    reads it, so the adapter must drop it — while keeping the channels the
+    web client does read (`messages`, `todos`, `__interrupt__`)."""
+    events = [
+        (
+            "values",
+            {
+                "messages": [HumanMessage(content="hi", id="user-msg-1")],
+                "todos": [{"content": "step 1", "status": "pending"}],
+                "files": {"notes.md": "x" * 10_000},
+            },
+        )
+    ]
+    sse = [
+        s
+        async for s in LangGraphStreamAdapter(subgraphs=False).stream(
+            _async_gen(events)
+        )
+    ]
+
+    assert len(sse) == 1
+    [(event, data)] = decode_sse_blocks(sse[0])
+    assert event == "values"
+    assert "files" not in data
+    assert data["todos"] == [{"content": "step 1", "status": "pending"}]
+    assert [m["id"] for m in data["messages"]] == ["user-msg-1"]
+
+
 # ── LangGraph adapter error events (what the run record persists) ────────
 
 

--- a/streaming-memory-assessment.md
+++ b/streaming-memory-assessment.md
@@ -1,0 +1,286 @@
+# Streaming memory assessment — why the tab hits ~1.5GB
+
+**Date**: 2026-09-01
+**Symptom**: when an agent run streams a lot of tokens, the auxilia browser tab grows to ~1.5GB.
+
+## TL;DR
+
+It is not one leak — it is **quadratic allocation churn** across three layers, and the
+number matches a known upstream problem: LangChain's own support article on
+deepagents + token streaming reports "memory spikes (1–1.5 GB or higher)" with
+`streamMode: ['messages', 'updates']`, because **every token materializes a new
+`AIMessageChunk` object plus a full re-merge of the accumulated message**. We run
+that exact stack in the browser, with `values` snapshots on top, and re-render the
+whole chat page at token rate. Retained memory is bounded (roughly the final thread
+state ×2–3); the 1.5GB is mostly garbage V8 hasn't collected because the tab never
+goes idle while streaming.
+
+Upgrading `ai` / `@ai-sdk/react` will change nothing — the chat page doesn't use the
+AI SDK at all (only a type import in `prompt-input.tsx`). The two upgrades that do
+matter are **streamdown 1.6 → 2.6** (2.5 stops re-rendering completed blocks) and,
+more importantly, **implementation changes** listed below.
+
+## Layer 1 — `@langchain/langgraph-sdk` `useStream`: O(n²) per-token work (biggest)
+
+`web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx:500` uses
+`useStream` + `FetchStreamTransport` (SDK 1.7.5). Inside the SDK
+(`dist/ui/manager.js`, `dist/ui/messages.js`), **every `messages` SSE event —
+i.e. every token chunk —** does all of the following:
+
+1. `MessageTupleManager.add`: coerces the chunk to an `AIMessageChunk` and
+   `prev.concat(chunk)` — string-concatenates the full accumulated `content`
+   (and DeepSeek's `additional_kwargs.reasoning_content`) into brand-new strings.
+   Cost per token is O(message length) → **O(n²) bytes allocated over one response**.
+2. `toMessage(chunk)` → `chunk.toDict()`: re-serializes the entire accumulated
+   message to a fresh plain object.
+3. `setStreamValues`: `messages.slice()` (copies the whole message array) + a new
+   values object.
+4. `setState` → `notifyListeners()` — **unthrottled**, see Layer 3.
+
+On the measured thread (~110KB of AI text + reasoning ≈ 7,000+ token events), step 1
+alone churns ~30MB, steps 2–3 add tens more, and — dominating everything — each of
+those 7,000+ events triggers a full `ChatPage` re-render (Layer 3): 251 messages'
+worth of React elements rebuilt per event easily exceeds **1MB per render × thousands
+of renders = multiple GB of element churn** over a long run. Subagent tokens stream
+too (`subgraphs=True`), multiplying this during parallel subagent runs.
+
+Upstream confirmation: [LangChain support — "How do I resolve memory issues when
+streaming tokens with deepagents and subagents?"](https://support.langchain.com/articles/8854872772-how-do-i-resolve-memory-issues-when-streaming-tokens-with-deepagents-and-subagents)
+— it names the same symptom ("significant memory spikes (1–1.5 GB or higher)") and the
+same cause ("Messages mode yields one `AIMessageChunk` per LLM token across all graph
+levels, including subagents … a single run can produce 10,000+ chunk objects"). (Their
+server-side advice — callbacks instead of chunk objects, or `subgraphs: false` —
+targets backend stream iteration; in our architecture the equivalent lever is the
+backend adapter and what the browser is made to parse. The React SDK has no fix as
+of 1.10.0, whose changelog contains no perf work.)
+
+## Layer 2 — backend streams 3 redundant modes, one of them O(n²) on the wire
+
+`backend/app/agents/runtime.py:616`:
+
+```python
+stream_mode=["messages", "values", "updates"], subgraphs=True
+```
+
+- **`values` emits the entire graph state after every superstep** — all messages
+  plus the deepagents `files` dict. Measured on the thread that hit 1.5GB
+  (`output-f0c70a93823fdf23.json` at repo root — 251 messages: 120 AI + 127 tool,
+  ~600KB final state, `files` empty, weight dominated by tool outputs ~189KB and
+  reasoning ~90KB): emitting a snapshot as each message lands sums to **~83MB of
+  JSON** parsed browser-side over one thread — and `JSON.parse` output typically
+  occupies 2–4× the JSON size as JS objects, so ~200–300MB of allocation from
+  `values` alone.
+- **`updates`** duplicates every node's output messages a third time.
+- **Reattach replays from `last_event_id=0`** (`use-durable-run.ts:75`), so
+  reconnecting to a long run re-parses the *entire* O(n²) event log in one burst —
+  the worst-case memory moment.
+
+The client genuinely needs: token deltas (`messages`), `__interrupt__` + `todos` +
+final state (`values`), and subagent lifecycle (`updates` namespaces). It does not
+need `files` in every intermediate snapshot, nor full message arrays in every
+`values` event — but the SDK replaces `values` wholesale, so trimming requires care
+(see recommendations).
+
+## Layer 3 — the chat page re-renders at token rate
+
+`useStream` is called **without the `throttle` option** (page.tsx:500), so the SDK's
+`useSyncExternalStore` subscription fires on *every* internal `setState` — at least
+once per SSE event, often more (subagent `bumpVersion`). The existing
+`useThrottledValue(…, 60)` (page.tsx:549, 612) only throttles *which data the
+children see*; **the 1,500-line `ChatPage` component itself still re-renders per
+token**, rebuilding the React element tree for the entire conversation each time.
+
+Additional per-render cost: `(thread as any).toolCalls` (page.tsx:610) is a getter
+that runs `getToolCallsWithResults()` over **all** messages — full scan + array/map
+allocation, per token.
+
+What's already good: `MessageResponse` is `memo`-ized with a `children` string
+comparator (message.tsx:121), so completed messages don't re-parse markdown;
+`ReasoningContent` is memoized; throttling caps Streamdown re-parses of the live
+message at ~16Hz.
+
+## Layer 4 — streamdown 1.6.11 (minor)
+
+The live message is re-parsed and every one of its blocks re-rendered at 16Hz while
+it streams. Streamdown 2.x is a rewrite:
+[2.5 — "Completed blocks no longer re-render when new streaming content arrives"](https://vercel.com/changelog/streamdown-2-5),
+[2.3 — code blocks render plain text before shiki loads](https://vercel.com/changelog/streamdown-2-3),
+[v2 — smaller bundle, plugin architecture](https://vercel.com/changelog/streamdown-v2).
+It's a major (plugin-based API) — check `Streamdown` props usage in `message.tsx` /
+`reasoning.tsx` during migration.
+
+## Library version audit
+
+| Package | Installed | Latest | Verdict |
+| --- | --- | --- | --- |
+| `@langchain/langgraph-sdk` | 1.7.5 | 1.10.0 | No perf/memory fixes in between; the per-token churn is unfixed upstream. Upgrade is safe but won't move the needle. (1.9.31 has an unrelated HITL-interrupt-after-reload fix we may want.) |
+| `streamdown` | 1.6.11 | 2.6.0 | **Worth upgrading** — 2.5 stops re-rendering completed blocks. Major-version migration. |
+| `@langchain/core` | 1.1.34 | 1.2.9 | No chunk-concat optimization found; upgrade neutral. |
+| `ai` / `@ai-sdk/react` | 6.0.67 / 3.0.63 | 7.x / 4.x | **Not on the streaming path** (type-only import). Irrelevant to this issue. |
+
+## Upstream landscape (langgraphjs issue sweep, 2026-09-01)
+
+Searched `langchain-ai/langgraphjs` issues/PRs for memory, re-render, throttle, and
+useStream performance. **No open issue covers our exact browser-side symptom on the
+legacy path, and no fix is coming to it** — but upstream has already solved the
+mechanism in a *new* React stack we don't use yet:
+
+- **The legacy path (ours)**: `@langchain/langgraph-sdk/react` `useStream` +
+  `FetchStreamTransport` (`dist/react/stream.custom.js`). Per-event
+  `notifyListeners` and per-token chunk merging are inherent to its `StreamManager`;
+  changelog through 1.10.0 has zero perf work. This is maintenance-mode code.
+- **The new stack**: [`@langchain/react`](https://github.com/langchain-ai/langgraphjs/tree/main/libs/sdk-react)
+  (v1.0.33, actively developed, used by LangChain's own open-swe UI). Full rewrite:
+  `StreamController` + `ChannelRegistry` + per-channel *projections* with selector
+  hooks (`useMessages`, `useToolCalls`, `useValues`) — only components subscribed to
+  a projection re-render, and store writes are **coalesced per macrotask**.
+  [PR #2387](https://github.com/langchain-ai/langgraphjs/pull/2387) fixed exactly our
+  failure mechanism there ("per-event `store.setState` calls fire
+  `useSyncExternalStore` notifications per event"; its regression test asserts a
+  200-delta burst produces <10 notifications). First-class subagent support
+  (`SubagentMap`, discovery snapshots) replaces `filterSubagentMessages`.
+- **The new wire format**: the new stack speaks the
+  [Agent Streaming Protocol](https://github.com/langchain-ai/agent-protocol)
+  (`@langchain/protocol`) — thread-centric, **delta-based** (`message-start`,
+  `text-delta`, `reasoning-delta`, `message-finish`, tool lifecycle events) with
+  seq-numbered replay. That eliminates both the `values` snapshot firehose *and*
+  per-token chunk-object merging at the protocol level. There are
+  [Python bindings + FastAPI server stubs](https://github.com/langchain-ai/agent-protocol)
+  (`py-langchain-protocol`), and our durable-run Redis event log with
+  `last_event_id` replay is architecturally aligned with the protocol's replay
+  contract — the migration is an event-format change, not an architecture change.
+  Frontend-side, `HttpAgentServerAdapter` targets exactly our shape (self-hosted
+  HTTP/SSE backend, custom paths, cookie/header auth via `fetch` override).
+- **Maturity caveats**: the custom-adapter path is young — open issue
+  [#2754](https://github.com/langchain-ai/langgraphjs/issues/2754) (2026-08-27,
+  self-hosted custom-transport `getHistory` goes out unauthenticated) and
+  [#2705](https://github.com/langchain-ai/langgraphjs/issues/2705) (the same
+  notification-storm class of bug in `useChannel` replay, closed 2026-08) show the
+  edges are still being sanded.
+
+**Conclusion**: the short-term app-side fixes below stand on their own — nothing
+upstream will rescue the legacy path. Medium-term, the durable answer is migrating
+to `@langchain/react` + Agent Streaming Protocol (backend emits protocol-v2 deltas
+from the run event log; frontend uses `HttpAgentServerAdapter` + selector hooks),
+which fixes all three layers by design. Worth a separate migration assessment once
+the custom-adapter issues settle.
+
+### Migration shape (assessed 2026-09-01)
+
+**No hand-written adapter is needed.** The stock `HttpAgentServerAdapter` is built
+for exactly our deployment ("point `useStream` at a single HTTP endpoint that
+speaks the v2 protocol"): it takes `paths` overrides (default
+`/threads/:threadId/{commands,stream,state}` — maps directly onto our
+`/api/backend` proxy routes), a `fetch` override (where our 409
+`model_unavailable` / `stale_interrupt` handling from `use-durable-run.ts` moves),
+and cookie auth rides along since the proxy is same-origin. A custom
+`AgentServerAdapter` would only be worth writing as a *client-side translator* of
+our legacy SSE — zero backend change, but it keeps the O(n²) `values` wire cost, so
+it's the worse half of the win. Since we own the backend, emit the protocol there.
+
+**What the backend takes.** The [Agent Streaming Protocol](https://github.com/langchain-ai/agent-protocol)
+maps ~1:1 onto machinery we already have:
+
+| Protocol requirement | What we already have |
+| --- | --- |
+| `POST /threads/{id}/stream` (filtered SSE) + `POST /threads/{id}/commands` + `GET /threads/{id}/state` | runs stream endpoint, cancel endpoint, thread GET |
+| `run.start` / cancel commands | `RunService.create` / cancel |
+| Ring-buffer replay, monotonic `seq`, client sends `since` | durable-run Redis event log + `last_event_id` replay |
+| HITL: `input.requested` event carries `interruptId`; client resumes with `input.respond` echoing it | checkpoint-keyed interrupt ids + stale-resume 409 (PR #307) — same design |
+| Channels: `messages` deltas (`message-start`/`content-block-delta`/…), `tools` lifecycle, `lifecycle`, optional `values`/`updates` | `LangGraphStreamAdapter` — this is the real work: rewrite it to emit protocol deltas instead of values snapshots |
+
+There is **no runtime Python server** for the protocol — only generated
+TypedDict/Literal payload typings (`py/` bindings) and FastAPI stubs
+auto-generated from the OpenAPI spec — so the astream→protocol translation in
+`stream.py` is hand-rolled (bounded: token deltas from `messages` mode, tool
+lifecycle from `updates`, subgraph namespaces we already emit).
+
+**What the frontend takes.** Add `@langchain/react@1.0.33` (+ `@langchain/protocol`
+typings; it brings its own compatible `@langchain/langgraph-sdk`), bump
+`@langchain/core` 1.1.34 → ≥1.1.48. Then rewrite the chat page's stream layer:
+`useStream({ transport: new HttpAgentServerAdapter(...) })` + selector hooks
+replace `thread.messages`/`toolCalls`/`interrupt`; `useThrottledValue` and most of
+`use-durable-run.ts` go away (protocol replay/reconnect is built in); the subagent
+components re-type from `@langchain/langgraph-sdk/ui`'s `SubagentStreamInterface`
+to the new `SubagentMap`/discovery snapshots; the `toSdkMessages` snake_case
+restoration hack likely dies too (the adapter's `getState` bypasses the axios
+interceptor). Caveat to re-check at migration time: open issue
+[#2754](https://github.com/langchain-ai/langgraphjs/issues/2754) — custom-adapter
+`getHistory` ignores `defaultHeaders`/`fetch` (used for subagent history
+hydration); likely survivable for us because auth is a same-origin cookie, but
+verify.
+
+Rough scope: one backend PR (protocol emitter + 3 endpoint shims, keeping legacy
+SSE for Slack/invoke), one frontend PR (chat page + subagent components). The
+legacy and new stacks can run side by side behind a route during the cutover.
+
+## Recommendations, in impact order
+
+1. **Stop per-token re-renders of `ChatPage`.** Two options:
+   - Try `throttle: true` in the `useStream` options — the SDK coalesces
+     notifications with a 0ms trailing timer, collapsing same-tick bursts to one
+     render per macrotask. (Avoid `throttle: <ms>` — the SDK's implementation is a
+     trailing *debounce*: under a continuous token flow faster than the interval it
+     would starve updates entirely until the stream pauses.)
+   - Or restructure: extract the conversation body into a `memo`-ized component fed
+     only the throttled `messages`/`toolCalls`, so the component that owns
+     `useStream` renders almost nothing itself.
+2. **Don't read `thread.toolCalls` on every render** — it's a full recompute. Derive
+   tool calls from the throttled messages via the existing
+   `computeToolCallsFromMessages` (already memoized) and drop the getter read, or
+   sample the getter inside the same throttle.
+3. **Trim the `values` firehose backend-side.** On the measured thread the cost is
+   the `messages` array re-sent in every snapshot (~83MB cumulative), not `files`
+   (empty there — still worth stripping for sandbox-heavy threads). The real cut —
+   dropping intermediate `messages` from `values` and letting the `messages` chunks
+   maintain the list — needs SDK-side care because `setStreamValues` replaces state
+   wholesale. Also consider replaying reattaches from a checkpoint instead of
+   `last_event_id=0`.
+4. **Upgrade streamdown to 2.6** for the completed-block re-render fix.
+5. **Verify empirically** (separate port 3100 per convention): stream a long
+   response with DevTools → Memory. Take a heap snapshot after the run + manual GC —
+   if retained heap drops to tens of MB, this confirms churn (not a leak) and the
+   fixes above are the right lever; the allocation-instrumentation timeline will
+   show the hot stacks (`concat`/`toDict` and React element creation).
+
+## Sources
+
+- [LangChain support: memory issues streaming tokens with deepagents/subagents](https://support.langchain.com/articles/8854872772-how-do-i-resolve-memory-issues-when-streaming-tokens-with-deepagents-and-subagents)
+- [Streamdown 2.5 changelog](https://vercel.com/changelog/streamdown-2-5) · [2.3](https://vercel.com/changelog/streamdown-2-3) · [v2](https://vercel.com/changelog/streamdown-v2) · [1.6](https://vercel.com/changelog/streamdown-1-6-is-now-available-to-run-faster-and-ship-less-code)
+- [langgraphjs releases](https://github.com/langchain-ai/langgraphjs/releases)
+- SDK internals read from `web/node_modules/@langchain/langgraph-sdk/dist/{react/stream.custom.js, ui/manager.js, ui/messages.js}` (v1.7.5)
+
+## Measured A/B results (2026-09-01, Part 1 quick fixes — PR #310)
+
+Method: `web/scripts/measure-stream-memory.mjs` (Playwright + CDP heap sampling
+at 250ms) against production builds — `main` (worktree, :3101) vs
+`perf/streaming-memory-quick-fixes` (:3100), same backend (:8000, branch code —
+`files` was empty on this thread so the values trim is not a factor here). Same
+thread (agent with 0 MCP servers, deepseek-v4-flash), same prompt, run order
+M-B-B-M so each build ran once early / once late as history grew. All four runs
+produced near-identical ~31.9K-char essays; pair 2 was also duration-matched
+(~37–38s).
+
+| run     | stream | PEAK heap | post-GC retained | script CPU | style recalcs |
+| ------- | ------ | --------- | ---------------- | ---------- | ------------- |
+| main    | 75.8s  | 164.1 MB  | 88.7 MB          | 6.8s       | 16,717        |
+| branch  | 38.3s  | 50.9 MB   | 22.1 MB          | 3.8s       | 9,224         |
+| branch2 | 36.9s  | 50.7 MB   | 22.8 MB          | 3.6s       | 8,834         |
+| main2   | 38.4s  | 123.8 MB  | 90.9 MB          | 5.1s       | 9,222         |
+
+- **Peak JS heap: 2.4–3.2× lower** on the branch (124–164 MB → ~51 MB), on a
+  *small* thread (single long text response, no subagents, no tool storm). The
+  1.5GB thread's costs are quadratic in conversation size, so the absolute gap
+  compounds there.
+- **Retained heap after GC: ~4× lower** (≈90 MB → ≈22 MB) — main holds ~90 MB
+  live after the stream ends (main2's *baseline* was already 84.8 MB right
+  after loading history); the branch settles at ~22 MB.
+- **Main-thread CPU ~30–45% lower** at matched duration (script 5.1s → 3.6s).
+- Time series JSONs: `web/scripts/out/mem-{main,branch,branch2,main2}-*.json`.
+
+Caveat: JS heap of the page, not full Task-Manager footprint; single thread,
+prompt mode only (reattach replay not yet measured). Build gotcha found on the
+way: `.next-mem/` (the isolated dist dir used for these builds) was not
+gitignored, so Tailwind v4's auto content detection scanned its minified build
+chunks and generated broken CSS ("Missed semicolon" at a moving column) —
+fixed by adding `.next-mem/` to the root `.gitignore`.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -53,7 +53,7 @@
 				"shiki": "^3.15.0",
 				"snakecase-keys": "^9.0.2",
 				"sonner": "^2.0.7",
-				"streamdown": "^1.6.10",
+				"streamdown": "^2.6.0",
 				"tailwind-merge": "^3.4.0",
 				"tokenlens": "^1.3.1",
 				"use-stick-to-bottom": "^1.1.1",
@@ -236,19 +236,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@antfu/install-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
-			"license": "MIT",
-			"dependencies": {
-				"package-manager-detector": "^1.3.0",
-				"tinyexec": "^1.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -552,12 +539,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@braintree/sanitize-url": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
-			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
-			"license": "MIT"
-		},
 		"node_modules/@bramus/specificity": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -576,12 +557,6 @@
 			"resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
 			"integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
 			"license": "MIT"
-		},
-		"node_modules/@chevrotain/types": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
-			"license": "Apache-2.0"
 		},
 		"node_modules/@csstools/color-helpers": {
 			"version": "6.0.2",
@@ -1019,23 +994,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
-			}
-		},
-		"node_modules/@iconify/types": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-			"license": "MIT"
-		},
-		"node_modules/@iconify/utils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
-			"integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
-			"license": "MIT",
-			"dependencies": {
-				"@antfu/install-pkg": "^1.1.0",
-				"@iconify/types": "^2.0.0",
-				"mlly": "^1.8.0"
 			}
 		},
 		"node_modules/@img/colour": {
@@ -1750,15 +1708,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/@mermaid-js/parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
-			"integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
-			"license": "MIT",
-			"dependencies": {
-				"@chevrotain/types": "~11.1.2"
 			}
 		},
 		"node_modules/@modelcontextprotocol/ext-apps": {
@@ -6904,100 +6853,10 @@
 				"assertion-error": "^2.0.1"
 			}
 		},
-		"node_modules/@types/d3": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-array": "*",
-				"@types/d3-axis": "*",
-				"@types/d3-brush": "*",
-				"@types/d3-chord": "*",
-				"@types/d3-color": "*",
-				"@types/d3-contour": "*",
-				"@types/d3-delaunay": "*",
-				"@types/d3-dispatch": "*",
-				"@types/d3-drag": "*",
-				"@types/d3-dsv": "*",
-				"@types/d3-ease": "*",
-				"@types/d3-fetch": "*",
-				"@types/d3-force": "*",
-				"@types/d3-format": "*",
-				"@types/d3-geo": "*",
-				"@types/d3-hierarchy": "*",
-				"@types/d3-interpolate": "*",
-				"@types/d3-path": "*",
-				"@types/d3-polygon": "*",
-				"@types/d3-quadtree": "*",
-				"@types/d3-random": "*",
-				"@types/d3-scale": "*",
-				"@types/d3-scale-chromatic": "*",
-				"@types/d3-selection": "*",
-				"@types/d3-shape": "*",
-				"@types/d3-time": "*",
-				"@types/d3-time-format": "*",
-				"@types/d3-timer": "*",
-				"@types/d3-transition": "*",
-				"@types/d3-zoom": "*"
-			}
-		},
-		"node_modules/@types/d3-array": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-axis": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-brush": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-selection": "*"
-			}
-		},
-		"node_modules/@types/d3-chord": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-			"license": "MIT"
-		},
 		"node_modules/@types/d3-color": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
 			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-contour": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-array": "*",
-				"@types/geojson": "*"
-			}
-		},
-		"node_modules/@types/d3-delaunay": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-dispatch": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-drag": {
@@ -7009,54 +6868,6 @@
 				"@types/d3-selection": "*"
 			}
 		},
-		"node_modules/@types/d3-dsv": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-ease": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-fetch": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-dsv": "*"
-			}
-		},
-		"node_modules/@types/d3-force": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-format": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-geo": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/geojson": "*"
-			}
-		},
-		"node_modules/@types/d3-hierarchy": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-			"license": "MIT"
-		},
 		"node_modules/@types/d3-interpolate": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -7066,76 +6877,10 @@
 				"@types/d3-color": "*"
 			}
 		},
-		"node_modules/@types/d3-path": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-polygon": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-quadtree": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-random": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-			"integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-scale": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-time": "*"
-			}
-		},
-		"node_modules/@types/d3-scale-chromatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-			"license": "MIT"
-		},
 		"node_modules/@types/d3-selection": {
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
 			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-shape": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/d3-path": "*"
-			}
-		},
-		"node_modules/@types/d3-time": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-time-format": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-			"license": "MIT"
-		},
-		"node_modules/@types/d3-timer": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-transition": {
@@ -7188,12 +6933,6 @@
 				"@types/estree": "*"
 			}
 		},
-		"node_modules/@types/geojson": {
-			"version": "7946.0.16",
-			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-			"license": "MIT"
-		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -7214,12 +6953,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/katex": {
-			"version": "0.16.8",
-			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
-			"integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/mdast": {
@@ -7265,13 +6998,6 @@
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
-		},
-		"node_modules/@types/trusted-types": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
@@ -7823,16 +7549,6 @@
 				"win32"
 			]
 		},
-		"node_modules/@upsetjs/venn.js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
-			"integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"d3-selection": "^3.0.0",
-				"d3-transition": "^3.0.1"
-			}
-		},
 		"node_modules/@vercel/oidc": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
@@ -8083,6 +7799,7 @@
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -8989,26 +8706,11 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/commander": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/confbox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
 			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
@@ -9075,15 +8777,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/cose-base": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
-			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
-			"license": "MIT",
-			"dependencies": {
-				"layout-base": "^1.0.0"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -9125,173 +8818,11 @@
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
-		"node_modules/cytoscape": {
-			"version": "3.34.1",
-			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
-			"integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/cytoscape-cose-bilkent": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
-			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-			"license": "MIT",
-			"dependencies": {
-				"cose-base": "^1.0.0"
-			},
-			"peerDependencies": {
-				"cytoscape": "^3.2.0"
-			}
-		},
-		"node_modules/cytoscape-fcose": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-			"license": "MIT",
-			"dependencies": {
-				"cose-base": "^2.2.0"
-			},
-			"peerDependencies": {
-				"cytoscape": "^3.2.0"
-			}
-		},
-		"node_modules/cytoscape-fcose/node_modules/cose-base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-			"license": "MIT",
-			"dependencies": {
-				"layout-base": "^2.0.0"
-			}
-		},
-		"node_modules/cytoscape-fcose/node_modules/layout-base": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-			"license": "MIT"
-		},
-		"node_modules/d3": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "3",
-				"d3-axis": "3",
-				"d3-brush": "3",
-				"d3-chord": "3",
-				"d3-color": "3",
-				"d3-contour": "4",
-				"d3-delaunay": "6",
-				"d3-dispatch": "3",
-				"d3-drag": "3",
-				"d3-dsv": "3",
-				"d3-ease": "3",
-				"d3-fetch": "3",
-				"d3-force": "3",
-				"d3-format": "3",
-				"d3-geo": "3",
-				"d3-hierarchy": "3",
-				"d3-interpolate": "3",
-				"d3-path": "3",
-				"d3-polygon": "3",
-				"d3-quadtree": "3",
-				"d3-random": "3",
-				"d3-scale": "4",
-				"d3-scale-chromatic": "3",
-				"d3-selection": "3",
-				"d3-shape": "3",
-				"d3-time": "3",
-				"d3-time-format": "4",
-				"d3-timer": "3",
-				"d3-transition": "3",
-				"d3-zoom": "3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-array": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-			"license": "ISC",
-			"dependencies": {
-				"internmap": "1 - 2"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-axis": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-brush": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dispatch": "1 - 3",
-				"d3-drag": "2 - 3",
-				"d3-interpolate": "1 - 3",
-				"d3-selection": "3",
-				"d3-transition": "3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-chord": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-path": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/d3-color": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
 			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
 			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-contour": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-delaunay": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-			"license": "ISC",
-			"dependencies": {
-				"delaunator": "5"
-			},
 			"engines": {
 				"node": ">=12"
 			}
@@ -9318,101 +8849,11 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/d3-dsv": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-			"license": "ISC",
-			"dependencies": {
-				"commander": "7",
-				"iconv-lite": "0.6",
-				"rw": "1"
-			},
-			"bin": {
-				"csv2json": "bin/dsv2json.js",
-				"csv2tsv": "bin/dsv2dsv.js",
-				"dsv2dsv": "bin/dsv2dsv.js",
-				"dsv2json": "bin/dsv2json.js",
-				"json2csv": "bin/json2dsv.js",
-				"json2dsv": "bin/json2dsv.js",
-				"json2tsv": "bin/json2dsv.js",
-				"tsv2csv": "bin/dsv2dsv.js",
-				"tsv2json": "bin/dsv2json.js"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-dsv/node_modules/commander": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/d3-ease": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
 			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
 			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-fetch": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dsv": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-force": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-dispatch": "1 - 3",
-				"d3-quadtree": "1 - 3",
-				"d3-timer": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-format": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-geo": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2.5.0 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-hierarchy": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-			"license": "ISC",
 			"engines": {
 				"node": ">=12"
 			}
@@ -9429,152 +8870,11 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/d3-path": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-polygon": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-quadtree": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-random": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-sankey": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
-			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"d3-array": "1 - 2",
-				"d3-shape": "^1.2.0"
-			}
-		},
-		"node_modules/d3-sankey/node_modules/d3-array": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"internmap": "^1.0.0"
-			}
-		},
-		"node_modules/d3-sankey/node_modules/d3-path": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/d3-sankey/node_modules/d3-shape": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"d3-path": "1"
-			}
-		},
-		"node_modules/d3-sankey/node_modules/internmap": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-			"license": "ISC"
-		},
-		"node_modules/d3-scale": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2.10.0 - 3",
-				"d3-format": "1 - 3",
-				"d3-interpolate": "1.2.0 - 3",
-				"d3-time": "2.1.1 - 3",
-				"d3-time-format": "2 - 4"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-scale-chromatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-color": "1 - 3",
-				"d3-interpolate": "1 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/d3-selection": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-shape": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-path": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-time": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-array": "2 - 3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/d3-time-format": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-			"license": "ISC",
-			"dependencies": {
-				"d3-time": "1 - 3"
-			},
 			"engines": {
 				"node": ">=12"
 			}
@@ -9621,16 +8921,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/dagre-d3-es": {
-			"version": "7.0.14",
-			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
-			"integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
-			"license": "MIT",
-			"dependencies": {
-				"d3": "^7.9.0",
-				"lodash-es": "^4.17.21"
 			}
 		},
 		"node_modules/damerau-levenshtein": {
@@ -9707,12 +8997,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/dayjs": {
-			"version": "1.11.23",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
-			"integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
-			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -9803,15 +9087,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/delaunator": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-			"license": "ISC",
-			"dependencies": {
-				"robust-predicates": "^3.0.2"
-			}
-		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -9887,15 +9162,6 @@
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/dompurify": {
-			"version": "3.4.14",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
-			"integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"optionalDependencies": {
-				"@types/trusted-types": "^2.0.7"
-			}
 		},
 		"node_modules/dotenv": {
 			"version": "17.2.3",
@@ -10246,18 +9512,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-toolkit": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.51.0.tgz",
-			"integrity": "sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==",
-			"license": "MIT",
-			"workspaces": [
-				"docs",
-				"benchmarks",
-				"tests/types",
-				"tests/browser-compat"
-			]
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -10936,15 +10190,6 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/fastdom": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
-			"integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
-			"license": "MIT",
-			"dependencies": {
-				"strictdom": "^1.0.1"
-			}
-		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -11244,18 +10489,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/get-east-asian-width": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/get-intrinsic": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -11395,12 +10628,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/hachure-fill": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
-			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-			"license": "MIT"
-		},
 		"node_modules/has-bigints": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -11492,62 +10719,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/hast": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hast/-/hast-1.0.0.tgz",
-			"integrity": "sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==",
-			"deprecated": "Renamed to rehype",
-			"license": "MIT"
-		},
-		"node_modules/hast-util-from-dom": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
-			"integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
-			"license": "ISC",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"hastscript": "^9.0.0",
-				"web-namespaces": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-from-html": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-			"integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"devlop": "^1.1.0",
-				"hast-util-from-parse5": "^8.0.0",
-				"parse5": "^7.0.0",
-				"vfile": "^6.0.0",
-				"vfile-message": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-from-html-isomorphic": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
-			"integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"hast-util-from-dom": "^5.0.0",
-				"hast-util-from-html": "^2.0.0",
-				"unist-util-remove-position": "^5.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/hast-util-from-parse5": {
 			"version": "8.0.3",
 			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
@@ -11562,19 +10733,6 @@
 				"vfile": "^6.0.0",
 				"vfile-location": "^5.0.0",
 				"web-namespaces": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-is-element": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-			"integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11703,22 +10861,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/hast-util-to-text": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-			"integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/unist": "^3.0.0",
-				"hast-util-is-element": "^3.0.0",
-				"unist-util-find-after": "^5.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/hast-util-whitespace": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -11841,18 +10983,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -11925,15 +11055,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/internmap": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/ip-address": {
@@ -12691,22 +11812,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/katex": {
-			"version": "0.16.47",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-			"integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-			"funding": [
-				"https://opencollective.com/katex",
-				"https://github.com/sponsors/katex"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"commander": "^8.3.0"
-			},
-			"bin": {
-				"katex": "cli.js"
-			}
-		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -12716,11 +11821,6 @@
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
-		},
-		"node_modules/khroma": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
 		},
 		"node_modules/knip": {
 			"version": "6.14.1",
@@ -12858,12 +11958,6 @@
 			"engines": {
 				"node": ">=0.10"
 			}
-		},
-		"node_modules/layout-base": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
-			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-			"license": "MIT"
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
@@ -13216,12 +12310,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lodash-es": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-			"license": "MIT"
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13314,9 +12402,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "16.4.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+			"version": "17.0.6",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+			"integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
@@ -13481,25 +12569,6 @@
 				"devlop": "^1.0.0",
 				"mdast-util-from-markdown": "^2.0.0",
 				"mdast-util-to-markdown": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-math": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
-			"integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"devlop": "^1.0.0",
-				"longest-streak": "^3.0.0",
-				"mdast-util-from-markdown": "^2.0.0",
-				"mdast-util-to-markdown": "^2.1.0",
-				"unist-util-remove-position": "^5.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -13687,36 +12756,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/mermaid": {
-			"version": "11.17.0",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.0.tgz",
-			"integrity": "sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==",
-			"license": "MIT",
-			"dependencies": {
-				"@braintree/sanitize-url": "^7.1.2",
-				"@iconify/utils": "^3.0.2",
-				"@mermaid-js/parser": "^1.2.1",
-				"@types/d3": "^7.4.3",
-				"@upsetjs/venn.js": "^2.0.0",
-				"cytoscape": "^3.34.0",
-				"cytoscape-cose-bilkent": "^4.1.0",
-				"cytoscape-fcose": "^2.2.0",
-				"d3": "^7.9.0",
-				"d3-sankey": "^0.12.3",
-				"dagre-d3-es": "7.0.14",
-				"dayjs": "^1.11.21",
-				"dompurify": "^3.3.3",
-				"es-toolkit": "^1.45.1",
-				"fastdom": "1.0.12",
-				"katex": "^0.16.47",
-				"khroma": "^2.1.0",
-				"marked": "^16.3.0",
-				"roughjs": "^4.6.6",
-				"stylis": "^4.3.6",
-				"ts-dedent": "^2.2.0",
-				"uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
-			}
-		},
 		"node_modules/micromark": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -13784,77 +12823,6 @@
 				"micromark-util-subtokenize": "^2.0.0",
 				"micromark-util-symbol": "^2.0.0",
 				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-extension-cjk-friendly": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-1.2.3.tgz",
-			"integrity": "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q==",
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.1.0",
-				"micromark-extension-cjk-friendly-util": "2.1.1",
-				"micromark-util-chunked": "^2.0.1",
-				"micromark-util-resolve-all": "^2.0.1",
-				"micromark-util-symbol": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"micromark": "^4.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"peerDependenciesMeta": {
-				"micromark-util-types": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/micromark-extension-cjk-friendly-gfm-strikethrough": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-gfm-strikethrough/-/micromark-extension-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
-			"integrity": "sha512-gSPnxgHDDqXYOBvQRq6lerrq9mjDhdtKn+7XETuXjxWcL62yZEfUdA28Ml1I2vDIPfAOIKLa0h2XDSGkInGHFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"devlop": "^1.1.0",
-				"get-east-asian-width": "^1.3.0",
-				"micromark-extension-cjk-friendly-util": "2.1.1",
-				"micromark-util-character": "^2.1.1",
-				"micromark-util-chunked": "^2.0.1",
-				"micromark-util-resolve-all": "^2.0.1",
-				"micromark-util-symbol": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"micromark": "^4.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"peerDependenciesMeta": {
-				"micromark-util-types": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/micromark-extension-cjk-friendly-util": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-2.1.1.tgz",
-			"integrity": "sha512-egs6+12JU2yutskHY55FyR48ZiEcFOJFyk9rsiyIhcJ6IvWB6ABBqVrBw8IobqJTDZ/wdSr9eoXDPb5S2nW1bg==",
-			"license": "MIT",
-			"dependencies": {
-				"get-east-asian-width": "^1.3.0",
-				"micromark-util-character": "^2.1.1",
-				"micromark-util-symbol": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependenciesMeta": {
-				"micromark-util-types": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/micromark-extension-gfm": {
@@ -13968,25 +12936,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"devlop": "^1.0.0",
-				"micromark-factory-space": "^2.0.0",
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/micromark-extension-math": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
-			"integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/katex": "^0.16.0",
-				"devlop": "^1.0.0",
-				"katex": "^0.16.0",
 				"micromark-factory-space": "^2.0.0",
 				"micromark-util-character": "^2.0.0",
 				"micromark-util-symbol": "^2.0.0",
@@ -14436,18 +13385,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/mlly": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.15.0",
-				"pathe": "^2.0.3",
-				"pkg-types": "^1.3.1",
-				"ufo": "^1.6.1"
 			}
 		},
 		"node_modules/motion": {
@@ -15035,12 +13972,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/package-manager-detector": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-			"license": "MIT"
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15100,12 +14031,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/path-data-parser": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
-			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-			"license": "MIT"
-		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -15146,6 +14071,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/picocolors": {
@@ -15174,17 +14100,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/pkg-types": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-			"license": "MIT",
-			"dependencies": {
-				"confbox": "^0.1.8",
-				"mlly": "^1.7.4",
-				"pathe": "^2.0.1"
 			}
 		},
 		"node_modules/playwright": {
@@ -15232,22 +14147,6 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/points-on-curve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
-			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-			"license": "MIT"
-		},
-		"node_modules/points-on-path": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
-			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-			"license": "MIT",
-			"dependencies": {
-				"path-data-parser": "0.1.0",
-				"points-on-curve": "0.2.0"
 			}
 		},
 		"node_modules/possible-typed-array-names": {
@@ -15946,31 +14845,12 @@
 			}
 		},
 		"node_modules/rehype-harden": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/rehype-harden/-/rehype-harden-1.1.7.tgz",
-			"integrity": "sha512-j5DY0YSK2YavvNGV+qBHma15J9m0WZmRe8posT5AtKDS6TNWtMVTo6RiqF8SidfcASYz8f3k2J/1RWmq5zTXUw==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/rehype-harden/-/rehype-harden-1.1.8.tgz",
+			"integrity": "sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==",
 			"license": "MIT",
 			"dependencies": {
 				"unist-util-visit": "^5.0.0"
-			}
-		},
-		"node_modules/rehype-katex": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
-			"integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/katex": "^0.16.0",
-				"hast-util-from-html-isomorphic": "^2.0.0",
-				"hast-util-to-text": "^4.0.0",
-				"katex": "^0.16.0",
-				"unist-util-visit-parents": "^6.0.0",
-				"vfile": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/rehype-raw": {
@@ -16017,48 +14897,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/remark-cjk-friendly": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-1.2.3.tgz",
-			"integrity": "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g==",
-			"license": "MIT",
-			"dependencies": {
-				"micromark-extension-cjk-friendly": "1.2.3"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"@types/mdast": "^4.0.0",
-				"unified": "^11.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/mdast": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/remark-cjk-friendly-gfm-strikethrough": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/remark-cjk-friendly-gfm-strikethrough/-/remark-cjk-friendly-gfm-strikethrough-1.2.3.tgz",
-			"integrity": "sha512-bXfMZtsaomK6ysNN/UGRIcasQAYkC10NtPmP0oOHOV8YOhA2TXmwRXCku4qOzjIFxAPfish5+XS0eIug2PzNZA==",
-			"license": "MIT",
-			"dependencies": {
-				"micromark-extension-cjk-friendly-gfm-strikethrough": "1.2.3"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"@types/mdast": "^4.0.0",
-				"unified": "^11.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/mdast": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/remark-gfm": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -16070,22 +14908,6 @@
 				"micromark-extension-gfm": "^3.0.0",
 				"remark-parse": "^11.0.0",
 				"remark-stringify": "^11.0.0",
-				"unified": "^11.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-math": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
-			"integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/mdast": "^4.0.0",
-				"mdast-util-math": "^3.0.0",
-				"micromark-extension-math": "^3.0.0",
 				"unified": "^11.0.0"
 			},
 			"funding": {
@@ -16142,9 +14964,9 @@
 			}
 		},
 		"node_modules/remend": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/remend/-/remend-1.0.1.tgz",
-			"integrity": "sha512-152puVH0qMoRJQFnaMG+rVDdf01Jq/CaED+MBuXExurJgdbkLp0c3TIe4R12o28Klx8uyGsjvFNG05aFG69G9w==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/remend/-/remend-1.3.1.tgz",
+			"integrity": "sha512-N3DiY5qbRPoa5vkxn1oDLMyXOVTeo6Hp+XOj6SIqJAYUgLS0Q587gILPMom/qm86AQ/ZrcOdwEIzCz8V3J0nxQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/require-from-string": {
@@ -16208,12 +15030,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/robust-predicates": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-			"license": "Unlicense"
-		},
 		"node_modules/rolldown": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
@@ -16275,18 +15091,6 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
-		"node_modules/roughjs": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
-			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-			"license": "MIT",
-			"dependencies": {
-				"hachure-fill": "^0.5.2",
-				"path-data-parser": "^0.1.0",
-				"points-on-curve": "^0.2.0",
-				"points-on-path": "^0.2.1"
-			}
-		},
 		"node_modules/router": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -16326,12 +15130,6 @@
 			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
-		},
-		"node_modules/rw": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.3",
@@ -16852,53 +15650,31 @@
 			}
 		},
 		"node_modules/streamdown": {
-			"version": "1.6.11",
-			"resolved": "https://registry.npmjs.org/streamdown/-/streamdown-1.6.11.tgz",
-			"integrity": "sha512-Y38fwRx5kCKTluwM+Gf27jbbi9q6Qy+WC9YrC1YbCpMkktT3PsRBJHMWiqYeF8y/JzLpB1IzDoeaB6qkQEDnAA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/streamdown/-/streamdown-2.6.0.tgz",
+			"integrity": "sha512-nQZVUn4GvB2R5SAlDNph20iKZeW+RM4gv6G1H3ACypEnmQf8PgTHZ/1Ta2OACRwQ2coK7aW5AeIAa7Ls5zk+RA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"clsx": "^2.1.1",
-				"hast": "^1.0.0",
 				"hast-util-to-jsx-runtime": "^2.3.6",
 				"html-url-attributes": "^3.0.1",
-				"katex": "^0.16.22",
-				"lucide-react": "^0.542.0",
-				"marked": "^16.2.1",
-				"mermaid": "^11.11.0",
-				"rehype-harden": "^1.1.6",
-				"rehype-katex": "^7.0.1",
+				"marked": "^17.0.1",
+				"rehype-harden": "^1.1.8",
 				"rehype-raw": "^7.0.0",
 				"rehype-sanitize": "^6.0.0",
-				"remark-cjk-friendly": "^1.2.3",
-				"remark-cjk-friendly-gfm-strikethrough": "^1.2.3",
 				"remark-gfm": "^4.0.1",
-				"remark-math": "^6.0.0",
 				"remark-parse": "^11.0.0",
 				"remark-rehype": "^11.1.2",
-				"remend": "1.0.1",
-				"shiki": "^3.12.2",
-				"tailwind-merge": "^3.3.1",
+				"remend": "1.3.1",
+				"tailwind-merge": "^3.6.0",
 				"unified": "^11.0.5",
-				"unist-util-visit": "^5.0.0"
+				"unist-util-visit": "^5.1.0",
+				"unist-util-visit-parents": "^6.0.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0 || ^19.0.0"
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			}
-		},
-		"node_modules/streamdown/node_modules/lucide-react": {
-			"version": "0.542.0",
-			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
-			"integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
-			"license": "ISC",
-			"peerDependencies": {
-				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/strictdom": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
-			"integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
-			"license": "MIT"
 		},
 		"node_modules/string.prototype.includes": {
 			"version": "2.0.1",
@@ -17104,12 +15880,6 @@
 				}
 			}
 		},
-		"node_modules/stylis": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-			"integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-			"license": "MIT"
-		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -17169,9 +15939,9 @@
 			}
 		},
 		"node_modules/tailwind-merge": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
-			"integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+			"integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -17222,6 +15992,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
 			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -17396,15 +16167,6 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=4.8.4"
-			}
-		},
-		"node_modules/ts-dedent": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
-			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.10"
 			}
 		},
 		"node_modules/tsconfig-paths": {
@@ -17649,12 +16411,6 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/ufo": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-			"license": "MIT"
-		},
 		"node_modules/unbash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
@@ -17720,20 +16476,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/unist-util-find-after": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-			"integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-is": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/unist-util-is": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -17754,20 +16496,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-remove-position": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-			"integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-visit": "^5.0.0"
 			},
 			"funding": {
 				"type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -62,7 +62,7 @@
 		"shiki": "^3.15.0",
 		"snakecase-keys": "^9.0.2",
 		"sonner": "^2.0.7",
-		"streamdown": "^1.6.10",
+		"streamdown": "^2.6.0",
 		"tailwind-merge": "^3.4.0",
 		"tokenlens": "^1.3.1",
 		"use-stick-to-bottom": "^1.1.1",

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
@@ -92,7 +92,7 @@ export type ConversationBodyProps = {
   isLoading: boolean;
   isInterrupted: boolean;
   hitlToolNames: Set<string> | null;
-  decisions: Record<string, HitlDecision>;
+  decisions: Partial<Record<string, HitlDecision>>;
   recordDecision: (toolCallId: string, decision: HitlDecision) => void;
   modelUnavailable: boolean;
   onRegenerate: () => void;
@@ -385,11 +385,12 @@ export const ConversationBody = memo(function ConversationBody({
             (s) => s.kind === "tool" && !isTaskCall(s.tc),
           ).length;
           const subagentCount = chainSteps.length - toolCount;
+          // Last visible message: nothing after it, or only tool results
+          // (tool messages render via the chain, not as bubbles — parallel
+          // tool calls can leave several of them trailing).
           const isLastMessage =
             messageIndex === messages.length - 1 ||
-            // Last AI message before a potential loading indicator
-            (messageIndex === messages.length - 2 &&
-              messages[messages.length - 1]?.type === "tool");
+            messages.slice(messageIndex + 1).every((m) => m.type === "tool");
           const isLastAiMessage = !isLoading && isLastMessage && text.length > 0;
 
           return (
@@ -423,9 +424,11 @@ export const ConversationBody = memo(function ConversationBody({
                             subagent={sub}
                             mcpServers={mcpServers}
                             agent={findAgentForSubagentType(
-                              sub.toolCall?.args?.subagent_type as
-                                | string
-                                | undefined,
+                              (
+                                sub.toolCall as
+                                  | { args?: Record<string, unknown> }
+                                  | undefined
+                              )?.args?.subagent_type as string | undefined,
                             )}
                             onOpen={
                               sub.messages.length === 0 &&
@@ -674,7 +677,6 @@ export const ConversationBody = memo(function ConversationBody({
 
       {/* Streaming indicator when AI has started but text is still coming */}
       {assistantIsStreaming &&
-        lastMsg !== null &&
         getTextContent(lastMsg).length === 0 &&
         !getToolCallsForMessage(lastMsg).length && (
           <div>

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
@@ -1,0 +1,707 @@
+"use client";
+
+import { Fragment, memo, useCallback, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import {
+  MessageActions,
+  MessageAction,
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+import {
+  Reasoning,
+  ReasoningTrigger,
+  ReasoningContent,
+} from "@/components/ai-elements/reasoning";
+import {
+  ChainOfThought,
+  ChainStep,
+  ChainStepIcon,
+  NeedsApprovalBadge,
+  StepCode,
+  StepSection,
+  TERMINAL_ICON,
+  humanizeToolName,
+  isSandboxTool,
+  summarizeToolArgs,
+} from "@/components/ai-elements/chain-of-thought";
+import { AgentAvatar } from "@/components/ui/agent-avatar";
+import {
+  Error,
+  ErrorContent,
+  ErrorDetails,
+} from "@/components/ai-elements/error";
+import {
+  Attachment,
+  AttachmentPreview,
+  AttachmentHoverCard,
+  AttachmentHoverCardTrigger,
+  AttachmentInfo,
+  AttachmentHoverCardContent,
+  getMediaCategory,
+  getAttachmentLabel,
+  Attachments,
+} from "@/components/ai-elements/attachments";
+import {
+  SubAgentCard,
+  SubAgentProgress,
+  SynthesisIndicator,
+} from "@/components/ai-elements/subagent";
+import { TodoList } from "@/components/ai-elements/todo-list";
+import type { Todo } from "@/components/ai-elements/todo-list";
+import { extractToolErrorText } from "@/lib/utils/tool-content";
+import { cn } from "@/lib/utils";
+import { api } from "@/lib/api/client";
+import { useMcpServersStore } from "@/stores/mcp-servers-store";
+import { useAgentsStore } from "@/stores/agents-store";
+import type { HitlDecision } from "@/hooks/use-hitl-approvals";
+import {
+  RefreshCcwIcon,
+  CopyIcon,
+  Loader2,
+  XCircleIcon,
+} from "lucide-react";
+import { ThinkingLoader } from "../components/loader";
+import { McpAppWidget } from "../components/mcp-app-widget";
+import {
+  type ChainStepData,
+  type LCMessage,
+  type LocalToolCall,
+  type SubagentData,
+  getFileAttachments,
+  getMcpAppInfoFromToolCall,
+  getReasoningContent,
+  getStructuredContentFromToolCall,
+  getTextContent,
+  getToolMetadata,
+  getToolOutputContent,
+  getToolRenderState,
+  sanitizeToolIdentifier,
+} from "./message-helpers";
+
+export type ConversationBodyProps = {
+  threadId: string;
+  /** Throttled stream messages (or initial history when idle). */
+  messages: LCMessage[];
+  /** Tool calls derived (memoized) from `messages`. */
+  toolCalls: LocalToolCall[];
+  /** Stable wrapper around the SDK's subagent lookup. */
+  getSubagentsByMessage: (messageId: string) => SubagentData[];
+  supervisorTodos: Todo[];
+  isLoading: boolean;
+  isInterrupted: boolean;
+  hitlToolNames: Set<string> | null;
+  decisions: Record<string, HitlDecision>;
+  recordDecision: (toolCallId: string, decision: HitlDecision) => void;
+  modelUnavailable: boolean;
+  onRegenerate: () => void;
+  error: unknown;
+  rehydratedError: string | null;
+  /**
+   * Bumped (throttled, ~16Hz) on stream notifications that change no other
+   * prop — subagent token streams only mutate SDK-internal state — so this
+   * memoized body still re-renders to show them. Not read; its only job is
+   * to break the memo comparison.
+   */
+  streamTick: number;
+};
+
+/**
+ * The conversation render tree, extracted from ChatPage and memoized so the
+ * component that owns `useStream` (notified per SSE event) renders almost
+ * nothing itself. All props are either throttled (~16Hz) or identity-stable
+ * between stream events, which bounds how often this (large) tree rebuilds.
+ */
+export const ConversationBody = memo(function ConversationBody({
+  threadId,
+  messages,
+  toolCalls,
+  getSubagentsByMessage,
+  supervisorTodos,
+  isLoading,
+  isInterrupted,
+  hitlToolNames,
+  decisions,
+  recordDecision,
+  modelUnavailable,
+  onRegenerate,
+  error,
+  rehydratedError,
+}: ConversationBodyProps) {
+  const { mcpServers } = useMcpServersStore();
+  const workspaceAgents = useAgentsStore((s) => s.agents);
+
+  // Subagent internal conversations restored from subgraph checkpoints on
+  // refresh, keyed by tool_call_id. The SDK's custom transport doesn't expose a
+  // way to inject these into the reconstructed subagents, so we hold them here
+  // and pass them to SubAgentCard as a fallback.
+  const [subagentMessages, setSubagentMessages] = useState<
+    Record<string, unknown[]>
+  >({});
+  const fetchedSubagentHistory = useRef(new Set<string>());
+
+  const loadSubagentHistory = useCallback(
+    async (toolCallId: string) => {
+      const key = `${threadId}:${toolCallId}`;
+      if (fetchedSubagentHistory.current.has(key)) return;
+      fetchedSubagentHistory.current.add(key);
+
+      try {
+        const res = await api.get(
+          `/threads/${threadId}/subagents/${toolCallId}/state`,
+        );
+        const msgs = res.data?.messages;
+        if (Array.isArray(msgs) && msgs.length > 0) {
+          setSubagentMessages((prev) => ({ ...prev, [toolCallId]: msgs }));
+        }
+      } catch {
+        // Allow a later open to retry a transient failure.
+        fetchedSubagentHistory.current.delete(key);
+      }
+    },
+    [threadId],
+  );
+
+  const knownServerNames = useMemo(
+    () =>
+      [...mcpServers.map((server) => server.name)].sort(
+        (a, b) => b.length - a.length,
+      ),
+    [mcpServers],
+  );
+
+  // Resolve a subagent_type (sanitize_tool_name(agent.name) backend-side)
+  // back to the workspace agent, for its emoji/pastel tile in chain steps.
+  const findAgentForSubagentType = useCallback(
+    (subagentType: string | undefined) => {
+      if (!subagentType) return undefined;
+      return (
+        workspaceAgents.find(
+          (a) => sanitizeToolIdentifier(a.name) === subagentType,
+        ) ??
+        workspaceAgents.find(
+          (a) =>
+            a.name.toLowerCase() ===
+            subagentType.replaceAll("_", " ").toLowerCase(),
+        )
+      );
+    },
+    [workspaceAgents],
+  );
+
+  // Index tool calls by AI message id once per render, so the inner map can
+  // look them up in O(1) instead of filtering the full list per message.
+  const toolCallsByMessageId = useMemo(() => {
+    const map = new Map<string, LocalToolCall[]>();
+    for (const tc of toolCalls) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const id = (tc.aiMessage as any)?.id as string | undefined;
+      if (!id || !tc.call.name) continue;
+      const existing = map.get(id);
+      if (existing) existing.push(tc);
+      else map.set(id, [tc]);
+    }
+    return map;
+  }, [toolCalls]);
+
+  const getToolCallsForMessage = useCallback(
+    (message: LCMessage) => {
+      if (!message.id) return [];
+      return toolCallsByMessageId.get(message.id) ?? [];
+    },
+    [toolCallsByMessageId],
+  );
+
+  // Loading state detection
+  const lastMsg = messages.length > 0 ? messages[messages.length - 1] : null;
+  const isAwaitingResponse =
+    isLoading &&
+    lastMsg != null &&
+    (lastMsg.type === "human" || lastMsg.type === "user");
+
+  const assistantIsStreaming =
+    isLoading &&
+    lastMsg != null &&
+    (lastMsg.type === "ai" || lastMsg.type === "assistant");
+
+  // ---- Chain-of-thought grouping ----
+  // One timeline per run of *consecutive* tool work: steps from adjacent AI
+  // messages merge into the run's first step-bearing AI message, but any
+  // assistant text ends the run — a message's own steps render above its
+  // text, and tool calls after the text start a new chain below it. Task
+  // tool calls pair with their SDK subagent stream by id, preserving the
+  // original tool_call order.
+  const chainByOwner = new Map<string, ChainStepData[]>();
+  {
+    let turnOwner: string | null = null;
+    for (const m of messages) {
+      if (m.type === "human" || m.type === "user") {
+        turnOwner = null;
+        continue;
+      }
+      if ((m.type !== "ai" && m.type !== "assistant") || !m.id) continue;
+      const hasText = getTextContent(m).trim().length > 0;
+      const tcs = getToolCallsForMessage(m);
+      const subs = getSubagentsByMessage(m.id);
+      if (tcs.length === 0 && subs.length === 0) {
+        if (hasText) turnOwner = null;
+        continue;
+      }
+
+      const subById = new Map(subs.map((s) => [s.id, s]));
+      const paired = new Set<string>();
+      const steps: ChainStepData[] = [];
+      for (const tc of tcs) {
+        const sub = subById.get(tc.id);
+        if (sub) {
+          steps.push({ kind: "subagent", sub });
+          paired.add(sub.id);
+        } else {
+          steps.push({ kind: "tool", tc });
+        }
+      }
+      for (const sub of subs) {
+        if (!paired.has(sub.id)) steps.push({ kind: "subagent", sub });
+      }
+
+      if (turnOwner == null) {
+        turnOwner = m.id;
+        chainByOwner.set(m.id, steps);
+      } else {
+        chainByOwner.get(turnOwner)?.push(...steps);
+      }
+      // The message's text renders below its steps — anything after it
+      // belongs to a fresh chain.
+      if (hasText) turnOwner = null;
+    }
+  }
+
+  // ---- Render ----
+
+  return (
+    <>
+      {supervisorTodos.length > 0 && (
+        <TodoList
+          todos={supervisorTodos}
+          className="mb-4 rounded-lg border border-border/50 bg-muted/30 p-4"
+        />
+      )}
+      {messages.map((message, messageIndex) => {
+        // Skip tool messages — they're rendered via toolCalls pairing
+        if (message.type === "tool") return null;
+
+        // ---- Human message ----
+        if (message.type === "human" || message.type === "user") {
+          const text = getTextContent(message);
+          const attachments = getFileAttachments(message);
+
+          return (
+            <Fragment key={message.id ?? messageIndex}>
+              {attachments.length > 0 && (
+                <div className="flex justify-end">
+                  <Attachments variant="inline">
+                    {attachments.map((attachment) => {
+                      const mediaCategory = getMediaCategory(attachment);
+                      const label = getAttachmentLabel(attachment);
+                      return (
+                        <AttachmentHoverCard key={attachment.id}>
+                          <AttachmentHoverCardTrigger asChild>
+                            <Attachment data={attachment}>
+                              <div className="relative size-5 shrink-0">
+                                <div className="absolute inset-0 transition-opacity group-hover:opacity-0">
+                                  <AttachmentPreview />
+                                </div>
+                              </div>
+                              <AttachmentInfo />
+                            </Attachment>
+                          </AttachmentHoverCardTrigger>
+                          <AttachmentHoverCardContent>
+                            <div className="space-y-3">
+                              {mediaCategory === "image" &&
+                                "url" in attachment &&
+                                attachment.url && (
+                                  <div className="flex items-center justify-center overflow-hidden rounded-md border">
+                                    <Image
+                                      alt={label}
+                                      className="object-contain"
+                                      height={200}
+                                      src={attachment.url as string}
+                                      width={200}
+                                    />
+                                  </div>
+                                )}
+                              <div className="space-y-1 px-0.5">
+                                <h4 className="font-semibold text-sm leading-none">
+                                  {label}
+                                </h4>
+                              </div>
+                            </div>
+                          </AttachmentHoverCardContent>
+                        </AttachmentHoverCard>
+                      );
+                    })}
+                  </Attachments>
+                </div>
+              )}
+              {text && (
+                <Message from="user">
+                  <MessageContent>
+                    <MessageResponse>{text}</MessageResponse>
+                  </MessageContent>
+                </Message>
+              )}
+            </Fragment>
+          );
+        }
+
+        // ---- AI message ----
+        if (message.type === "ai" || message.type === "assistant") {
+          const text = getTextContent(message);
+          const reasoning = getReasoningContent(message);
+          const chainSteps = message.id
+            ? (chainByOwner.get(message.id) ?? [])
+            : [];
+          const chainSubagents = chainSteps
+            .filter(
+              (s): s is Extract<ChainStepData, { kind: "subagent" }> =>
+                s.kind === "subagent",
+            )
+            .map((s) => s.sub);
+          const chainActive = chainSteps.some((s) =>
+            s.kind === "tool"
+              ? s.tc.state === "pending"
+              : s.sub.status === "running" || s.sub.status === "pending",
+          );
+          const chainLockOpen = chainSteps.some(
+            (s) =>
+              s.kind === "tool" &&
+              getToolRenderState(s.tc, isInterrupted, hitlToolNames) ===
+                "approval-requested" &&
+              !decisions[s.tc.id],
+          );
+          const isTaskCall = (tc: LocalToolCall) => tc.call.name === "task";
+          const toolCount = chainSteps.filter(
+            (s) => s.kind === "tool" && !isTaskCall(s.tc),
+          ).length;
+          const subagentCount = chainSteps.length - toolCount;
+          const isLastMessage =
+            messageIndex === messages.length - 1 ||
+            // Last AI message before a potential loading indicator
+            (messageIndex === messages.length - 2 &&
+              messages[messages.length - 1]?.type === "tool");
+          const isLastAiMessage = !isLoading && isLastMessage && text.length > 0;
+
+          return (
+            <Fragment key={message.id ?? messageIndex}>
+              {/* Reasoning / thinking */}
+              {reasoning && (
+                <Reasoning
+                  className="w-full"
+                  isStreaming={assistantIsStreaming && isLastMessage}
+                >
+                  <ReasoningTrigger />
+                  <ReasoningContent>{reasoning}</ReasoningContent>
+                </Reasoning>
+              )}
+
+              {/* Chain of thought: the turn's tool + subagent steps */}
+              {chainSteps.length > 0 && (
+                <div className="w-full space-y-2">
+                  <ChainOfThought
+                    active={chainActive}
+                    lockOpen={chainLockOpen}
+                    toolCount={toolCount}
+                    subagentCount={subagentCount}
+                  >
+                    {chainSteps.map((step) => {
+                      if (step.kind === "subagent") {
+                        const sub = step.sub;
+                        return (
+                          <SubAgentCard
+                            key={sub.id}
+                            subagent={sub}
+                            mcpServers={mcpServers}
+                            agent={findAgentForSubagentType(
+                              sub.toolCall?.args?.subagent_type as
+                                | string
+                                | undefined,
+                            )}
+                            onOpen={
+                              sub.messages.length === 0 &&
+                              (sub.status === "complete" ||
+                                sub.status === "error")
+                                ? () => void loadSubagentHistory(sub.id)
+                                : undefined
+                            }
+                            fallbackMessages={subagentMessages[sub.id]}
+                          />
+                        );
+                      }
+
+                      const tc = step.tc;
+                      const toolState = getToolRenderState(
+                        tc,
+                        isInterrupted,
+                        hitlToolNames,
+                      );
+                      const decided = decisions[tc.id];
+                      const output = getToolOutputContent(tc);
+                      const errorText =
+                        tc.state === "error" && tc.result
+                          ? extractToolErrorText(tc.result.content)
+                          : undefined;
+                      const stepMeta =
+                        toolState === "approval-requested" ? (
+                          <NeedsApprovalBadge />
+                        ) : toolState === "input-available" ? (
+                          <Loader2 className="size-3 animate-spin text-petrol" />
+                        ) : toolState === "output-error" ? (
+                          <XCircleIcon className="size-3.5 text-destructive" />
+                        ) : undefined;
+                      const approvalFooter =
+                        toolState === "approval-requested" ? (
+                          <div className="flex items-center gap-2 pt-1">
+                            <button
+                              type="button"
+                              disabled={decided != null || modelUnavailable}
+                              onClick={() => {
+                                recordDecision(tc.id, "approve");
+                              }}
+                              className={cn(
+                                "cursor-pointer rounded-[7px] bg-petrol px-4 py-1.5 text-[12.5px] font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed",
+                                decided === "reject" && "opacity-40",
+                              )}
+                            >
+                              Approve
+                            </button>
+                            <button
+                              type="button"
+                              disabled={decided != null || modelUnavailable}
+                              onClick={() => {
+                                recordDecision(tc.id, "reject");
+                              }}
+                              className={cn(
+                                "cursor-pointer rounded-[7px] border border-input bg-card px-4 py-1.5 text-[12.5px] font-semibold text-foreground transition-colors hover:border-border-hover disabled:cursor-not-allowed",
+                                decided === "approve" && "opacity-40",
+                              )}
+                            >
+                              Deny
+                            </button>
+                          </div>
+                        ) : null;
+                      const resultSection =
+                        errorText !== undefined ? (
+                          <StepSection label="ERROR" error>
+                            <StepCode value={errorText} />
+                          </StepSection>
+                        ) : (
+                          output !== undefined && (
+                            <StepSection label="RESULT">
+                              <StepCode value={output} />
+                            </StepSection>
+                          )
+                        );
+
+                      if (isTaskCall(tc)) {
+                        // task call the SDK didn't pair with a subagent
+                        // stream (e.g. filtered history) — still render
+                        // it as a subagent-style step.
+                        const args = tc.call.args as
+                          | Record<string, unknown>
+                          | undefined;
+                        const subagentType = (args?.subagent_type ??
+                          args?.subagentType) as string | undefined;
+                        const matched = findAgentForSubagentType(subagentType);
+                        const description = args?.description as
+                          | string
+                          | undefined;
+                        return (
+                          <ChainStep
+                            key={tc.id}
+                            node={
+                              <AgentAvatar
+                                color={matched?.color}
+                                emoji={matched?.emoji}
+                                size="2xs"
+                                className="relative z-[1]"
+                              />
+                            }
+                            title={`Ask ${matched?.name ?? subagentType?.replaceAll("_", " ") ?? "subagent"}`}
+                            summary={description}
+                            meta={stepMeta}
+                            lockOpen={
+                              toolState === "approval-requested" && !decided
+                            }
+                          >
+                            {description && (
+                              <StepSection label="TASK">
+                                <StepCode value={description} />
+                              </StepSection>
+                            )}
+                            {resultSection}
+                            {approvalFooter}
+                          </ChainStep>
+                        );
+                      }
+
+                      const sandbox = isSandboxTool(tc.call.name);
+                      const { serverName, toolName } = sandbox
+                        ? {
+                            serverName: "Code execution",
+                            toolName: tc.call.name,
+                          }
+                        : getToolMetadata(tc.call.name, knownServerNames);
+                      return (
+                        <ChainStep
+                          key={tc.id}
+                          node={
+                            <ChainStepIcon
+                              icon={
+                                sandbox
+                                  ? TERMINAL_ICON
+                                  : mcpServers.find(
+                                      (server) => server.name === serverName,
+                                    )?.iconUrl
+                              }
+                              name={serverName}
+                            />
+                          }
+                          title={humanizeToolName(toolName)}
+                          summary={summarizeToolArgs(tc.call.args)}
+                          meta={stepMeta}
+                          lockOpen={
+                            toolState === "approval-requested" && !decided
+                          }
+                        >
+                          {tc.call.args !== undefined && (
+                            <StepSection label="PARAMETERS">
+                              <StepCode value={tc.call.args} />
+                            </StepSection>
+                          )}
+                          {resultSection}
+                          {approvalFooter}
+                        </ChainStep>
+                      );
+                    })}
+                  </ChainOfThought>
+                  {chainSubagents.length > 0 && (
+                    <>
+                      <SubAgentProgress subagents={chainSubagents} />
+                      <SynthesisIndicator
+                        subagents={chainSubagents}
+                        isCoordinatorStreaming={
+                          assistantIsStreaming && isLastMessage
+                        }
+                      />
+                    </>
+                  )}
+                  {/* Interactive MCP app widgets surface below the chain */}
+                  {chainSteps.map((step) => {
+                    if (step.kind !== "tool") return null;
+                    const appToolInfo = getMcpAppInfoFromToolCall(step.tc);
+                    if (!appToolInfo) return null;
+                    return (
+                      <McpAppWidget
+                        key={`app-${step.tc.id}`}
+                        input={step.tc.call.args}
+                        output={getToolOutputContent(step.tc)}
+                        structuredContent={getStructuredContentFromToolCall(
+                          step.tc,
+                        )}
+                        errorText={
+                          step.tc.state === "error" && step.tc.result
+                            ? extractToolErrorText(step.tc.result.content)
+                            : undefined
+                        }
+                        toolName={
+                          getToolMetadata(step.tc.call.name, knownServerNames)
+                            .toolName
+                        }
+                        appToolInfo={appToolInfo}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Text content */}
+              {text && (
+                <>
+                  <Message from="assistant">
+                    <MessageContent>
+                      <MessageResponse>{text}</MessageResponse>
+                    </MessageContent>
+                  </Message>
+                  {isLastAiMessage && (
+                    <MessageActions>
+                      {!modelUnavailable && (
+                        <MessageAction onClick={onRegenerate} label="Retry">
+                          <RefreshCcwIcon className="size-3" />
+                        </MessageAction>
+                      )}
+                      <MessageAction
+                        onClick={() => {
+                          void navigator.clipboard.writeText(text);
+                        }}
+                        label="Copy"
+                      >
+                        <CopyIcon className="size-3" />
+                      </MessageAction>
+                    </MessageActions>
+                  )}
+                </>
+              )}
+            </Fragment>
+          );
+        }
+
+        return null;
+      })}
+
+      {/* Loading indicator */}
+      {isAwaitingResponse && (
+        <div>
+          <Message from="assistant">
+            <div className="w-full flex flex-col gap-2">
+              <MessageContent>
+                <ThinkingLoader className="px-0" />
+              </MessageContent>
+            </div>
+          </Message>
+        </div>
+      )}
+
+      {/* Streaming indicator when AI has started but text is still coming */}
+      {assistantIsStreaming &&
+        lastMsg !== null &&
+        getTextContent(lastMsg).length === 0 &&
+        !getToolCallsForMessage(lastMsg).length && (
+          <div>
+            <Message from="assistant">
+              <div className="w-full flex flex-col gap-2">
+                <MessageContent>
+                  <ThinkingLoader className="px-0" />
+                </MessageContent>
+              </div>
+            </Message>
+          </div>
+        )}
+
+      {(error != null || rehydratedError != null) && (
+        <Error>
+          <ErrorContent>An error occurred.</ErrorContent>
+          <ErrorDetails>
+            <div>
+              {error != null
+                ? error instanceof globalThis.Error
+                  ? error.message
+                  : String(error)
+                : rehydratedError}
+            </div>
+          </ErrorDetails>
+        </Error>
+      )}
+    </>
+  );
+});

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
@@ -1,0 +1,338 @@
+// ---------------------------------------------------------------------------
+// Pure helpers shared by the chat page and its conversation body: extracting
+// content from LangChain message dicts, pairing tool calls with results, and
+// normalizing snake_case/camelCase shapes. No React, no state — everything
+// here is identity-stable so memoized consumers can rely on their inputs.
+// ---------------------------------------------------------------------------
+
+import type { SubagentStreamInterface } from "@langchain/langgraph-sdk/ui";
+import type { AttachmentData } from "@/components/ai-elements/attachments";
+import type { McpAppToolInfo } from "../components/mcp-app-widget";
+
+export type LCToolCallEntry = {
+  name: string;
+  args: Record<string, unknown>;
+  id?: string;
+};
+
+export type LCMessage = {
+  type: string;
+  content: string | Array<Record<string, unknown>>;
+  id?: string;
+  name?: string;
+  // snake_case (from stream / raw API)
+  tool_calls?: LCToolCallEntry[];
+  tool_call_id?: string;
+  // camelCase (after Axios interceptor)
+  toolCalls?: LCToolCallEntry[];
+  toolCallId?: string;
+  additionalKwargs?: Record<string, unknown>;
+  status?: string;
+  additional_kwargs?: Record<string, unknown>;
+  response_metadata?: Record<string, unknown>;
+  artifact?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export function getTextContent(message: LCMessage): string {
+  if (typeof message.content === "string") return message.content;
+  if (Array.isArray(message.content)) {
+    return message.content
+      .filter((c) => c.type === "text")
+      .map((c) => c.text as string)
+      .join("");
+  }
+  return "";
+}
+
+export function getReasoningContent(message: LCMessage): string | null {
+  // Anthropic: `thinking` blocks in content.
+  if (Array.isArray(message.content)) {
+    const thinking = message.content.filter((c) => c.type === "thinking");
+    if (thinking.length > 0) {
+      return thinking.map((c) => (c.thinking as string) || "").join("\n");
+    }
+  }
+  // DeepSeek: reasoning lives in additional_kwargs.reasoning_content, not in
+  // content. Streamed messages keep snake_case (SSE bypasses the Axios
+  // interceptor); history loaded via GET /threads/{id} is camelCased.
+  const kwargs = message.additional_kwargs ?? message.additionalKwargs;
+  const reasoning = kwargs?.reasoning_content ?? kwargs?.reasoningContent;
+  return typeof reasoning === "string" && reasoning ? reasoning : null;
+}
+
+export function getFileAttachments(message: LCMessage): AttachmentData[] {
+  if (!Array.isArray(message.content)) return [];
+  const attachments: AttachmentData[] = [];
+  let idx = 0;
+
+  for (const block of message.content) {
+    // Image blocks: "image_url" (snake_case from stream) or "imageUrl" (camelCase from Axios)
+    if (block.type === "image_url" || block.type === "imageUrl") {
+      const imgField = block.image_url ?? block.imageUrl;
+      const url =
+        typeof imgField === "string"
+          ? imgField
+          : (imgField as Record<string, string>)?.url || "";
+      const dataUrl = url.startsWith("data:")
+        ? url
+        : `data:image/jpeg;base64,${url}`;
+      attachments.push({
+        id: `${message.id}-file-${idx++}`,
+        url: dataUrl,
+        type: "file" as const,
+        filename: "Image.jpg",
+        mediaType: "image/jpeg",
+      });
+    }
+
+    // File blocks: {"type": "file", "mime_type"/"mimeType": "...", "base64": "...", "filename": "..."}
+    if (block.type === "file") {
+      const mimeType = (block.mime_type ??
+        block.mimeType ??
+        "application/octet-stream") as string;
+      const base64 = (block.base64 ?? "") as string;
+      const filename = (block.filename ?? "file") as string;
+      const dataUrl = `data:${mimeType};base64,${base64}`;
+      attachments.push({
+        id: `${message.id}-file-${idx++}`,
+        url: dataUrl,
+        type: "file" as const,
+        filename,
+        mediaType: mimeType,
+      });
+    }
+  }
+
+  return attachments;
+}
+
+// ---------------------------------------------------------------------------
+// Tool name parsing (reused from old code)
+// ---------------------------------------------------------------------------
+
+export const sanitizeToolIdentifier = (value: string): string => {
+  const sanitized = value
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return sanitized || "tool";
+};
+
+export const getToolMetadata = (
+  toolName: string,
+  knownServerNames: string[],
+) => {
+  for (const serverName of knownServerNames) {
+    const aliases = [serverName, sanitizeToolIdentifier(serverName)];
+    for (const alias of aliases) {
+      if (toolName === alias || toolName.startsWith(`${alias}_`)) {
+        const suffix = toolName.slice(alias.length);
+        const name = suffix.startsWith("_") ? suffix.slice(1) : suffix;
+        return { serverName, toolName: name || toolName };
+      }
+    }
+  }
+  const separatorIndex = toolName.indexOf("_");
+  if (separatorIndex === -1) {
+    return { serverName: toolName, toolName };
+  }
+  return {
+    serverName: toolName.slice(0, separatorIndex),
+    toolName: toolName.slice(separatorIndex + 1),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Compute tool calls from plain message dicts (for persisted history)
+// ---------------------------------------------------------------------------
+
+export type LocalToolCall = {
+  id: string;
+  call: { name: string; args: Record<string, unknown>; id?: string };
+  result: LCMessage | undefined;
+  aiMessage: LCMessage;
+  index: number;
+  state: "pending" | "completed" | "error";
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SubagentData = SubagentStreamInterface<any, any, any>;
+
+// A chain-of-thought step: a plain tool call, or a subagent call (a `task`
+// tool call the SDK paired with its subagent stream).
+export type ChainStepData =
+  | { kind: "tool"; tc: LocalToolCall }
+  | { kind: "subagent"; sub: SubagentData };
+
+// The LangGraph SDK reconstructs subagent containers from history, but it reads
+// LangChain's snake_case keys (`tool_calls`, `tool_call_id`, `args.subagent_type`).
+// Our axios response interceptor camelCases API payloads, so messages loaded via
+// GET /threads/{id} arrive as `toolCalls` / `toolCallId` / `args.subagentType` and
+// the SDK builds zero subagents. Restore the snake_case shape the SDK expects
+// before handing it the initial values. Streaming is unaffected (SSE bypasses the
+// interceptor and is already snake_case).
+export function toSdkMessages(messages: LCMessage[]): LCMessage[] {
+  return messages.map((msg) => {
+    const m = msg as unknown as Record<string, unknown>;
+    const out: Record<string, unknown> = { ...m };
+
+    if ("toolCallId" in out) {
+      out.tool_call_id = out.toolCallId;
+      delete out.toolCallId;
+    }
+
+    const toolCalls = (m.toolCalls ?? m.tool_calls) as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (Array.isArray(toolCalls)) {
+      out.tool_calls = toolCalls.map((tc) => {
+        // Subagent (task) args carry `subagent_type`; the interceptor
+        // camelCased it to `subagentType`. Restore it so the SDK's
+        // isValidSubagentType() check passes during reconstruction.
+        if (tc.name === "task" && tc.args && typeof tc.args === "object") {
+          const args = tc.args as Record<string, unknown>;
+          return {
+            ...tc,
+            args: {
+              ...args,
+              subagent_type: args.subagent_type ?? args.subagentType,
+            },
+          };
+        }
+        return tc;
+      });
+      delete out.toolCalls;
+    }
+
+    return out as unknown as LCMessage;
+  });
+}
+
+export function computeToolCallsFromMessages(
+  messages: LCMessage[],
+): LocalToolCall[] {
+  // Axios camelCase interceptor converts snake_case keys from the API:
+  //   tool_call_id → toolCallId, tool_calls → toolCalls
+  // Handle both formats for robustness.
+  const getToolCallId = (msg: LCMessage): string | undefined =>
+    (msg.tool_call_id ?? msg.toolCallId) as string | undefined;
+  const getToolCalls = (msg: LCMessage): LCMessage["tool_calls"] | undefined =>
+    msg.tool_calls ?? (msg.toolCalls as LCMessage["tool_calls"]);
+
+  const toolResults = new Map<string, LCMessage>();
+  for (const msg of messages) {
+    if (msg.type === "tool") {
+      const tcId = getToolCallId(msg);
+      if (tcId) toolResults.set(tcId, msg);
+    }
+  }
+
+  const result: LocalToolCall[] = [];
+  for (const msg of messages) {
+    const toolCalls = getToolCalls(msg);
+    if (
+      (msg.type === "ai" || msg.type === "assistant") &&
+      Array.isArray(toolCalls) &&
+      toolCalls.length > 0
+    ) {
+      for (let i = 0; i < toolCalls.length; i++) {
+        const tc = toolCalls[i];
+        const tcId = tc.id || `${msg.id}-tc-${i}`;
+        const toolMsg = toolResults.get(tcId);
+        result.push({
+          id: tcId,
+          call: { name: tc.name, args: tc.args, id: tc.id },
+          result: toolMsg,
+          aiMessage: msg,
+          index: i,
+          state: toolMsg
+            ? toolMsg.status === "error"
+              ? "error"
+              : "completed"
+            : "pending",
+        });
+      }
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Map ToolCallWithResult state to AI Elements component state
+// ---------------------------------------------------------------------------
+
+export type ToolRenderState =
+  | "output-available"
+  | "output-error"
+  | "approval-requested"
+  | "input-available";
+
+export function getToolRenderState(
+  tc: LocalToolCall,
+  isInterrupted: boolean,
+  hitlToolNames?: Set<string> | null,
+): ToolRenderState {
+  if (tc.state === "completed") return "output-available";
+  if (tc.state === "error") return "output-error";
+  // pending
+  if (isInterrupted && (!hitlToolNames || hitlToolNames.has(tc.call.name))) {
+    return "approval-requested";
+  }
+  return "input-available";
+}
+
+// Extracts the set of tool names that require human approval from an HITL
+// interrupt payload. Tolerates both snake_case (live SSE) and camelCase
+// (rehydrated via the axios interceptor) shapes.
+export function extractHitlToolNames(value: unknown): Set<string> | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  const arr = (v.action_requests ?? v.actionRequests) as
+    | Array<{ name?: string }>
+    | undefined;
+  if (!Array.isArray(arr)) return null;
+  const names = arr
+    .map((r) => (r && typeof r.name === "string" ? r.name : null))
+    .filter((n): n is string => n != null);
+  return new Set(names);
+}
+
+export function getMcpAppInfoFromToolCall(
+  tc: LocalToolCall,
+): McpAppToolInfo | null {
+  const artifact = tc.result?.artifact;
+  if (!artifact || typeof artifact !== "object") return null;
+  const a = artifact as Record<string, unknown>;
+  // Handle both camelCase (Axios/history) and snake_case (stream)
+  const resourceUri = (a.mcpAppResourceUri ?? a.mcp_app_resource_uri) as
+    | string
+    | undefined;
+  const serverId = (a.mcpServerId ?? a.mcp_server_id) as string | undefined;
+  if (!resourceUri || !serverId) return null;
+  return { resourceUri, serverId };
+}
+
+export function getStructuredContentFromToolCall(
+  tc: LocalToolCall,
+): Record<string, unknown> | undefined {
+  const artifact = tc.result?.artifact;
+  if (!artifact || typeof artifact !== "object") return undefined;
+  const a = artifact as Record<string, unknown>;
+  // Handle both camelCase (Axios/history) and snake_case (stream/langchain-mcp-adapters)
+  const sc = a.structuredContent ?? a.structured_content;
+  if (sc && typeof sc === "object") return sc as Record<string, unknown>;
+  return undefined;
+}
+
+export function getToolOutputContent(tc: LocalToolCall): unknown {
+  if (!tc.result) return undefined;
+  const content = tc.result.content;
+  if (typeof content === "string") {
+    try {
+      return JSON.parse(content);
+    } catch {
+      return content;
+    }
+  }
+  return content;
+}

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
@@ -73,10 +73,13 @@ export function getFileAttachments(message: LCMessage): AttachmentData[] {
       const url =
         typeof imgField === "string"
           ? imgField
-          : (imgField as Record<string, string>)?.url || "";
-      const dataUrl = url.startsWith("data:")
-        ? url
-        : `data:image/jpeg;base64,${url}`;
+          : ((imgField as Record<string, string> | undefined)?.url ?? "");
+      // Absolute URLs pass through untouched; only raw base64 payloads get
+      // wrapped into a data URL.
+      const dataUrl =
+        url.startsWith("data:") || /^https?:\/\//.test(url)
+          ? url
+          : `data:image/jpeg;base64,${url}`;
       attachments.push({
         id: `${message.id}-file-${idx++}`,
         url: dataUrl,
@@ -148,7 +151,7 @@ export const getToolMetadata = (
 
 export type LocalToolCall = {
   id: string;
-  call: { name: string; args: Record<string, unknown>; id?: string };
+  call: { name: string; args?: Record<string, unknown>; id?: string };
   result: LCMessage | undefined;
   aiMessage: LCMessage;
   index: number;
@@ -235,8 +238,7 @@ export function computeToolCallsFromMessages(
       Array.isArray(toolCalls) &&
       toolCalls.length > 0
     ) {
-      for (let i = 0; i < toolCalls.length; i++) {
-        const tc = toolCalls[i];
+      for (const [i, tc] of toolCalls.entries()) {
         const tcId = tc.id || `${msg.id}-tc-${i}`;
         const toolMsg = toolResults.get(tcId);
         result.push({
@@ -288,7 +290,7 @@ export function extractHitlToolNames(value: unknown): Set<string> | null {
   if (!value || typeof value !== "object") return null;
   const v = value as Record<string, unknown>;
   const arr = (v.action_requests ?? v.actionRequests) as
-    | Array<{ name?: string }>
+    | Array<{ name?: string } | null>
     | undefined;
   if (!Array.isArray(arr)) return null;
   const names = arr

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -185,7 +185,7 @@ const ChatPage = () => {
 
   // Supervisor todos from stream values
   const streamValues = thread.values as Record<string, unknown>;
-  const supervisorTodos = (streamValues?.todos ?? EMPTY_TODOS) as Todo[];
+  const supervisorTodos = (streamValues.todos ?? EMPTY_TODOS) as Todo[];
 
   // Messages: use stream messages when available, else initial.
   // Throttle to ~16Hz so streamed chunks don't trigger per-token re-renders

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -1,429 +1,45 @@
 "use client";
 
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import Image from "next/image";
-import {
-  MessageActions,
-  MessageAction,
-  Message,
-  MessageContent,
-  MessageResponse,
-} from "@/components/ai-elements/message";
-import {
-  Reasoning,
-  ReasoningTrigger,
-  ReasoningContent,
-} from "@/components/ai-elements/reasoning";
-import {
-  ChainOfThought,
-  ChainStep,
-  ChainStepIcon,
-  NeedsApprovalBadge,
-  StepCode,
-  StepSection,
-  TERMINAL_ICON,
-  humanizeToolName,
-  isSandboxTool,
-  summarizeToolArgs,
-} from "@/components/ai-elements/chain-of-thought";
-import { AgentAvatar } from "@/components/ui/agent-avatar";
-import type { AttachmentData } from "@/components/ai-elements/attachments";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
-import {
-  Error,
-  ErrorContent,
-  ErrorDetails,
-} from "@/components/ai-elements/error";
-import {
-  Attachment,
-  AttachmentPreview,
-  AttachmentHoverCard,
-  AttachmentHoverCardTrigger,
-  AttachmentInfo,
-  AttachmentHoverCardContent,
-  getMediaCategory,
-  getAttachmentLabel,
-  Attachments,
-} from "@/components/ai-elements/attachments";
 import { type PromptInputMessage } from "@/components/ai-elements/prompt-input";
-import { extractToolErrorText } from "@/lib/utils/tool-content";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import ChatPromptInput from "../components/prompt-input";
-import {
-  RefreshCcwIcon,
-  CopyIcon,
-  ArchiveIcon,
-  CircleSlash,
-  Loader2,
-  ShieldCheck,
-  XCircleIcon,
-} from "lucide-react";
+import { ArchiveIcon, CircleSlash, ShieldCheck } from "lucide-react";
 import {
   useStream,
   FetchStreamTransport,
 } from "@langchain/langgraph-sdk/react";
-import type {
-  SubagentApi,
-  SubagentStreamInterface,
-} from "@langchain/langgraph-sdk/ui";
-import {
-  SubAgentCard,
-  SubAgentProgress,
-  SynthesisIndicator,
-} from "@/components/ai-elements/subagent";
-import { TodoList } from "@/components/ai-elements/todo-list";
+import type { SubagentApi } from "@langchain/langgraph-sdk/ui";
 import type { Todo } from "@/components/ai-elements/todo-list";
 import { useParams } from "next/navigation";
 import { api, API_BASE_URL } from "@/lib/api/client";
-import { ThinkingLoader } from "../components/loader";
 import { useActiveRunsStore } from "@/stores/active-runs-store";
-import { useMcpServersStore } from "@/stores/mcp-servers-store";
 import { useAgentsStore } from "@/stores/agents-store";
 import { canConfigureAgent } from "@/types/agents";
 import { usePendingMessageStore } from "@/stores/pending-message-store";
 import { useAgentReadiness } from "@/hooks/use-agent-readiness";
 import { useHitlApprovals } from "@/hooks/use-hitl-approvals";
 import { useThrottledValue } from "@/hooks/use-throttled-value";
+import { useStreamTick } from "@/hooks/use-stream-tick";
 import { useDurableRun, REATTACH_RUN_FIELD } from "@/hooks/use-durable-run";
 import { useChatHeaderStore } from "@/stores/chat-header-store";
+import { ConversationBody } from "./conversation-body";
 import {
-  McpAppWidget,
-  type McpAppToolInfo,
-} from "../components/mcp-app-widget";
+  type LCMessage,
+  computeToolCallsFromMessages,
+  extractHitlToolNames,
+  getToolRenderState,
+  toSdkMessages,
+} from "./message-helpers";
 
-// ---------------------------------------------------------------------------
-// Helpers for extracting content from LangChain messages
-// ---------------------------------------------------------------------------
-
-type LCToolCallEntry = {
-  name: string;
-  args: Record<string, unknown>;
-  id?: string;
-};
-
-type LCMessage = {
-  type: string;
-  content: string | Array<Record<string, unknown>>;
-  id?: string;
-  name?: string;
-  // snake_case (from stream / raw API)
-  tool_calls?: LCToolCallEntry[];
-  tool_call_id?: string;
-  // camelCase (after Axios interceptor)
-  toolCalls?: LCToolCallEntry[];
-  toolCallId?: string;
-  additionalKwargs?: Record<string, unknown>;
-  status?: string;
-  additional_kwargs?: Record<string, unknown>;
-  response_metadata?: Record<string, unknown>;
-  artifact?: Record<string, unknown>;
-  [key: string]: unknown;
-};
-
-function getTextContent(message: LCMessage): string {
-  if (typeof message.content === "string") return message.content;
-  if (Array.isArray(message.content)) {
-    return message.content
-      .filter((c) => c.type === "text")
-      .map((c) => c.text as string)
-      .join("");
-  }
-  return "";
-}
-
-function getReasoningContent(message: LCMessage): string | null {
-  // Anthropic: `thinking` blocks in content.
-  if (Array.isArray(message.content)) {
-    const thinking = message.content.filter((c) => c.type === "thinking");
-    if (thinking.length > 0) {
-      return thinking.map((c) => (c.thinking as string) || "").join("\n");
-    }
-  }
-  // DeepSeek: reasoning lives in additional_kwargs.reasoning_content, not in
-  // content. Streamed messages keep snake_case (SSE bypasses the Axios
-  // interceptor); history loaded via GET /threads/{id} is camelCased.
-  const kwargs = message.additional_kwargs ?? message.additionalKwargs;
-  const reasoning = kwargs?.reasoning_content ?? kwargs?.reasoningContent;
-  return typeof reasoning === "string" && reasoning ? reasoning : null;
-}
-
-function getFileAttachments(message: LCMessage): AttachmentData[] {
-  if (!Array.isArray(message.content)) return [];
-  const attachments: AttachmentData[] = [];
-  let idx = 0;
-
-  for (const block of message.content) {
-    // Image blocks: "image_url" (snake_case from stream) or "imageUrl" (camelCase from Axios)
-    if (block.type === "image_url" || block.type === "imageUrl") {
-      const imgField = block.image_url ?? block.imageUrl;
-      const url =
-        typeof imgField === "string"
-          ? imgField
-          : (imgField as Record<string, string>)?.url || "";
-      const dataUrl = url.startsWith("data:")
-        ? url
-        : `data:image/jpeg;base64,${url}`;
-      attachments.push({
-        id: `${message.id}-file-${idx++}`,
-        url: dataUrl,
-        type: "file" as const,
-        filename: "Image.jpg",
-        mediaType: "image/jpeg",
-      });
-    }
-
-    // File blocks: {"type": "file", "mime_type"/"mimeType": "...", "base64": "...", "filename": "..."}
-    if (block.type === "file") {
-      const mimeType = (block.mime_type ??
-        block.mimeType ??
-        "application/octet-stream") as string;
-      const base64 = (block.base64 ?? "") as string;
-      const filename = (block.filename ?? "file") as string;
-      const dataUrl = `data:${mimeType};base64,${base64}`;
-      attachments.push({
-        id: `${message.id}-file-${idx++}`,
-        url: dataUrl,
-        type: "file" as const,
-        filename,
-        mediaType: mimeType,
-      });
-    }
-  }
-
-  return attachments;
-}
-
-// ---------------------------------------------------------------------------
-// Tool name parsing (reused from old code)
-// ---------------------------------------------------------------------------
-
-const sanitizeToolIdentifier = (value: string): string => {
-  const sanitized = value
-    .replace(/[^a-zA-Z0-9_-]/g, "_")
-    .replace(/^_+|_+$/g, "");
-  return sanitized || "tool";
-};
-
-const getToolMetadata = (toolName: string, knownServerNames: string[]) => {
-  for (const serverName of knownServerNames) {
-    const aliases = [serverName, sanitizeToolIdentifier(serverName)];
-    for (const alias of aliases) {
-      if (toolName === alias || toolName.startsWith(`${alias}_`)) {
-        const suffix = toolName.slice(alias.length);
-        const name = suffix.startsWith("_") ? suffix.slice(1) : suffix;
-        return { serverName, toolName: name || toolName };
-      }
-    }
-  }
-  const separatorIndex = toolName.indexOf("_");
-  if (separatorIndex === -1) {
-    return { serverName: toolName, toolName };
-  }
-  return {
-    serverName: toolName.slice(0, separatorIndex),
-    toolName: toolName.slice(separatorIndex + 1),
-  };
-};
-
-// ---------------------------------------------------------------------------
-// Compute tool calls from plain message dicts (for persisted history)
-// ---------------------------------------------------------------------------
-
-type LocalToolCall = {
-  id: string;
-  call: { name: string; args: Record<string, unknown>; id?: string };
-  result: LCMessage | undefined;
-  aiMessage: LCMessage;
-  index: number;
-  state: "pending" | "completed" | "error";
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SubagentData = SubagentStreamInterface<any, any, any>;
-
-// A chain-of-thought step: a plain tool call, or a subagent call (a `task`
-// tool call the SDK paired with its subagent stream).
-type ChainStepData =
-  | { kind: "tool"; tc: LocalToolCall }
-  | { kind: "subagent"; sub: SubagentData };
-
-// The LangGraph SDK reconstructs subagent containers from history, but it reads
-// LangChain's snake_case keys (`tool_calls`, `tool_call_id`, `args.subagent_type`).
-// Our axios response interceptor camelCases API payloads, so messages loaded via
-// GET /threads/{id} arrive as `toolCalls` / `toolCallId` / `args.subagentType` and
-// the SDK builds zero subagents. Restore the snake_case shape the SDK expects
-// before handing it the initial values. Streaming is unaffected (SSE bypasses the
-// interceptor and is already snake_case).
-function toSdkMessages(messages: LCMessage[]): LCMessage[] {
-  return messages.map((msg) => {
-    const m = msg as unknown as Record<string, unknown>;
-    const out: Record<string, unknown> = { ...m };
-
-    if ("toolCallId" in out) {
-      out.tool_call_id = out.toolCallId;
-      delete out.toolCallId;
-    }
-
-    const toolCalls = (m.toolCalls ?? m.tool_calls) as
-      Array<Record<string, unknown>> | undefined;
-    if (Array.isArray(toolCalls)) {
-      out.tool_calls = toolCalls.map((tc) => {
-        // Subagent (task) args carry `subagent_type`; the interceptor
-        // camelCased it to `subagentType`. Restore it so the SDK's
-        // isValidSubagentType() check passes during reconstruction.
-        if (tc.name === "task" && tc.args && typeof tc.args === "object") {
-          const args = tc.args as Record<string, unknown>;
-          return {
-            ...tc,
-            args: {
-              ...args,
-              subagent_type: args.subagent_type ?? args.subagentType,
-            },
-          };
-        }
-        return tc;
-      });
-      delete out.toolCalls;
-    }
-
-    return out as unknown as LCMessage;
-  });
-}
-
-function computeToolCallsFromMessages(messages: LCMessage[]): LocalToolCall[] {
-  // Axios camelCase interceptor converts snake_case keys from the API:
-  //   tool_call_id → toolCallId, tool_calls → toolCalls
-  // Handle both formats for robustness.
-  const getToolCallId = (msg: LCMessage): string | undefined =>
-    (msg.tool_call_id ?? msg.toolCallId) as string | undefined;
-  const getToolCalls = (msg: LCMessage): LCMessage["tool_calls"] | undefined =>
-    msg.tool_calls ?? (msg.toolCalls as LCMessage["tool_calls"]);
-
-  const toolResults = new Map<string, LCMessage>();
-  for (const msg of messages) {
-    if (msg.type === "tool") {
-      const tcId = getToolCallId(msg);
-      if (tcId) toolResults.set(tcId, msg);
-    }
-  }
-
-  const result: LocalToolCall[] = [];
-  for (const msg of messages) {
-    const toolCalls = getToolCalls(msg);
-    if (
-      (msg.type === "ai" || msg.type === "assistant") &&
-      Array.isArray(toolCalls) &&
-      toolCalls.length > 0
-    ) {
-      for (let i = 0; i < toolCalls.length; i++) {
-        const tc = toolCalls[i];
-        const tcId = tc.id || `${msg.id}-tc-${i}`;
-        const toolMsg = toolResults.get(tcId);
-        result.push({
-          id: tcId,
-          call: { name: tc.name, args: tc.args, id: tc.id },
-          result: toolMsg,
-          aiMessage: msg,
-          index: i,
-          state: toolMsg
-            ? toolMsg.status === "error"
-              ? "error"
-              : "completed"
-            : "pending",
-        });
-      }
-    }
-  }
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Map ToolCallWithResult state to AI Elements component state
-// ---------------------------------------------------------------------------
-
-type ToolRenderState =
-  | "output-available"
-  | "output-error"
-  | "approval-requested"
-  | "input-available";
-
-function getToolRenderState(
-  tc: LocalToolCall,
-  isInterrupted: boolean,
-  hitlToolNames?: Set<string> | null,
-): ToolRenderState {
-  if (tc.state === "completed") return "output-available";
-  if (tc.state === "error") return "output-error";
-  // pending
-  if (isInterrupted && (!hitlToolNames || hitlToolNames.has(tc.call.name))) {
-    return "approval-requested";
-  }
-  return "input-available";
-}
-
-// Extracts the set of tool names that require human approval from an HITL
-// interrupt payload. Tolerates both snake_case (live SSE) and camelCase
-// (rehydrated via the axios interceptor) shapes.
-function extractHitlToolNames(value: unknown): Set<string> | null {
-  if (!value || typeof value !== "object") return null;
-  const v = value as Record<string, unknown>;
-  const arr = (v.action_requests ?? v.actionRequests) as
-    Array<{ name?: string }> | undefined;
-  if (!Array.isArray(arr)) return null;
-  const names = arr
-    .map((r) => (r && typeof r.name === "string" ? r.name : null))
-    .filter((n): n is string => n != null);
-  return new Set(names);
-}
-
-function getMcpAppInfoFromToolCall(tc: LocalToolCall): McpAppToolInfo | null {
-  const artifact = tc.result?.artifact;
-  if (!artifact || typeof artifact !== "object") return null;
-  const a = artifact as Record<string, unknown>;
-  // Handle both camelCase (Axios/history) and snake_case (stream)
-  const resourceUri = (a.mcpAppResourceUri ?? a.mcp_app_resource_uri) as
-    string | undefined;
-  const serverId = (a.mcpServerId ?? a.mcp_server_id) as string | undefined;
-  if (!resourceUri || !serverId) return null;
-  return { resourceUri, serverId };
-}
-
-function getStructuredContentFromToolCall(
-  tc: LocalToolCall,
-): Record<string, unknown> | undefined {
-  const artifact = tc.result?.artifact;
-  if (!artifact || typeof artifact !== "object") return undefined;
-  const a = artifact as Record<string, unknown>;
-  // Handle both camelCase (Axios/history) and snake_case (stream/langchain-mcp-adapters)
-  const sc = a.structuredContent ?? a.structured_content;
-  if (sc && typeof sc === "object") return sc as Record<string, unknown>;
-  return undefined;
-}
-
-function getToolOutputContent(tc: LocalToolCall): unknown {
-  if (!tc.result) return undefined;
-  const content = tc.result.content;
-  if (typeof content === "string") {
-    try {
-      return JSON.parse(content);
-    } catch {
-      return content;
-    }
-  }
-  return content;
-}
+// Stable fallback so `values.todos ?? []` doesn't mint a new identity per
+// render and defeat the memoized conversation body.
+const EMPTY_TODOS: Todo[] = [];
 
 // ---------------------------------------------------------------------------
 // Chat page component
@@ -461,16 +77,7 @@ const ChatPage = () => {
   // Set on submit so a still-in-flight rehydration fetch can't restore the
   // previous run's error after the new run already owns the error state.
   const rehydratedErrorStale = useRef(false);
-  // Subagent internal conversations restored from subgraph checkpoints on
-  // refresh, keyed by tool_call_id. The SDK's custom transport doesn't expose a
-  // way to inject these into the reconstructed subagents, so we hold them here
-  // and pass them to SubAgentCard as a fallback.
-  const [subagentMessages, setSubagentMessages] = useState<
-    Record<string, unknown[]>
-  >({});
-  const fetchedSubagentHistory = useRef(new Set<string>());
 
-  const { mcpServers } = useMcpServersStore();
   // Sidebar populates the agents store; when this agent is there and the
   // viewer can edit it, the "not configured" notice points them at the fix
   // instead of telling them to contact the owner (who may be themselves).
@@ -503,6 +110,28 @@ const ChatPage = () => {
     initialValues: initialValues ?? { messages: [] },
     messagesKey: "messages",
     filterSubagentMessages: true,
+    // Coalesce same-tick SSE bursts into one listener notification per
+    // macrotask (reattach replay is the worst case). Do NOT pass a number
+    // here — the SDK implements numeric throttle as a trailing debounce,
+    // which starves updates under a continuous token flow.
+    throttle: true,
+    onError: (err: unknown) => {
+      if (!(err instanceof globalThis.Error)) return;
+      // Mid-session race: an admin disabled the model after this page
+      // loaded. The gate 409s and use-durable-run rethrows it with this
+      // name — lock the send affordances (composer, Retry, HITL approvals)
+      // like the on-load flag.
+      if (err.name === "ModelUnavailableError") {
+        setModelUnavailable(true);
+      }
+      // A 409 stale_interrupt means this view resumed an approval that was
+      // already handled elsewhere (another tab, Slack). The checkpoint is
+      // the truth — reload so the thread renders its actual state instead
+      // of the stale cards.
+      if (err.name === "StaleInterruptError") {
+        window.location.reload();
+      }
+    },
     onFinish: () => {
       // Poll now so the sidebar spinner/badge flips with the stream instead
       // of on the next tick.
@@ -535,12 +164,28 @@ const ChatPage = () => {
   }, [cancel, stop]);
 
   // The custom transport path exposes subagent methods at runtime but
-  // BaseStream types do not include them. Cast to access the API.
-  const subagentApi = thread as unknown as SubagentApi;
+  // BaseStream types do not include them. Cast to access the API. The ref
+  // indirection gives the memoized conversation body an identity-stable
+  // lookup — the SDK rebuilds the thread object on every render, but every
+  // snapshot delegates to the same underlying StreamManager, so a
+  // one-render-stale ref still reads live subagent state.
+  const subagentApiRef = useRef(thread as unknown as SubagentApi);
+  useEffect(() => {
+    subagentApiRef.current = thread as unknown as SubagentApi;
+  });
+  const getSubagentsByMessage = useCallback(
+    (messageId: string) =>
+      subagentApiRef.current.getSubagentsByMessage(messageId),
+    [],
+  );
+
+  // Bumps ≤16Hz on stream notifications; lets the memoized conversation body
+  // follow subagent-only updates (which change no other prop identity).
+  const streamTick = useStreamTick(60);
 
   // Supervisor todos from stream values
   const streamValues = thread.values as Record<string, unknown>;
-  const supervisorTodos = (streamValues?.todos ?? []) as Todo[];
+  const supervisorTodos = (streamValues?.todos ?? EMPTY_TODOS) as Todo[];
 
   // Messages: use stream messages when available, else initial.
   // Throttle to ~16Hz so streamed chunks don't trigger per-token re-renders
@@ -552,25 +197,6 @@ const ChatPage = () => {
     streamMessages.length > 0 || isLoading ? streamMessages : initMessages;
 
   const isInterrupted = interrupt != null || rehydratedInterrupt;
-
-  // Mid-session race: an admin disabled the model after this page loaded.
-  // The gate 409s and use-durable-run rethrows it with this name — lock the
-  // send affordances (composer, Retry, HITL approvals) like the on-load flag.
-  useEffect(() => {
-    if (error instanceof globalThis.Error && error.name === "ModelUnavailableError") {
-      setModelUnavailable(true);
-    }
-  }, [error]);
-
-  // A 409 stale_interrupt means this view resumed an approval that was
-  // already handled elsewhere (another tab, Slack). The checkpoint is the
-  // truth — reload so the thread renders its actual state instead of the
-  // stale cards.
-  useEffect(() => {
-    if (error instanceof globalThis.Error && error.name === "StaleInterruptError") {
-      window.location.reload();
-    }
-  }, [error]);
 
   // The way back without a page refresh: re-read the server-computed flag
   // (the banner's "Check again") so an admin re-enabling the model unlocks
@@ -605,78 +231,16 @@ const ChatPage = () => {
     (interrupt as { id?: string } | null | undefined)?.id ??
     rehydratedInterruptId;
 
-  // Tool calls: use stream tool calls when streaming, else compute from messages
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const streamToolCallsRaw = ((thread as any).toolCalls ??
-    []) as LocalToolCall[];
-  const streamToolCalls = useThrottledValue(streamToolCallsRaw, 60);
-  const localToolCalls = useMemo(
+  // Tool calls, derived once per (throttled) messages change. The SDK also
+  // exposes a `toolCalls` getter, but it rescans every message on each
+  // property read — per render, per token — so we never touch it.
+  const toolCalls = useMemo(
     () => computeToolCallsFromMessages(messages),
     [messages],
   );
-  const toolCalls =
-    streamToolCalls.length > 0 || isLoading ? streamToolCalls : localToolCalls;
-
-  // Index tool calls by AI message id once per render, so the inner map can
-  // look them up in O(1) instead of filtering the full list per message.
-  const toolCallsByMessageId = useMemo(() => {
-    const map = new Map<string, LocalToolCall[]>();
-    for (const tc of toolCalls) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const id = (tc.aiMessage as any)?.id as string | undefined;
-      if (!id || !tc.call.name) continue;
-      const existing = map.get(id);
-      if (existing) existing.push(tc);
-      else map.set(id, [tc]);
-    }
-    return map;
-  }, [toolCalls]);
-
-  const getToolCallsForMessage = useCallback(
-    (message: LCMessage) => {
-      if (!message.id) return [];
-      return toolCallsByMessageId.get(message.id) ?? [];
-    },
-    [toolCallsByMessageId],
-  );
-
-  // Resolve a subagent_type (sanitize_tool_name(agent.name) backend-side)
-  // back to the workspace agent, for its emoji/pastel tile in chain steps.
-  const workspaceAgents = useAgentsStore((s) => s.agents);
-  const findAgentForSubagentType = useCallback(
-    (subagentType: string | undefined) => {
-      if (!subagentType) return undefined;
-      return (
-        workspaceAgents.find(
-          (a) => sanitizeToolIdentifier(a.name) === subagentType,
-        ) ??
-        workspaceAgents.find(
-          (a) =>
-            a.name.toLowerCase() ===
-            subagentType.replaceAll("_", " ").toLowerCase(),
-        )
-      );
-    },
-    [workspaceAgents],
-  );
-
-  // Loading state detection
-  const lastMsg = messages.length > 0 ? messages[messages.length - 1] : null;
-  const isAwaitingResponse =
-    isLoading &&
-    lastMsg != null &&
-    (lastMsg.type === "human" || lastMsg.type === "user");
-
-  const assistantIsStreaming =
-    isLoading &&
-    lastMsg != null &&
-    (lastMsg.type === "ai" || lastMsg.type === "assistant");
 
   const consumePendingMessage = usePendingMessageStore(
     (state) => state.consumePendingMessage,
-  );
-  const knownServerNames = [...mcpServers.map((server) => server.name)].sort(
-    (a, b) => b.length - a.length,
   );
   const { setCurrentChat, clearCurrentChat } = useChatHeaderStore();
 
@@ -764,7 +328,7 @@ const ChatPage = () => {
     messages,
   });
 
-  const handleRegenerate = () => {
+  const handleRegenerate = useCallback(() => {
     // Find the last human message and resubmit with regenerate trigger
     const lastHuman = [...messages]
       .reverse()
@@ -781,29 +345,7 @@ const ChatPage = () => {
         streamSubgraphs: true,
       },
     );
-  };
-
-  const loadSubagentHistory = useCallback(
-    async (toolCallId: string) => {
-      const key = `${threadId}:${toolCallId}`;
-      if (fetchedSubagentHistory.current.has(key)) return;
-      fetchedSubagentHistory.current.add(key);
-
-      try {
-        const res = await api.get(
-          `/threads/${threadId}/subagents/${toolCallId}/state`,
-        );
-        const msgs = res.data?.messages;
-        if (Array.isArray(msgs) && msgs.length > 0) {
-          setSubagentMessages((prev) => ({ ...prev, [toolCallId]: msgs }));
-        }
-      } catch {
-        // Allow a later open to retry a transient failure.
-        fetchedSubagentHistory.current.delete(key);
-      }
-    },
-    [threadId],
-  );
+  }, [messages, submit]);
 
   // ---- Initialization ----
 
@@ -930,58 +472,6 @@ const ChatPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId]);
 
-  // ---- Chain-of-thought grouping ----
-  // One timeline per run of *consecutive* tool work: steps from adjacent AI
-  // messages merge into the run's first step-bearing AI message, but any
-  // assistant text ends the run — a message's own steps render above its
-  // text, and tool calls after the text start a new chain below it. Task
-  // tool calls pair with their SDK subagent stream by id, preserving the
-  // original tool_call order.
-  const chainByOwner = new Map<string, ChainStepData[]>();
-  {
-    let turnOwner: string | null = null;
-    for (const m of messages) {
-      if (m.type === "human" || m.type === "user") {
-        turnOwner = null;
-        continue;
-      }
-      if ((m.type !== "ai" && m.type !== "assistant") || !m.id) continue;
-      const hasText = getTextContent(m).trim().length > 0;
-      const tcs = getToolCallsForMessage(m);
-      const subs = subagentApi.getSubagentsByMessage(m.id);
-      if (tcs.length === 0 && subs.length === 0) {
-        if (hasText) turnOwner = null;
-        continue;
-      }
-
-      const subById = new Map(subs.map((s) => [s.id, s]));
-      const paired = new Set<string>();
-      const steps: ChainStepData[] = [];
-      for (const tc of tcs) {
-        const sub = subById.get(tc.id);
-        if (sub) {
-          steps.push({ kind: "subagent", sub });
-          paired.add(sub.id);
-        } else {
-          steps.push({ kind: "tool", tc });
-        }
-      }
-      for (const sub of subs) {
-        if (!paired.has(sub.id)) steps.push({ kind: "subagent", sub });
-      }
-
-      if (turnOwner == null) {
-        turnOwner = m.id;
-        chainByOwner.set(m.id, steps);
-      } else {
-        chainByOwner.get(turnOwner)?.push(...steps);
-      }
-      // The message's text renders below its steps — anything after it
-      // belongs to a fresh chain.
-      if (hasText) turnOwner = null;
-    }
-  }
-
   // ---- Render ----
 
   return (
@@ -989,447 +479,23 @@ const ChatPage = () => {
       <div className="h-full relative flex flex-1 flex-col min-h-0 w-full">
         <Conversation>
           <ConversationContent className="max-w-4xl mx-auto w-full lg:px-10 sm:px-6 px-2">
-            {supervisorTodos.length > 0 && (
-              <TodoList
-                todos={supervisorTodos}
-                className="mb-4 rounded-lg border border-border/50 bg-muted/30 p-4"
-              />
-            )}
-            {messages.map((message, messageIndex) => {
-              // Skip tool messages — they're rendered via toolCalls pairing
-              if (message.type === "tool") return null;
-
-              // ---- Human message ----
-              if (message.type === "human" || message.type === "user") {
-                const text = getTextContent(message);
-                const attachments = getFileAttachments(message);
-
-                return (
-                  <Fragment key={message.id ?? messageIndex}>
-                    {attachments.length > 0 && (
-                      <div className="flex justify-end">
-                        <Attachments variant="inline">
-                          {attachments.map((attachment) => {
-                            const mediaCategory = getMediaCategory(attachment);
-                            const label = getAttachmentLabel(attachment);
-                            return (
-                              <AttachmentHoverCard key={attachment.id}>
-                                <AttachmentHoverCardTrigger asChild>
-                                  <Attachment data={attachment}>
-                                    <div className="relative size-5 shrink-0">
-                                      <div className="absolute inset-0 transition-opacity group-hover:opacity-0">
-                                        <AttachmentPreview />
-                                      </div>
-                                    </div>
-                                    <AttachmentInfo />
-                                  </Attachment>
-                                </AttachmentHoverCardTrigger>
-                                <AttachmentHoverCardContent>
-                                  <div className="space-y-3">
-                                    {mediaCategory === "image" &&
-                                      "url" in attachment &&
-                                      attachment.url && (
-                                        <div className="flex items-center justify-center overflow-hidden rounded-md border">
-                                          <Image
-                                            alt={label}
-                                            className="object-contain"
-                                            height={200}
-                                            src={attachment.url as string}
-                                            width={200}
-                                          />
-                                        </div>
-                                      )}
-                                    <div className="space-y-1 px-0.5">
-                                      <h4 className="font-semibold text-sm leading-none">
-                                        {label}
-                                      </h4>
-                                    </div>
-                                  </div>
-                                </AttachmentHoverCardContent>
-                              </AttachmentHoverCard>
-                            );
-                          })}
-                        </Attachments>
-                      </div>
-                    )}
-                    {text && (
-                      <Message from="user">
-                        <MessageContent>
-                          <MessageResponse>{text}</MessageResponse>
-                        </MessageContent>
-                      </Message>
-                    )}
-                  </Fragment>
-                );
-              }
-
-              // ---- AI message ----
-              if (message.type === "ai" || message.type === "assistant") {
-                const text = getTextContent(message);
-                const reasoning = getReasoningContent(message);
-                const chainSteps = message.id
-                  ? (chainByOwner.get(message.id) ?? [])
-                  : [];
-                const chainSubagents = chainSteps
-                  .filter(
-                    (s): s is Extract<ChainStepData, { kind: "subagent" }> =>
-                      s.kind === "subagent",
-                  )
-                  .map((s) => s.sub);
-                const chainActive = chainSteps.some((s) =>
-                  s.kind === "tool"
-                    ? s.tc.state === "pending"
-                    : s.sub.status === "running" || s.sub.status === "pending",
-                );
-                const chainLockOpen = chainSteps.some(
-                  (s) =>
-                    s.kind === "tool" &&
-                    getToolRenderState(s.tc, isInterrupted, hitlToolNames) ===
-                      "approval-requested" &&
-                    !decisions[s.tc.id],
-                );
-                const isTaskCall = (tc: LocalToolCall) =>
-                  tc.call.name === "task";
-                const toolCount = chainSteps.filter(
-                  (s) => s.kind === "tool" && !isTaskCall(s.tc),
-                ).length;
-                const subagentCount = chainSteps.length - toolCount;
-                const isLastMessage =
-                  messageIndex === messages.length - 1 ||
-                  // Last AI message before a potential loading indicator
-                  (messageIndex === messages.length - 2 &&
-                    messages[messages.length - 1]?.type === "tool");
-                const isLastAiMessage =
-                  !isLoading && isLastMessage && text.length > 0;
-
-                return (
-                  <Fragment key={message.id ?? messageIndex}>
-                    {/* Reasoning / thinking */}
-                    {reasoning && (
-                      <Reasoning
-                        className="w-full"
-                        isStreaming={assistantIsStreaming && isLastMessage}
-                      >
-                        <ReasoningTrigger />
-                        <ReasoningContent>{reasoning}</ReasoningContent>
-                      </Reasoning>
-                    )}
-
-                    {/* Chain of thought: the turn's tool + subagent steps */}
-                    {chainSteps.length > 0 && (
-                      <div className="w-full space-y-2">
-                        <ChainOfThought
-                          active={chainActive}
-                          lockOpen={chainLockOpen}
-                          toolCount={toolCount}
-                          subagentCount={subagentCount}
-                        >
-                          {chainSteps.map((step) => {
-                            if (step.kind === "subagent") {
-                              const sub = step.sub;
-                              return (
-                                <SubAgentCard
-                                  key={sub.id}
-                                  subagent={sub}
-                                  mcpServers={mcpServers}
-                                  agent={findAgentForSubagentType(
-                                    sub.toolCall?.args?.subagent_type as
-                                      | string
-                                      | undefined,
-                                  )}
-                                  onOpen={
-                                    sub.messages.length === 0 &&
-                                    (sub.status === "complete" ||
-                                      sub.status === "error")
-                                      ? () => void loadSubagentHistory(sub.id)
-                                      : undefined
-                                  }
-                                  fallbackMessages={subagentMessages[sub.id]}
-                                />
-                              );
-                            }
-
-                            const tc = step.tc;
-                            const toolState = getToolRenderState(
-                              tc,
-                              isInterrupted,
-                              hitlToolNames,
-                            );
-                            const decided = decisions[tc.id];
-                            const output = getToolOutputContent(tc);
-                            const errorText =
-                              tc.state === "error" && tc.result
-                                ? extractToolErrorText(tc.result.content)
-                                : undefined;
-                            const stepMeta =
-                              toolState === "approval-requested" ? (
-                                <NeedsApprovalBadge />
-                              ) : toolState === "input-available" ? (
-                                <Loader2 className="size-3 animate-spin text-petrol" />
-                              ) : toolState === "output-error" ? (
-                                <XCircleIcon className="size-3.5 text-destructive" />
-                              ) : undefined;
-                            const approvalFooter =
-                              toolState === "approval-requested" ? (
-                                <div className="flex items-center gap-2 pt-1">
-                                  <button
-                                    type="button"
-                                    disabled={
-                                      decided != null || modelUnavailable
-                                    }
-                                    onClick={() => {
-                                      recordDecision(tc.id, "approve");
-                                    }}
-                                    className={cn(
-                                      "cursor-pointer rounded-[7px] bg-petrol px-4 py-1.5 text-[12.5px] font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed",
-                                      decided === "reject" && "opacity-40",
-                                    )}
-                                  >
-                                    Approve
-                                  </button>
-                                  <button
-                                    type="button"
-                                    disabled={
-                                      decided != null || modelUnavailable
-                                    }
-                                    onClick={() => {
-                                      recordDecision(tc.id, "reject");
-                                    }}
-                                    className={cn(
-                                      "cursor-pointer rounded-[7px] border border-input bg-card px-4 py-1.5 text-[12.5px] font-semibold text-foreground transition-colors hover:border-border-hover disabled:cursor-not-allowed",
-                                      decided === "approve" && "opacity-40",
-                                    )}
-                                  >
-                                    Deny
-                                  </button>
-                                </div>
-                              ) : null;
-                            const resultSection =
-                              errorText !== undefined ? (
-                                <StepSection label="ERROR" error>
-                                  <StepCode value={errorText} />
-                                </StepSection>
-                              ) : (
-                                output !== undefined && (
-                                  <StepSection label="RESULT">
-                                    <StepCode value={output} />
-                                  </StepSection>
-                                )
-                              );
-
-                            if (isTaskCall(tc)) {
-                              // task call the SDK didn't pair with a subagent
-                              // stream (e.g. filtered history) — still render
-                              // it as a subagent-style step.
-                              const args = tc.call.args as
-                                | Record<string, unknown>
-                                | undefined;
-                              const subagentType = (args?.subagent_type ??
-                                args?.subagentType) as string | undefined;
-                              const matched =
-                                findAgentForSubagentType(subagentType);
-                              const description = args?.description as
-                                | string
-                                | undefined;
-                              return (
-                                <ChainStep
-                                  key={tc.id}
-                                  node={
-                                    <AgentAvatar
-                                      color={matched?.color}
-                                      emoji={matched?.emoji}
-                                      size="2xs"
-                                      className="relative z-[1]"
-                                    />
-                                  }
-                                  title={`Ask ${matched?.name ?? subagentType?.replaceAll("_", " ") ?? "subagent"}`}
-                                  summary={description}
-                                  meta={stepMeta}
-                                  lockOpen={
-                                    toolState === "approval-requested" &&
-                                    !decided
-                                  }
-                                >
-                                  {description && (
-                                    <StepSection label="TASK">
-                                      <StepCode value={description} />
-                                    </StepSection>
-                                  )}
-                                  {resultSection}
-                                  {approvalFooter}
-                                </ChainStep>
-                              );
-                            }
-
-                            const sandbox = isSandboxTool(tc.call.name);
-                            const { serverName, toolName } = sandbox
-                              ? {
-                                  serverName: "Code execution",
-                                  toolName: tc.call.name,
-                                }
-                              : getToolMetadata(
-                                  tc.call.name,
-                                  knownServerNames,
-                                );
-                            return (
-                              <ChainStep
-                                key={tc.id}
-                                node={
-                                  <ChainStepIcon
-                                    icon={
-                                      sandbox
-                                        ? TERMINAL_ICON
-                                        : mcpServers.find(
-                                            (server) =>
-                                              server.name === serverName,
-                                          )?.iconUrl
-                                    }
-                                    name={serverName}
-                                  />
-                                }
-                                title={humanizeToolName(toolName)}
-                                summary={summarizeToolArgs(tc.call.args)}
-                                meta={stepMeta}
-                                lockOpen={
-                                  toolState === "approval-requested" &&
-                                  !decided
-                                }
-                              >
-                                {tc.call.args !== undefined && (
-                                  <StepSection label="PARAMETERS">
-                                    <StepCode value={tc.call.args} />
-                                  </StepSection>
-                                )}
-                                {resultSection}
-                                {approvalFooter}
-                              </ChainStep>
-                            );
-                          })}
-                        </ChainOfThought>
-                        {chainSubagents.length > 0 && (
-                          <>
-                            <SubAgentProgress subagents={chainSubagents} />
-                            <SynthesisIndicator
-                              subagents={chainSubagents}
-                              isCoordinatorStreaming={
-                                assistantIsStreaming && isLastMessage
-                              }
-                            />
-                          </>
-                        )}
-                        {/* Interactive MCP app widgets surface below the chain */}
-                        {chainSteps.map((step) => {
-                          if (step.kind !== "tool") return null;
-                          const appToolInfo = getMcpAppInfoFromToolCall(
-                            step.tc,
-                          );
-                          if (!appToolInfo) return null;
-                          return (
-                            <McpAppWidget
-                              key={`app-${step.tc.id}`}
-                              input={step.tc.call.args}
-                              output={getToolOutputContent(step.tc)}
-                              structuredContent={getStructuredContentFromToolCall(
-                                step.tc,
-                              )}
-                              errorText={
-                                step.tc.state === "error" && step.tc.result
-                                  ? extractToolErrorText(step.tc.result.content)
-                                  : undefined
-                              }
-                              toolName={
-                                getToolMetadata(
-                                  step.tc.call.name,
-                                  knownServerNames,
-                                ).toolName
-                              }
-                              appToolInfo={appToolInfo}
-                            />
-                          );
-                        })}
-                      </div>
-                    )}
-
-                    {/* Text content */}
-                    {text && (
-                      <>
-                        <Message from="assistant">
-                          <MessageContent>
-                            <MessageResponse>{text}</MessageResponse>
-                          </MessageContent>
-                        </Message>
-                        {isLastAiMessage && (
-                          <MessageActions>
-                            {!modelUnavailable && (
-                              <MessageAction
-                                onClick={handleRegenerate}
-                                label="Retry"
-                              >
-                                <RefreshCcwIcon className="size-3" />
-                              </MessageAction>
-                            )}
-                            <MessageAction
-                              onClick={() => {
-                                void navigator.clipboard.writeText(text);
-                              }}
-                              label="Copy"
-                            >
-                              <CopyIcon className="size-3" />
-                            </MessageAction>
-                          </MessageActions>
-                        )}
-                      </>
-                    )}
-                  </Fragment>
-                );
-              }
-
-              return null;
-            })}
-
-            {/* Loading indicator */}
-            {isAwaitingResponse && (
-              <div>
-                <Message from="assistant">
-                  <div className="w-full flex flex-col gap-2">
-                    <MessageContent>
-                      <ThinkingLoader className="px-0" />
-                    </MessageContent>
-                  </div>
-                </Message>
-              </div>
-            )}
-
-            {/* Streaming indicator when AI has started but text is still coming */}
-            {assistantIsStreaming &&
-              lastMsg !== null &&
-              getTextContent(lastMsg).length === 0 &&
-              !getToolCallsForMessage(lastMsg).length && (
-                <div>
-                  <Message from="assistant">
-                    <div className="w-full flex flex-col gap-2">
-                      <MessageContent>
-                        <ThinkingLoader className="px-0" />
-                      </MessageContent>
-                    </div>
-                  </Message>
-                </div>
-              )}
-
-            {(error != null || rehydratedError != null) && (
-              <Error>
-                <ErrorContent>An error occurred.</ErrorContent>
-                <ErrorDetails>
-                  <div>
-                    {error != null
-                      ? error instanceof globalThis.Error
-                        ? error.message
-                        : String(error)
-                      : rehydratedError}
-                  </div>
-                </ErrorDetails>
-              </Error>
-            )}
+            <ConversationBody
+              threadId={threadId}
+              messages={messages}
+              toolCalls={toolCalls}
+              getSubagentsByMessage={getSubagentsByMessage}
+              supervisorTodos={supervisorTodos}
+              isLoading={isLoading}
+              isInterrupted={isInterrupted}
+              hitlToolNames={hitlToolNames}
+              decisions={decisions}
+              recordDecision={recordDecision}
+              modelUnavailable={modelUnavailable}
+              onRegenerate={handleRegenerate}
+              error={error}
+              rehydratedError={rehydratedError}
+              streamTick={streamTick}
+            />
           </ConversationContent>
           <ConversationScrollButton />
         </Conversation>

--- a/web/src/components/ai-elements/reasoning.tsx
+++ b/web/src/components/ai-elements/reasoning.tsx
@@ -9,7 +9,14 @@ import {
 import { cn } from "@/lib/utils";
 import { ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
-import { createContext, memo, useContext, useEffect, useState } from "react";
+import {
+	createContext,
+	memo,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { Streamdown } from "streamdown";
 import { Shimmer } from "./shimmer";
 import { Loader } from "@/components/ai-elements/loader";
@@ -64,19 +71,21 @@ export const Reasoning = memo(
 		});
 
 		const [hasAutoClosed, setHasAutoClosed] = useState(false);
-		const [startTime, setStartTime] = useState<number | null>(null);
+		// Never rendered — only read back when streaming ends to compute the
+		// duration, so a ref (not state) avoids a cascading render per stream.
+		const startTimeRef = useRef<number | null>(null);
 
 		// Track duration when streaming starts and ends
 		useEffect(() => {
 			if (isStreaming) {
-				if (startTime === null) {
-					setStartTime(Date.now());
+				if (startTimeRef.current === null) {
+					startTimeRef.current = Date.now();
 				}
-			} else if (startTime !== null) {
-				setDuration(Math.ceil((Date.now() - startTime) / MS_IN_S));
-				setStartTime(null);
+			} else if (startTimeRef.current !== null) {
+				setDuration(Math.ceil((Date.now() - startTimeRef.current) / MS_IN_S));
+				startTimeRef.current = null;
 			}
-		}, [isStreaming, startTime, setDuration]);
+		}, [isStreaming, setDuration]);
 
 		// Auto-open when streaming starts
 		useEffect(() => {
@@ -93,7 +102,9 @@ export const Reasoning = memo(
 					setHasAutoClosed(true);
 				}, AUTO_CLOSE_DELAY);
 
-				return () => clearTimeout(timer);
+				return () => {
+					clearTimeout(timer);
+				};
 			}
 		}, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed]);
 
@@ -202,7 +213,9 @@ export const ReasoningContent = memo(
 							className
 						)}
 					>
-						<Streamdown {...props}>{children}</Streamdown>
+						{/* Streamdown 2.x types props strictly (e.g. dir is a literal
+						    union) — the Collapsible div props never belonged on it. */}
+						<Streamdown>{children}</Streamdown>
 					</div>
 				</div>
 			</div>

--- a/web/src/hooks/use-stream-tick.ts
+++ b/web/src/hooks/use-stream-tick.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * A counter that bumps at most once per `intervalMs`, and only after the
+ * owning component rendered for some other reason.
+ *
+ * Purpose: the LangGraph SDK notifies its subscriber on every SSE event, but
+ * some of those notifications change nothing a memoized child receives by
+ * prop — subagent token streams only bump an internal version counter.
+ * Passing this tick as a prop lets a memoized conversation body follow that
+ * activity at a bounded rate (~16Hz) instead of re-rendering per token.
+ *
+ * The tick's own state update triggers one render, which must not re-arm the
+ * timer (that would loop at 16Hz forever, even when idle) — `skipRef` marks
+ * that render so the effect ignores it.
+ */
+export function useStreamTick(intervalMs = 60): number {
+	const [tick, setTick] = useState(0);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const skipRef = useRef(false);
+
+	// No dependency array on purpose: any render of the owner (i.e. any SDK
+	// notification) schedules a trailing tick unless one is already pending.
+	useEffect(() => {
+		if (skipRef.current) {
+			skipRef.current = false;
+			return;
+		}
+		if (timerRef.current != null) return;
+		timerRef.current = setTimeout(() => {
+			timerRef.current = null;
+			skipRef.current = true;
+			setTick((t) => t + 1);
+		}, intervalMs);
+	});
+
+	useEffect(() => {
+		return () => {
+			if (timerRef.current != null) clearTimeout(timerRef.current);
+		};
+	}, []);
+
+	return tick;
+}


### PR DESCRIPTION
## Summary

Part 1 (quick fixes) of #309 — streaming a long agent run grew the browser tab to ~1.5GB from quadratic allocation churn across three layers of the streaming pipeline (full diagnosis in the issue and `streaming-memory-assessment.md`). This PR takes the app-side fixes; Part 2 (the `@langchain/react` + Agent Streaming Protocol migration) stays tracked in the issue.

## Frontend

- **Memoized conversation body** (the dominant churn): the conversation render tree moves out of `ChatPage` into `ConversationBody`, a `memo` component fed only throttled (~16Hz) or identity-stable props. The component owning `useStream` — notified per SSE event — now renders almost nothing itself; previously the ~1,500-line page rebuilt the React element tree for the entire conversation per token. Pure message helpers move to `message-helpers.ts`. This structure is reused as-is by the Part 2 migration.
- **`useStreamTick`**: subagent-only updates change no top-level value identity (the SDK just bumps an internal version counter and notifies), so a throttled render tick passed as a prop keeps the memoized body following subagent activity at a bounded rate instead of freezing it.
- **No more `thread.toolCalls` getter reads**: the SDK getter rescans every message on each property read, per render. Tool calls are now derived once per throttled `messages` change via the existing `computeToolCallsFromMessages`.
- **`throttle: true` on `useStream`**: coalesces same-tick SSE bursts into one listener notification per macrotask — reattach replay (the full event log in one burst) is the worst case. Deliberately not `throttle: <ms>`, which the SDK implements as a trailing debounce that starves updates under continuous token flow.
- **Error latching via `onError`**: `ModelUnavailableError` / `StaleInterruptError` handling moves from effects watching `thread.error` into the stream's `onError` callback (also unblocks the strict pre-commit `react-hooks/set-state-in-effect` rule).
- **streamdown 1.6.11 → 2.6.0**: [2.5 stops re-rendering completed blocks](https://vercel.com/changelog/streamdown-2-5) while new content streams. The component API is compatible for our usage; v2's stricter prop types caught an accidental div-prop spread into `Streamdown` in `reasoning.tsx` (removed). `reasoning.tsx` also now tracks stream start time in a ref (never rendered — no reason to be state).

## Backend

- **`values` snapshots no longer carry the deepagents `files` dict** (`_serialize_state`): it was re-sent in every superstep snapshot and can be megabytes on sandbox-heavy threads, but no stream consumer reads it — the web client uses only `messages` / `todos` / `__interrupt__` from stream values, the Slack adapter ignores `values`, and history reads come from the checkpoint. Covered by a new adapter test.

Not taken here (called out in the issue as needing care / follow-up): dropping intermediate `messages` from `values` snapshots (the SDK replaces values wholesale), and replaying reattaches from a checkpoint instead of `last_event_id=0` — both are structurally solved by the Part 2 protocol migration.

## Verification

- `backend`: `uv run pytest tests/agents/` — 493 passed, 1 skipped; ruff clean.
- `web`: `next build` passes (type check included); strict pre-commit ESLint config clean on all touched files.
- The heap/allocation profile check from the issue (DevTools on a long streamed run, :3100) is **not** done here — it needs a live run; the issue checkbox stays open.

Refs #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streaming a long agent run no longer grows the browser tab to ~1.5GB — this PR cuts the quadratic allocation churn across the streaming pipeline (Part 1 of #309; the `@langchain/react` + Agent Streaming Protocol migration stays tracked in the issue). Measured results in `streaming-memory-assessment.md` show peak JS heap dropping from 124–164MB to ~51MB, retained memory from ~90MB to ~22MB, and script CPU down ~30%.

**Frontend**
- The conversation render tree moves into a memoized `ConversationBody` fed only throttled (~16Hz) or identity-stable props, so the component owning `useStream` renders almost nothing per SSE event.
- `useStreamTick` keeps the memoized body following subagent-only updates at a bounded rate instead of freezing it.
- Tool calls are derived once per throttled `messages` change instead of reading the SDK's `thread.toolCalls` getter, which rescans every message per property read.
- `throttle: true` on `useStream` coalesces same-tick SSE bursts into one listener notification per macrotask.
- `ModelUnavailableError` and `StaleInterruptError` now latch in the stream's `onError` callback instead of effects watching `thread.error`.
- Upgrading `streamdown` to 2.6.0 stops re-rendering completed blocks while streaming; its stricter prop types caught an accidental div-prop spread in `reasoning.tsx`.
- Review fixes: `isLastMessage` counts an AI message as last when trailing messages are tool results (Copy/Retry no longer hidden), `getFileAttachments` passes absolute http(s) image URLs through instead of base64 data URLs, and nullish guards/types now match the wire format per Codacy.
- Ignoring the `.next-mem` dist dir stops Tailwind v4's content detection from scanning it and breaking the CSS build.
- `next build` and strict ESLint pass.

**Backend**
- `values` snapshots no longer carry the deepagents `files` dict, re-sent every superstep and potentially megabytes on sandbox-heavy threads; no stream consumer reads it, and a new adapter test covers the change.
- `uv run pytest tests/agents/` passes (493 passed, 1 skipped).

<sup>Written for commit 0a832d1d6aa1d054cb78ab5e2a3fc3624befb40d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

