### PR TITLE
feat(chat): subagent conversation in a tinted task band

### DIFF
--- a/subagent-hitl-assessment.md
+++ b/subagent-hitl-assessment.md
@@ -1,0 +1,180 @@
+# Subagent HITL: what `@langchain/react` 1.0.33 changes, and what it implies for auxilia
+
+Assessment written 2026-09-04. No code changed. Companion to issue #301
+("Subagent tool approvals are silently dropped at run time").
+
+## TL;DR
+
+- The "1.0.33" is `@langchain/react`. Its own release note is a dependency bump; the
+  behaviour lives in `@langchain/langgraph-sdk`, which PR #312 moved from 1.7.5 to 1.10.0.
+  The relevant change is **sdk 1.9.29, PR langgraphjs#2672** *"surface nested interrupts on
+  stream.interrupts"*: `input.requested` events from any namespace (subagents included) are now
+  mirrored onto `stream.interrupts` live, each carrying its `namespace`, and
+  `respond({ interruptId })` resolves that namespace automatically (#2676).
+- Nothing changed server-side. Subagent HITL has been **checkpointed and resumable in LangGraph
+  since deepagents 0.5.x** (deepagents#602, Dec 2025): the `task` tool spreads the parent's
+  `configurable` into the subagent, which forwards `__pregel_checkpointer` and
+  `__pregel_checkpoint_ns`, so the subagent runs as a nested subgraph under `tools:<task-id>`.
+  That is exactly the namespace our history endpoint already reads.
+- **Our runtime's premise is stale.** `build_agent_middleware` / `ResolvedAgent.compile` say a
+  subagent "runs without a checkpointer, which is what drops the approval gate" and therefore pass
+  `interrupt_on=None`. The checkpointer is there. The gate is missing only because we don't add
+  `HumanInTheLoopMiddleware` to the subagent stack.
+- Closing #301 is therefore mostly plumbing, not architecture: add the middleware to subagents,
+  teach `hitl.py` to find the gated tool call in the interrupting namespace instead of the root
+  `messages` channel, and give the subagent card an approve/deny path in the web app.
+
+## 1. Upstream facts, verified against installed code
+
+### 1.1 Client (`web/node_modules`)
+
+| Package | Installed | Note |
+| --- | --- | --- |
+| `@langchain/react` | 1.0.33 | every 1.0.3x entry is "Updated dependencies" |
+| `@langchain/langgraph-sdk` | 1.10.0 | was 1.7.5 before PR #312 |
+| `@langchain/core` | 1.2.9 | |
+
+Behaviour in `@langchain/langgraph-sdk/dist/stream/controller.js`:
+
+- `#recordInterrupt` (≈1728): every `input.requested`, whatever `params.namespace`, is appended to
+  `rootStore.interrupts` with `namespace` on the entry. So `stream.interrupt` /
+  `stream.interrupts` now include subagent interrupts while the run is live. Before 1.9.29 a
+  root-only filter dropped them live but hydrate seeded them from `state.tasks`, so they appeared
+  only after a reload.
+- `respond()` (≈1015): resolves the namespace for the given `interruptId` and sends
+  `{ namespace, interrupt_id, response, update?, goto?, config, metadata }` as `input.respond`.
+- `respondAll()` exists for several interrupts at one checkpoint (parallel subagents each pausing).
+- `SubagentDiscoverySnapshot.status` is still `"running" | "complete" | "error"`. There is no
+  "interrupted" status; a paused subagent looks like a running one.
+
+### 1.2 Server (`backend/.venv`, langchain 1.3.17, langgraph 1.2.11, deepagents 0.5.6)
+
+- `deepagents/middleware/subagents.py:442-460`: `subagent_config = {"configurable":
+  {**runtime.config["configurable"], "ls_agent_type": "subagent"}}` then `subagent.ainvoke(...)`.
+  The spread carries `__pregel_checkpointer`, `__pregel_checkpoint_ns`, `thread_id`, and the
+  resume map. `create_agent` for the subagent is called with no `checkpointer` (591-598) and
+  never `checkpointer=False`, so `Pregel._defaults` inherits the parent's.
+- `deepagents/middleware/subagents.py:583-585`: a subagent spec's own `interrupt_on` becomes a
+  `HumanInTheLoopMiddleware` on the subagent. deepagents itself expects subagent HITL to work.
+- `langgraph/types.py:966-971`: `interrupt()` raises `GraphInterrupt(Interrupt.from_ns(value,
+  ns=checkpoint_ns))`; the id is `xxh3_128(ns)` (617-618), so a subagent interrupt id encodes
+  the subagent's task namespace.
+- Propagation to the parent: `langgraph/prebuilt/tool_node.py:982` re-raises `GraphBubbleUp`
+  from a tool; `langchain/agents/middleware/tool_error.py:145`, `tool_retry.py`, `model_retry.py`,
+  `model_fallback.py` all re-raise it. Our `ToolErrorMiddleware` subclasses the upstream one and
+  only supplies the formatter, so it inherits the re-raise. `langgraph/pregel/_runner.py:585-588`
+  then writes `(task_id, "__interrupt__", child_interrupts)` into the **root** checkpoint's pending
+  writes. The root `values` stream event carries the same interrupts (`pregel/main.py:4221-4228`).
+- Resume: `Command(resume={<interrupt_id>: payload})` is placed in `CONFIG_KEY_RESUME_MAP`
+  (`_loop.py:914`), which is part of `configurable` and so flows into the subagent through the
+  same spread. `_algo.py:622-633` hands each task a scratchpad keyed by the hash of its namespace,
+  which is the interrupt id. The parent re-runs only the interrupted `task` tool call because
+  `create_agent` dispatches one `Send("tools", [tool_call])` per call (`factory.py:1968`); sibling
+  tool results already in the checkpoint are not re-executed. The subagent reloads its own
+  checkpoint under `tools:<task-id>` and `interrupt()` returns the decision.
+- Payload / resume shapes are unchanged since 1.0: `{"action_requests": [{name, args,
+  description}], "review_configs": [...]}` in, `{"decisions": [approve | reject | edit |
+  respond]}` out, positional by request. `build_resume_command` already emits the id-keyed form
+  whenever the checkpoint yields a 32-hex id.
+- Newer Python releases change nothing here. deepagents 0.6.0 narrowed the forwarded config to
+  `callbacks/tags/configurable` "so Pregel recognises the subagent as a nested subgraph";
+  0.6.8 removed the forwarding in favour of langgraph's ambient-config merge (langgraph#7926).
+  Net effect on checkpointing and interrupt propagation: none. Known upstream limitation
+  (deepagents discussion #1762): a second interrupt raised by the *same* subagent after a
+  state update on resume can be swallowed; sequential gated calls in the ordinary loop are fine
+  but should be covered by a test.
+
+## 2. What happens in auxilia today if a subagent tool is gated
+
+1. `Toolset.prepare` computes `interrupt_on` for the subagent's own toolset (the editor lets you
+   set "requires approval" on a subagent's tools).
+2. `ResolvedAgent.compile` calls `build_agent_middleware(created_at,
+   recursion_limit=SUBAGENT_RECURSION_LIMIT)` with no `interrupt_on`, so neither
+   `HumanInTheLoopMiddleware` nor `PatchToolCallsMiddleware` is added. The tool runs unasked.
+   This is #301, and the fix is one argument.
+
+If you *did* add the middleware today, here is how far the rest of the stack would carry it:
+
+| Stage | Works? | Why |
+| --- | --- | --- |
+| Interrupt reaches the root checkpoint | yes | propagated by `_runner.py`, id = hash of subagent ns |
+| `pending_interrupt()` (worker, state, Slack, threads router) | yes | reads root `pending_writes`, tolerates the tuple form |
+| `emit._on_values` → `input.requested` | partly | root envelope emits it with `namespace: []`; the subagent's own envelope is dropped by the early `return` in the namespaced branch, so the client never learns which subagent paused |
+| `pending_approval_requests()` | **no** | matches `action_requests` against the **root** `messages` channel's last AI message, whose only call is `task`; falls back to `approval-<i>` ids |
+| `build_resume_command()` | degraded | id-keyed resume is correct, but `expected` comes from the broken matcher, so clients must send `approval-<i>` ids positionally |
+| `input.respond` → `RunService.create(command={"resume": ...})` | yes | ignores `namespace`; LangGraph routes by id |
+| Resume execution | yes | parent re-runs only the `task` Send; subagent resumes from its checkpoint |
+| Web: `stream.interrupt` set | yes (new) | sdk ≥1.9.29 mirrors nested interrupts to root |
+| Web: something to click | **no** | `getToolStepState` only marks **root** tool calls whose name is in `action_requests`; the nested `ToolStep` inside `SubAgentCard` never receives `approval` and keeps spinning |
+| Web: `useHitlApprovals` fires | **no** | `pendingToolCalls` is derived from root `toolCalls`; empty for a nested interrupt, so no batch is ever complete |
+| Slack cards | degraded | posted from root checkpoint with `approval-<i>` ids; approve path depends on the matcher |
+| Reload / hydrate | partly | `thread_state` seeds the root interrupt; the subagent card's history shows the gated call as running |
+
+## 3. Implications and proposed changes (not implemented)
+
+### Backend
+
+1. **Gate subagents.** `ResolvedAgent.compile` passes `interrupt_on=self.prepared.interrupt_on`
+   to `build_agent_middleware`. That also turns on `PatchToolCallsMiddleware` for subagents,
+   which is correct now that we know they are checkpointed (a cancelled run can leave a dangling
+   call in the subagent's namespace too). Rewrite the docstrings in `build_agent_middleware`,
+   `ResolvedAgent.compile` and `SUBAGENT_RECURSION_LIMIT` that claim there is no checkpointer.
+   The recursion-limit remark stays true: `task` does not forward `recursion_limit`.
+2. **Locate the gated call in its namespace.** `hitl.pending_interrupt` should also return the
+   pending write's `task_id`. For a propagated interrupt that task is the parent's `tools` Send,
+   and the subagent's namespace is `tools:<task_id>`, the same derivation
+   `protocol/service._task_namespace` uses for history. `pending_approval_requests` then loads
+   that namespace's checkpoint and matches `action_requests` against *its* last AI message
+   (root when the write came from the root `agent` task). Real `tool_call_id`s flow to the web
+   client, Slack and `build_resume_command` unchanged.
+3. **Emit the real namespace.** In `emit._on_values`, handle `interrupts` in the namespaced
+   branch too and emit `input.requested` with that namespace (dedup by id already prevents a
+   second root copy). The client can then key the approval UI on
+   `interrupt.namespace === subagent.namespace`. `input.respond` may keep ignoring `namespace`.
+4. **Hydration.** `thread_state` should expose the namespace on the interrupt task entry it
+   returns, so a reload lands the approval on the right card. Check what shape the SDK's
+   hydrate accepts for nested interrupts before deciding the field.
+5. **Slack.** `pending_approval_requests` fix covers the cards; consider prefixing the card
+   title with the subagent name, since the tool name alone is ambiguous across agents.
+6. **Concurrency.** Two subagents pausing in the same superstep produce two root interrupts.
+   `_input_respond` currently rejects batches of more than one response and
+   `build_resume_command` assumes one pending interrupt. Either accept several ids in one
+   command (the SDK's `respondAll`) or, more simply, resume one at a time and document that the
+   second card stays pending until the first resume's run is terminal.
+7. **Tests.** Add a runtime test: supervisor with a gated subagent tool → interrupt visible on
+   the root checkpoint with a 32-hex id → id-keyed resume → subagent's ToolMessage lands under
+   `tools:<task-id>`. Cover two sequential gated calls in one subagent (the #1762 caveat).
+
+### Frontend
+
+1. **Scope interrupts to a card.** Pass `stream.interrupts` (not just `interrupt`) down; a
+   `SubAgentCard` owns the interrupts whose `namespace` matches `subagent.namespace`. With
+   backend change 3 this is exact; without it, fall back to matching `action_requests`
+   name+args against the card's own tool calls.
+2. **Nested approval UI.** `getToolStepState` gets the card's interrupt so nested calls named in
+   `action_requests` render `awaiting-approval`; `ToolStep` already renders the approve/deny
+   footer when given `approval`, so the card just has to supply it and `lockOpen` while pending.
+   Show the `NeedsApprovalBadge` in the card's `meta` slot instead of the spinner, and let
+   `ChainOfThought.lockOpen` include nested pending approvals.
+3. **Decision batching per interrupt.** Today one `useHitlApprovals` instance works off root
+   `pendingToolCalls`. Move to one collector per interrupt id (root or nested) with the
+   pending calls for that namespace, calling `stream.respond(response, { interruptId })`. The
+   SDK resolves the namespace; the backend stale-checks the id.
+4. **Status.** `SubagentDiscoverySnapshot` has no paused state, so `SubAgentProgress` and the
+   header keep saying "Working" while waiting. Derive a local "needs approval" state from the
+   scoped interrupt rather than waiting on the SDK.
+5. **Hydration.** Depends on backend 4. Until then, after a reload the card shows the gated call
+   as running; approval still works from the root interrupt if the fallback matcher in 1 is in
+   place.
+
+### Editor
+
+Issue #301 suggested hiding the approval toggle on subagent tools until it works. With the
+above it becomes real, so leave the toggle and drop that suggestion from the issue.
+
+## 4. Order of work
+
+1. Backend 1 + 2 + tests (makes the feature exist and gives clients real ids).
+2. Frontend 1–3 (makes it usable from the web).
+3. Backend 3 + 4, frontend 4–5 (polish: right card, right status, reload).
+4. Backend 6 (parallel subagent approvals) only if a real agent design needs it.

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/subagent-card.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/subagent-card.tsx
@@ -8,6 +8,7 @@ import { useMessages, useToolCalls, useValues } from "@langchain/react";
 import type { AnyStream, SubagentDiscoverySnapshot } from "@langchain/react";
 import { Loader } from "@/components/ai-elements/loader";
 import {
+  ChainBand,
   ChainRail,
   ChainReasoningLine,
   ChainStep,
@@ -15,7 +16,6 @@ import {
   StepSection,
 } from "@/components/ai-elements/chain-of-thought";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
-import { MessageResponse } from "@/components/ai-elements/message";
 import { TodoList } from "@/components/ai-elements/todo-list";
 import type { Todo } from "@/components/ai-elements/todo-list";
 import { cn } from "@/lib/utils";
@@ -54,7 +54,7 @@ const SubAgentConversation = memo(function SubAgentConversation({
   const last = messages.length - 1;
 
   return (
-    <ChainRail>
+    <ChainRail startAtFirstNode>
       {messages.map((message, i) => {
         if (!isAIMessage(message)) return null;
         const text = message.text;
@@ -62,12 +62,10 @@ const SubAgentConversation = memo(function SubAgentConversation({
         return (
           <Fragment key={message.id ?? i}>
             {text && (
-              <ChainReasoningLine>
-                {text}
-                {isStreaming && i === last && calls.length === 0 && (
-                  <span className="ml-0.5 inline-block h-3 w-1 animate-pulse rounded-sm bg-petrol align-text-bottom" />
-                )}
-              </ChainReasoningLine>
+              <ChainReasoningLine
+                text={text}
+                streaming={isStreaming && i === last && calls.length === 0}
+              />
             )}
             {calls.map((tc) => (
               <ToolStep
@@ -115,12 +113,6 @@ export const SubAgentCard = memo(function SubAgentCard({
   const isStreaming = status === "running";
   const isError = status === "error";
   const todos = (values?.todos ?? []) as Todo[];
-  const result =
-    subagent.output == null
-      ? undefined
-      : typeof subagent.output === "string"
-        ? subagent.output
-        : JSON.stringify(subagent.output, null, 2);
   // Hydrated snapshots stamp both dates at load time — nothing to show then.
   const elapsed =
     completedAt != null && completedAt.getTime() > startedAt.getTime()
@@ -164,34 +156,20 @@ export const SubAgentCard = memo(function SubAgentCard({
         ) : undefined
       }
     >
-      {subagent.taskInput && (
-        <StepSection label="TASK">
-          <StepCode value={subagent.taskInput} />
-        </StepSection>
-      )}
-      {todos.length > 0 && <TodoList todos={todos} />}
-      {messages.some(isAIMessage) && (
+      <ChainBand label="TASK" text={subagent.taskInput}>
+        {todos.length > 0 && <TodoList todos={todos} className="mb-3" />}
         <SubAgentConversation
           messages={messages}
           toolCalls={toolCalls}
           isStreaming={isStreaming}
           describe={describe}
         />
-      )}
-      {result != null && result !== "" && (
-        <StepSection label="RESULT">
-          <div className="min-w-0 rounded-[6px] border border-border bg-card px-3 py-2.5 text-[12.5px] leading-[1.6] text-body dark:text-panel-body">
-            <MessageResponse className="text-[12.5px] leading-[1.6]">
-              {result}
-            </MessageResponse>
-          </div>
-        </StepSection>
-      )}
-      {isError && subagent.error != null && (
-        <StepSection label="ERROR" error>
-          <StepCode value={subagent.error} />
-        </StepSection>
-      )}
+        {isError && subagent.error != null && (
+          <StepSection label="ERROR" error className="mt-2">
+            <StepCode value={subagent.error} />
+          </StepSection>
+        )}
+      </ChainBand>
     </ChainStep>
   );
 });

--- a/web/src/components/ai-elements/chain-of-thought.tsx
+++ b/web/src/components/ai-elements/chain-of-thought.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from "@/lib/utils";
 import { ChevronDownIcon, Loader2 } from "lucide-react";
 import Image from "next/image";
-import type { ComponentProps, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useState } from "react";
 import { CodeBlock, SHIKI_MAX_CHARS } from "./code-block";
 import { MessageResponse } from "./message";
@@ -193,16 +193,23 @@ export const ChainThinking = ({ className }: { className?: string }) => (
 
 /** The 1px vertical rail steps hang on. Also used for nested subagent work. */
 export const ChainRail = ({
+	startAtFirstNode = false,
 	className,
 	children,
 }: {
+	/** Begin the line at the first node instead of the container's top edge —
+	 *  for rails with no header above them (a subagent's band). */
+	startAtFirstNode?: boolean;
 	className?: string;
 	children: ReactNode;
 }) => (
 	<div className={cn("relative", className)}>
 		<span
 			aria-hidden
-			className="absolute bottom-2 left-[10px] top-0 w-px bg-rail dark:bg-white/10"
+			className={cn(
+				"absolute bottom-2 left-[10px] w-px bg-rail dark:bg-white/10",
+				startAtFirstNode ? "top-[17px]" : "top-0",
+			)}
 		/>
 		{children}
 	</div>
@@ -344,13 +351,15 @@ export const ChainStep = ({
 export const StepSection = ({
 	label,
 	error = false,
+	className,
 	children,
 }: {
 	label: string;
 	error?: boolean;
+	className?: string;
 	children: ReactNode;
 }) => (
-	<div className="flex min-w-0 flex-col gap-1.5">
+	<div className={cn("flex min-w-0 flex-col gap-1.5", className)}>
 		<div
 			className={cn(
 				"font-mono text-[9.5px] font-semibold tracking-[0.09em]",
@@ -390,19 +399,101 @@ export const StepCode = ({ value }: { value: unknown }) => {
 	);
 };
 
-/** ✦ italic reasoning line (used inside subagent nested rails). */
-export const ChainReasoningLine = ({
-	children,
+/** Tinted band a step folds its nested work into (a subagent's own
+ *  conversation). Mono `// LABEL` header, optional plain text under it (the
+ *  task), then whatever hangs on the rail. */
+export const ChainBand = ({
+	label,
+	text,
 	className,
-}: ComponentProps<"div">) => (
-	<div className={cn("relative flex items-start gap-3 py-1.5", className)}>
-		<span className="relative z-[1] flex size-[22px] shrink-0 items-center justify-center bg-background text-[11px] text-petrol">
-			✦
-		</span>
-		<span className="min-w-0 whitespace-pre-wrap text-[12.5px] italic leading-[1.6] text-muted-foreground">
-			{children}
-		</span>
+	children,
+}: {
+	label: string;
+	text?: string;
+	className?: string;
+	children: ReactNode;
+}) => (
+	<div
+		className={cn(
+			"flex min-w-0 flex-col rounded-[10px] bg-hover/70 px-[18px] pb-4 pt-3.5 dark:bg-panel-card",
+			className,
+		)}
+	>
+		<div className="font-mono text-[10px] font-semibold tracking-[0.09em] text-meta dark:text-panel-dim">
+			{"// "}
+			{label}
+		</div>
+		{text && (
+			<div className="mt-2 whitespace-pre-wrap font-mono text-[11px] leading-[1.55] text-label dark:text-panel-dim">
+				{text}
+			</div>
+		)}
+		<div className="mt-3 flex min-w-0 flex-col">{children}</div>
 	</div>
+);
+
+/** 22px square node for a non-collapsible rail line — same tile as the
+ *  root chain's reasoning step. */
+export const ChainLineNode = ({
+	className,
+	children,
+}: {
+	className?: string;
+	children: ReactNode;
+}) => (
+	<span
+		className={cn(
+			"relative z-[1] flex size-[22px] shrink-0 items-center justify-center rounded-[6px] border border-border bg-card text-[11px]",
+			className,
+		)}
+	>
+		{children}
+	</span>
+);
+
+/** A plain (non-collapsible) line on the rail: a node and its text. */
+export const ChainLine = ({
+	node,
+	className,
+	children,
+}: {
+	node: ReactNode;
+	className?: string;
+	children: ReactNode;
+}) => (
+	<div className={cn("relative flex items-start gap-3 py-1.5", className)}>
+		{node}
+		<div className="min-w-0 flex-1 pt-[3px]">{children}</div>
+	</div>
+);
+
+/** ✦ italic line for a subagent's own text on its nested rail. Rendered as
+ *  markdown: its last line doubles as the subagent's result. */
+export const ChainReasoningLine = ({
+	text,
+	streaming = false,
+	className,
+}: {
+	text: string;
+	/** Show a caret after the text while it is still arriving. */
+	streaming?: boolean;
+	className?: string;
+}) => (
+	<ChainLine
+		className={className}
+		node={<ChainLineNode className="text-petrol">✦</ChainLineNode>}
+	>
+		<MessageResponse
+			className={cn(
+				"text-[12.5px] italic leading-[1.6] text-muted-foreground [&_[data-streamdown=strong]]:not-italic [&_[data-streamdown=strong]]:text-foreground",
+				// Caret on the last block while the text is still arriving.
+				streaming &&
+					"[&>*:last-child]:after:ml-0.5 [&>*:last-child]:after:inline-block [&>*:last-child]:after:h-3 [&>*:last-child]:after:w-1 [&>*:last-child]:after:animate-pulse [&>*:last-child]:after:rounded-sm [&>*:last-child]:after:bg-petrol [&>*:last-child]:after:align-text-bottom [&>*:last-child]:after:content-['']",
+			)}
+		>
+			{text}
+		</MessageResponse>
+	</ChainLine>
 );
 
 /** Amber approval badge for steps waiting on a human. */

--- a/web/src/components/ai-elements/chain-of-thought.tsx
+++ b/web/src/components/ai-elements/chain-of-thought.tsx
@@ -483,16 +483,19 @@ export const ChainReasoningLine = ({
 		className={className}
 		node={<ChainLineNode className="text-petrol">✦</ChainLineNode>}
 	>
-		<MessageResponse
+		{/* The caret lives on this wrapper, not on MessageResponse: that one is
+		    memoized on `children` alone, so a className flip with unchanged
+		    text would never render and the caret would outlive the stream. */}
+		<div
 			className={cn(
-				"text-[12.5px] italic leading-[1.6] text-muted-foreground [&_[data-streamdown=strong]]:not-italic [&_[data-streamdown=strong]]:text-foreground",
-				// Caret on the last block while the text is still arriving.
 				streaming &&
-					"[&>*:last-child]:after:ml-0.5 [&>*:last-child]:after:inline-block [&>*:last-child]:after:h-3 [&>*:last-child]:after:w-1 [&>*:last-child]:after:animate-pulse [&>*:last-child]:after:rounded-sm [&>*:last-child]:after:bg-petrol [&>*:last-child]:after:align-text-bottom [&>*:last-child]:after:content-['']",
+					"[&>*>*:last-child]:after:ml-0.5 [&>*>*:last-child]:after:inline-block [&>*>*:last-child]:after:h-3 [&>*>*:last-child]:after:w-1 [&>*>*:last-child]:after:animate-pulse [&>*>*:last-child]:after:rounded-sm [&>*>*:last-child]:after:bg-petrol [&>*>*:last-child]:after:align-text-bottom [&>*>*:last-child]:after:content-['']",
 			)}
 		>
-			{text}
-		</MessageResponse>
+			<MessageResponse className="text-[12.5px] italic leading-[1.6] text-muted-foreground [&_[data-streamdown=strong]]:not-italic [&_[data-streamdown=strong]]:text-foreground">
+				{text}
+			</MessageResponse>
+		</div>
 	</ChainLine>
 );
 


### PR DESCRIPTION
## Summary

- The subagent step keeps its chain header (avatar, "Ask …", task summary, elapsed) and folds its work into a tinted band: a mono `// TASK` header with the full task text, then the subagent's own rail.
- Rail nodes are square tiles like the root chain; the rail line starts at its first node instead of the band's top edge.
- The subagent's streamed text renders as markdown (bold upright inside the italic line) with an inline caret while streaming.
- The `RESULT` section is removed: the subagent's last message is its result.
- New chain primitives: `ChainBand`, `ChainLine`, `ChainLineNode`; `ChainRail` gains `startAtFirstNode`; `StepSection` accepts `className`.
- Adds `subagent-hitl-assessment.md` (repo root): what `@langchain/react` 1.0.33 / sdk 1.9.29 changes (nested interrupts mirrored to `stream.interrupts`), why subagent HITL is already checkpointed server-side (deepagents `task` forwards the parent `configurable`), and the backend + frontend work #301 actually needs. No behaviour change from the doc.

## Test plan

- [x] `tsc --noEmit` clean for `src/`
- [x] `eslint -c eslint.precommit.mjs` clean on both touched files
- [x] `vitest` thread helpers (8 tests) pass
- [x] Screenshotted via a throwaway fixture route in light and dark, with the nested tool step collapsed and expanded (fixture removed)
- [ ] Run a supervisor thread with a subagent and check the band live and after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the subagent card so its conversation renders in a tinted band with a mono `// TASK` header, replacing the separate TASK and RESULT sections; the subagent's last message is now its result.

Adds chain primitives `ChainBand`, `ChainLine`, and `ChainLineNode`; `ChainRail` gains `startAtFirstNode` and `StepSection` accepts `className`. Rail nodes are square tiles like the root chain, the rail starts at its first node, and streamed text renders as markdown with an inline caret while streaming. The caret lives on a wrapper around the memoized `MessageResponse` so it disappears once text stops arriving.

Adds `subagent-hitl-assessment.md`, an assessment of how `@langchain/react` 1.0.33 and `@langchain/langgraph-sdk` 1.9.29 affect nested interrupts, why subagent HITL is already checkpointed server-side, and what backend and frontend work issue #301 actually needs. The doc changes no behavior.

<sup>Written for commit fc27731653b80ac579aac99c3287258173afc7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

