### PR TITLE
feat(agents): subagent tool approvals (HITL) surface and resume like the parent's

### DIFF
--- a/backend/app/agents/hitl.py
+++ b/backend/app/agents/hitl.py
@@ -94,13 +94,16 @@ _TOOLS_NS_PREFIX = "tools:"
 _INTERRUPT_ID_RE = re.compile(r"[0-9a-f]{32}")
 
 
-def pending_interrupt(checkpoint_tuple: Any) -> PendingInterrupt | None:
-    """Return the pending HITL interrupt from a checkpoint tuple, or None.
+def pending_interrupts(checkpoint_tuple: Any) -> list[PendingInterrupt]:
+    """Every pending HITL interrupt on a checkpoint tuple, in write order.
 
-    Tolerates both an `Interrupt` object (the serde round-trips it) and a
-    plain ``{"value": ..., "id": ...}`` dict, mirroring the two shapes the
-    live stream and older checkpoints produce.
+    One per paused task: a parent approval or a paused subagent is one entry;
+    several subagents pausing in the same superstep are several. Tolerates
+    both an `Interrupt` object (the serde round-trips it) and a plain
+    ``{"value": ..., "id": ...}`` dict, mirroring the two shapes the live
+    stream and older checkpoints produce.
     """
+    found: list[PendingInterrupt] = []
     for task_id, channel, value in (
         getattr(checkpoint_tuple, "pending_writes", None) or []
     ):
@@ -111,38 +114,65 @@ def pending_interrupt(checkpoint_tuple: Any) -> PendingInterrupt | None:
             continue
         first = batch[0]
         if isinstance(first, dict) and "value" in first:
-            return PendingInterrupt(
-                id=first.get("id"), value=first.get("value"), task_id=task_id
+            found.append(
+                PendingInterrupt(
+                    id=first.get("id"), value=first.get("value"), task_id=task_id
+                )
             )
-        return PendingInterrupt(
-            id=getattr(first, "id", None),
-            value=getattr(first, "value", first),
-            task_id=task_id,
-        )
-    return None
+        else:
+            found.append(
+                PendingInterrupt(
+                    id=getattr(first, "id", None),
+                    value=getattr(first, "value", first),
+                    task_id=task_id,
+                )
+            )
+    return found
+
+
+def pending_interrupt(
+    checkpoint_tuple: Any, interrupt_id: str | None = None
+) -> PendingInterrupt | None:
+    """The pending interrupt with `interrupt_id`, or the first one, or None.
+
+    An addressed resume names its interrupt, which matters once parallel
+    subagents can pause together; every other reader (terminal-status
+    detection, Slack cards) deals with "the" pending interrupt.
+    """
+    interrupts = pending_interrupts(checkpoint_tuple)
+    if interrupt_id is not None:
+        return next((i for i in interrupts if i.id == interrupt_id), None)
+    return interrupts[0] if interrupts else None
 
 
 async def load_interrupt_scope(
-    checkpointer: Any, thread_id: str, root: Any = None
+    checkpointer: Any,
+    thread_id: str,
+    root: Any = None,
+    interrupt_id: str | None = None,
 ) -> InterruptScope | None:
     """Locate the thread's pending interrupt, or None when nothing is pending.
 
-    Reads the root checkpoint (or takes it as `root`), then follows the
-    interrupting task into `tools:<task_id>` for as long as a checkpoint exists
+    Reads the root checkpoint (or takes it as `root`), picks the interrupt
+    (`interrupt_id` when an addressed resume names one, else the first), then
+    follows its task into `tools:<task_id>` for as long as a checkpoint exists
     there and is paused on the *same* interrupt id: one hop for a subagent,
     one more per nesting level, none for a parent-agent approval (its pending
     write's task is the HITL node, which has no namespace of its own). The
     descent is bounded by `MAX_SUBAGENT_DEPTH` so a checkpointer answering
-    every namespace can never make it loop.
+    every namespace can never make it loop. The root `task` call that started
+    the paused subagent is matched on the first hop, where the child's seed
+    message is that call's description.
     """
     if root is None:
         root = await checkpointer.aget_tuple(
             config={"configurable": {"thread_id": thread_id}}
         )
-    interrupt = pending_interrupt(root)
+    interrupt = pending_interrupt(root, interrupt_id)
     if interrupt is None:
         return None
     namespace, scope, current = "", root, interrupt
+    subagent_call: dict[str, Any] | None = None
     for _ in range(MAX_SUBAGENT_DEPTH):
         if not current.task_id:
             break
@@ -150,11 +180,14 @@ async def load_interrupt_scope(
         child = await checkpointer.aget_tuple(
             config={"configurable": {"thread_id": thread_id, "checkpoint_ns": child_ns}}
         )
-        child_interrupt = pending_interrupt(child) if child is not None else None
-        if child_interrupt is None or child_interrupt.id != interrupt.id:
+        child_interrupt = (
+            pending_interrupt(child, interrupt.id) if child is not None else None
+        )
+        if child_interrupt is None:
             break
+        if not namespace:
+            subagent_call = _paused_task_call(root, _messages_of(child))
         namespace, scope, current = child_ns, child, child_interrupt
-    subagent_call = _paused_task_call(root, _messages_of(scope)) if namespace else None
     return InterruptScope(
         root=root,
         interrupt=interrupt,
@@ -162,6 +195,24 @@ async def load_interrupt_scope(
         checkpoint=scope,
         subagent_call=subagent_call,
     )
+
+
+async def load_interrupt_scopes(
+    checkpointer: Any, thread_id: str, root: Any = None
+) -> list[InterruptScope]:
+    """Every pending interrupt on the thread, each located to its scope."""
+    if root is None:
+        root = await checkpointer.aget_tuple(
+            config={"configurable": {"thread_id": thread_id}}
+        )
+    scopes: list[InterruptScope] = []
+    for interrupt in pending_interrupts(root):
+        scope = await load_interrupt_scope(
+            checkpointer, thread_id, root=root, interrupt_id=interrupt.id
+        )
+        if scope is not None:
+            scopes.append(scope)
+    return scopes
 
 
 def pending_approval_requests(

--- a/backend/app/agents/hitl.py
+++ b/backend/app/agents/hitl.py
@@ -8,9 +8,18 @@ the checkpoint on every read, stored nowhere by us). Everything here is a
 pure function of a checkpoint tuple plus client-supplied decisions: no
 session, no Redis, nothing that can expire.
 
+A subagent's gated tool interrupts too (deepagents' `task` runs it as a
+nested subgraph on the same checkpointer): the interrupt propagates to the
+root checkpoint's `pending_writes` under the parent's `tools` task, while the
+gated tool call itself lives in the subagent's own checkpoint, namespaced
+`tools:<that task id>`. `load_interrupt_scope` follows that link so approvals
+carry the real `tool_call_id` whichever agent paused; the pure helpers take
+the interrupting (root) checkpoint plus that `scope` checkpoint.
+
 Consumers: the thread read endpoint (rehydrating the approval UI), the run
 worker (terminal-status detection), the Slack consumer (posting approval
-cards), and `RunService.create` (canonicalizing an addressed resume).
+cards), `RunService.create` (canonicalizing an addressed resume), and the
+protocol state snapshot (interrupt namespace for the client).
 """
 
 import re
@@ -32,6 +41,50 @@ class PendingInterrupt(NamedTuple):
 
     id: str | None
     value: Any
+    #: The pending write's task id — for an interrupt that bubbled up from a
+    #: subagent, the parent's `tools` task, i.e. the subagent's namespace is
+    #: ``tools:<task_id>``. None for the dict shapes that don't carry one.
+    task_id: str | None = None
+
+
+class InterruptScope(NamedTuple):
+    """A pending interrupt located to the checkpoint that holds its tool calls.
+
+    `root` is the thread's root checkpoint tuple (the interrupt, its id and the
+    resume target live there); `checkpoint` is the tuple whose `messages`
+    channel holds the gated tool calls — the root itself for a parent-agent
+    approval, the subagent's `tools:<task-id>` checkpoint (nested further as
+    `tools:<a>|tools:<b>` for a subagent's subagent) when a subagent paused.
+    `namespace` is that checkpoint namespace (``""`` at the root) and
+    `subagent_call` the root `task` tool call awaiting the paused subagent.
+    """
+
+    root: Any
+    interrupt: PendingInterrupt
+    namespace: str
+    checkpoint: Any
+    subagent_call: dict[str, Any] | None
+
+    @property
+    def namespace_path(self) -> list[str]:
+        """The namespace as the protocol's segment list (``[]`` at the root)."""
+        return [seg for seg in self.namespace.split(_NS_SEP) if seg]
+
+    @property
+    def subagent_type(self) -> str | None:
+        """The paused subagent's `subagent_type`, when a subagent paused."""
+        if self.subagent_call is None:
+            return None
+        return (self.subagent_call.get("args") or {}).get("subagent_type")
+
+
+#: How many `task` levels `load_interrupt_scope` follows — a subagent's
+#: subagent's subagent is already deeper than any agent graph auxilia builds.
+MAX_SUBAGENT_DEPTH = 4
+
+#: langgraph's checkpoint-namespace separator (`langgraph.constants.NS_SEP`).
+_NS_SEP = "|"
+_TOOLS_NS_PREFIX = "tools:"
 
 
 #: `Command(resume=...)` is treated as a map keyed by interrupt ids only when
@@ -48,7 +101,9 @@ def pending_interrupt(checkpoint_tuple: Any) -> PendingInterrupt | None:
     plain ``{"value": ..., "id": ...}`` dict, mirroring the two shapes the
     live stream and older checkpoints produce.
     """
-    for _, channel, value in getattr(checkpoint_tuple, "pending_writes", None) or []:
+    for task_id, channel, value in (
+        getattr(checkpoint_tuple, "pending_writes", None) or []
+    ):
         if channel != "__interrupt__":
             continue
         batch = value if isinstance(value, (list, tuple)) else [value]
@@ -56,14 +111,62 @@ def pending_interrupt(checkpoint_tuple: Any) -> PendingInterrupt | None:
             continue
         first = batch[0]
         if isinstance(first, dict) and "value" in first:
-            return PendingInterrupt(id=first.get("id"), value=first.get("value"))
+            return PendingInterrupt(
+                id=first.get("id"), value=first.get("value"), task_id=task_id
+            )
         return PendingInterrupt(
-            id=getattr(first, "id", None), value=getattr(first, "value", first)
+            id=getattr(first, "id", None),
+            value=getattr(first, "value", first),
+            task_id=task_id,
         )
     return None
 
 
-def pending_approval_requests(checkpoint_tuple: Any) -> list[dict[str, Any]]:
+async def load_interrupt_scope(
+    checkpointer: Any, thread_id: str, root: Any = None
+) -> InterruptScope | None:
+    """Locate the thread's pending interrupt, or None when nothing is pending.
+
+    Reads the root checkpoint (or takes it as `root`), then follows the
+    interrupting task into `tools:<task_id>` for as long as a checkpoint exists
+    there and is paused on the *same* interrupt id: one hop for a subagent,
+    one more per nesting level, none for a parent-agent approval (its pending
+    write's task is the HITL node, which has no namespace of its own). The
+    descent is bounded by `MAX_SUBAGENT_DEPTH` so a checkpointer answering
+    every namespace can never make it loop.
+    """
+    if root is None:
+        root = await checkpointer.aget_tuple(
+            config={"configurable": {"thread_id": thread_id}}
+        )
+    interrupt = pending_interrupt(root)
+    if interrupt is None:
+        return None
+    namespace, scope, current = "", root, interrupt
+    for _ in range(MAX_SUBAGENT_DEPTH):
+        if not current.task_id:
+            break
+        child_ns = f"{namespace}{_NS_SEP if namespace else ''}{_TOOLS_NS_PREFIX}{current.task_id}"
+        child = await checkpointer.aget_tuple(
+            config={"configurable": {"thread_id": thread_id, "checkpoint_ns": child_ns}}
+        )
+        child_interrupt = pending_interrupt(child) if child is not None else None
+        if child_interrupt is None or child_interrupt.id != interrupt.id:
+            break
+        namespace, scope, current = child_ns, child, child_interrupt
+    subagent_call = _paused_task_call(root, _messages_of(scope)) if namespace else None
+    return InterruptScope(
+        root=root,
+        interrupt=interrupt,
+        namespace=namespace,
+        checkpoint=scope,
+        subagent_call=subagent_call,
+    )
+
+
+def pending_approval_requests(
+    checkpoint_tuple: Any, scope: Any = None
+) -> list[dict[str, Any]]:
     """Return the tool calls awaiting human approval on a paused checkpoint.
 
     `HumanInTheLoopMiddleware` interrupts with a `HITLRequest` whose
@@ -71,6 +174,12 @@ def pending_approval_requests(checkpoint_tuple: Any) -> list[dict[str, Any]]:
     are positional. We re-attach each request to the originating tool call (by
     name+args, falling back to position) so callers get a stable
     `tool_call_id` for the approve/reject UI. Returns `[]` when not interrupted.
+
+    The interrupt is read off `checkpoint_tuple` (the root); the tool calls off
+    `scope` when given — the subagent checkpoint `load_interrupt_scope`
+    located — else off the same tuple. Without the scope, a subagent's
+    approvals fall back to positional `approval-<i>` ids: the root's last AI
+    message only carries the `task` call.
     """
     interrupt = pending_interrupt(checkpoint_tuple)
     interrupt_value = interrupt.value if interrupt else None
@@ -82,10 +191,9 @@ def pending_approval_requests(checkpoint_tuple: Any) -> list[dict[str, Any]]:
     if not requests:
         return []
 
-    channel_values = getattr(checkpoint_tuple, "checkpoint", {}).get(
-        "channel_values", {}
+    tool_calls = _last_pending_tool_calls(
+        _messages_of(scope if scope is not None else checkpoint_tuple)
     )
-    tool_calls = _last_pending_tool_calls(channel_values.get("messages", []))
 
     approvals: list[dict[str, Any]] = []
     used: set[int] = set()
@@ -113,7 +221,7 @@ def is_addressed_resume(resume: Any) -> bool:
 
 
 def build_resume_command(
-    checkpoint_tuple: Any, resume: dict[str, Any]
+    checkpoint_tuple: Any, resume: dict[str, Any], scope: Any = None
 ) -> dict[str, Any]:
     """Turn an addressed resume into the canonical command to store and run.
 
@@ -126,6 +234,9 @@ def build_resume_command(
     id-keyed form, so LangGraph applies it only to the addressed interrupt.
     When the checkpoint carries no usable id, falls back to the plain form,
     which still targets the single pending interrupt.
+
+    `scope` is the checkpoint holding the gated tool calls (see
+    `pending_approval_requests`); the resume itself always targets the root.
 
     Raises `StaleApprovalError` when nothing is pending or the addressed
     interrupt was already resolved (the thread moved on — e.g. approved from
@@ -153,7 +264,9 @@ def build_resume_command(
             k: v for k, v in decision.items() if k != "tool_call_id"
         }
 
-    expected = [r["tool_call_id"] for r in pending_approval_requests(checkpoint_tuple)]
+    expected = [
+        r["tool_call_id"] for r in pending_approval_requests(checkpoint_tuple, scope)
+    ]
     missing = [tc for tc in expected if tc not in supplied]
     unknown = [tc for tc in supplied if tc not in expected]
     if missing or unknown:
@@ -166,6 +279,35 @@ def build_resume_command(
     if pending.id is None or not _INTERRUPT_ID_RE.fullmatch(pending.id):
         return {"resume": payload}
     return {"resume": {pending.id: payload}}
+
+
+def _messages_of(checkpoint_tuple: Any) -> list:
+    return (
+        (getattr(checkpoint_tuple, "checkpoint", None) or {})
+        .get("channel_values", {})
+        .get("messages", [])
+    )
+
+
+def _paused_task_call(root: Any, scope_messages: list) -> dict[str, Any] | None:
+    """The root `task` tool call whose subagent is the paused one.
+
+    Several subagents can run in parallel, so the pending `task` calls are
+    told apart by the subagent's seed: `task` starts the subagent with its
+    `description` as the first human message.
+    """
+    pending = [
+        tc
+        for tc in _last_pending_tool_calls(_messages_of(root))
+        if tc.get("name") == "task"
+    ]
+    if not pending:
+        return None
+    seed = scope_messages[0].content if scope_messages else None
+    for tc in pending:
+        if (tc.get("args") or {}).get("description") == seed:
+            return tc
+    return pending[0] if len(pending) == 1 else None
 
 
 def _last_pending_tool_calls(messages: list) -> list[dict[str, Any]]:

--- a/backend/app/agents/hitl.py
+++ b/backend/app/agents/hitl.py
@@ -153,16 +153,9 @@ async def load_interrupt_scope(
 ) -> InterruptScope | None:
     """Locate the thread's pending interrupt, or None when nothing is pending.
 
-    Reads the root checkpoint (or takes it as `root`), picks the interrupt
-    (`interrupt_id` when an addressed resume names one, else the first), then
-    follows its task into `tools:<task_id>` for as long as a checkpoint exists
-    there and is paused on the *same* interrupt id: one hop for a subagent,
-    one more per nesting level, none for a parent-agent approval (its pending
-    write's task is the HITL node, which has no namespace of its own). The
-    descent is bounded by `MAX_SUBAGENT_DEPTH` so a checkpointer answering
-    every namespace can never make it loop. The root `task` call that started
-    the paused subagent is matched on the first hop, where the child's seed
-    message is that call's description.
+    Reads the root checkpoint (or takes it as `root`) and picks the interrupt
+    (`interrupt_id` when an addressed resume names one, else the first); see
+    `_scope_of` for the descent into the paused subagent.
     """
     if root is None:
         root = await checkpointer.aget_tuple(
@@ -171,6 +164,35 @@ async def load_interrupt_scope(
     interrupt = pending_interrupt(root, interrupt_id)
     if interrupt is None:
         return None
+    return await _scope_of(checkpointer, thread_id, root, interrupt)
+
+
+async def load_interrupt_scopes(
+    checkpointer: Any, thread_id: str, root: Any = None
+) -> list[InterruptScope]:
+    """Every pending interrupt on the thread, each located to its scope — by
+    its own pending write, so id-less (older) entries resolve too."""
+    if root is None:
+        root = await checkpointer.aget_tuple(
+            config={"configurable": {"thread_id": thread_id}}
+        )
+    return [
+        await _scope_of(checkpointer, thread_id, root, interrupt)
+        for interrupt in pending_interrupts(root)
+    ]
+
+
+async def _scope_of(
+    checkpointer: Any, thread_id: str, root: Any, interrupt: PendingInterrupt
+) -> InterruptScope:
+    """Follow `interrupt`'s task into `tools:<task_id>` for as long as a
+    checkpoint exists there and is paused on the *same* interrupt id: one hop
+    for a subagent, one more per nesting level, none for a parent-agent
+    approval (its pending write's task is the HITL node, which has no
+    namespace of its own). The descent is bounded by `MAX_SUBAGENT_DEPTH` so
+    a checkpointer answering every namespace can never make it loop. The root
+    `task` call that started the paused subagent is matched on the first hop,
+    where the child's seed message is that call's description."""
     namespace, scope, current = "", root, interrupt
     subagent_call: dict[str, Any] | None = None
     for _ in range(MAX_SUBAGENT_DEPTH):
@@ -195,24 +217,6 @@ async def load_interrupt_scope(
         checkpoint=scope,
         subagent_call=subagent_call,
     )
-
-
-async def load_interrupt_scopes(
-    checkpointer: Any, thread_id: str, root: Any = None
-) -> list[InterruptScope]:
-    """Every pending interrupt on the thread, each located to its scope."""
-    if root is None:
-        root = await checkpointer.aget_tuple(
-            config={"configurable": {"thread_id": thread_id}}
-        )
-    scopes: list[InterruptScope] = []
-    for interrupt in pending_interrupts(root):
-        scope = await load_interrupt_scope(
-            checkpointer, thread_id, root=root, interrupt_id=interrupt.id
-        )
-        if scope is not None:
-            scopes.append(scope)
-    return scopes
 
 
 def pending_approval_requests(

--- a/backend/app/agents/protocol/emit.py
+++ b/backend/app/agents/protocol/emit.py
@@ -413,17 +413,20 @@ class ProtocolEmitter:
         langgraph stringifies the exception: ``(Interrupt(value=..., id='…'),)``.
         Three checks, so a genuine failure is never mistaken for a pause: the
         failing call is the `task` tool (name recorded at `tool-started`), the
-        message has the repr's shape, and every interrupt id it names is one
-        the subagent's own `values` envelope announced just before.
+        message has the repr's shape, and it names at least one interrupt id,
+        every one of which the subagent's own `values` envelope announced
+        just before.
         """
         if self._tool_names.get(tool_call_id) != "task":
             return False
         if not isinstance(message, str) or _INTERRUPT_REPR.match(message) is None:
             return False
         named = _INTERRUPT_ID_IN_REPR.findall(message)
-        return not named or all(
-            interrupt_id in self._interrupt_ids for interrupt_id in named
-        )
+        if not named:
+            # langgraph's repr always names the id; a shape without one is
+            # some other failure and must reach the client.
+            return False
+        return all(interrupt_id in self._interrupt_ids for interrupt_id in named)
 
     def _tool_result(
         self, namespace: list[str], tool_call_id: str, output: Any

--- a/backend/app/agents/protocol/emit.py
+++ b/backend/app/agents/protocol/emit.py
@@ -53,6 +53,7 @@ root-cause message) instead of being swallowed into an event.
 """
 
 import logging
+import re
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
@@ -86,6 +87,11 @@ _SUBGRAPH_STATUS = {
     "interrupted": "interrupted",
     "drained": "completed",
 }
+
+
+#: `str(GraphInterrupt(...))` — the shape a bubbling interrupt takes on the
+#: `tools` channel's `tool-error` message.
+_INTERRUPT_REPR = re.compile(r"^\(?Interrupt\(")
 
 
 def _ns_key(namespace: list[str]) -> str:
@@ -227,6 +233,7 @@ class ProtocolEmitter:
                 if first_human is not None:
                     trimmed["messages"] = [serialize_message(first_human)]
             out.append(ev.values_event(namespace, trimmed))
+            out.extend(self._input_requested(namespace, interrupts))
             return out
 
         out.append(ev.values_event([], trimmed))
@@ -238,6 +245,20 @@ class ProtocolEmitter:
             # only an id makes the echo deduplicable.
             if isinstance(message, HumanMessage) and isinstance(message.content, str):
                 out.extend(self._whole_message([], None, message, role="human"))
+        out.extend(self._input_requested([], interrupts))
+        return out
+
+    def _input_requested(self, namespace: list[str], interrupts: Any) -> list[dict]:
+        """`input.requested` for each interrupt not yet announced.
+
+        A subagent's interrupt rides on two `values` envelopes: its own
+        namespace's first (langgraph streams the subgraph's superstep before
+        the parent's), then the root's, once it has bubbled up through the
+        `task` tool. The first one wins, so the event carries the namespace
+        of the agent that actually paused and the client can pin the approval
+        to that subagent's card; the root copy is dropped by id.
+        """
+        out: list[dict] = []
         for interrupt in interrupts or ():
             interrupt_id = getattr(interrupt, "id", None)
             value = getattr(interrupt, "value", interrupt)
@@ -246,7 +267,9 @@ class ProtocolEmitter:
             if not isinstance(interrupt_id, str) or interrupt_id in self._interrupt_ids:
                 continue
             self._interrupt_ids.add(interrupt_id)
-            out.append(ev.input_requested([], interrupt_id=interrupt_id, payload=value))
+            out.append(
+                ev.input_requested(namespace, interrupt_id=interrupt_id, payload=value)
+            )
         return out
 
     # --- updates ------------------------------------------------------------------
@@ -351,6 +374,15 @@ class ProtocolEmitter:
         if kind == "tool-error":
             if not tool_call_id or tool_call_id in self._tool_finished_ids:
                 return []
+            if self._is_bubbling_interrupt(data.get("message")):
+                # A subagent's approval interrupt bubbles up through the
+                # `task` tool, and langgraph reports that to the parent's
+                # tool callbacks as a failure. It is not one: the call is
+                # paused, its subagent resumes into the same call later, and
+                # forwarding this would have the client mark the subagent
+                # card errored (with the Interrupt repr as the message) for
+                # the length of the pause. Leave the call running.
+                return []
             self._tool_finished_ids.add(tool_call_id)
             return [
                 ev.tool_error(
@@ -367,6 +399,20 @@ class ProtocolEmitter:
             return self._tool_result(namespace, str(tool_call_id), data.get("output"))
         # `tool-output-delta` is not part of the client contract yet.
         return []
+
+    def _is_bubbling_interrupt(self, message: Any) -> bool:
+        """Whether a `tool-error` message is a `GraphInterrupt` in flight.
+
+        langgraph stringifies the exception: ``(Interrupt(value=..., id='…'),)``.
+        The subagent's own `values` envelope announced that id just before,
+        so the id is the primary match; the repr shape is the fallback for an
+        ordering we did not observe.
+        """
+        if not isinstance(message, str):
+            return False
+        if any(interrupt_id in message for interrupt_id in self._interrupt_ids):
+            return "Interrupt(" in message
+        return _INTERRUPT_REPR.match(message) is not None
 
     def _tool_result(
         self, namespace: list[str], tool_call_id: str, output: Any

--- a/backend/app/agents/protocol/emit.py
+++ b/backend/app/agents/protocol/emit.py
@@ -92,6 +92,8 @@ _SUBGRAPH_STATUS = {
 #: `str(GraphInterrupt(...))` — the shape a bubbling interrupt takes on the
 #: `tools` channel's `tool-error` message.
 _INTERRUPT_REPR = re.compile(r"^\(?Interrupt\(")
+#: The ``id='<xxh3-128 hex>'`` field(s) inside that repr.
+_INTERRUPT_ID_IN_REPR = re.compile(r"\bid='([0-9a-f]{32})'")
 
 
 def _ns_key(namespace: list[str]) -> str:
@@ -114,6 +116,9 @@ class ProtocolEmitter:
         self._echoed_message_ids: set[str] = set()
         self._bound_namespaces: set[str] = set()
         self._tool_started_ids: set[str] = set()
+        #: tool-call id -> tool name, from `tool-started`; a bubbling
+        #: interrupt is only ever reported against the `task` tool.
+        self._tool_names: dict[str, str] = {}
         self._tool_finished_ids: set[str] = set()
 
     async def stream(self, run: AsyncIterator[dict]) -> AsyncGenerator[dict, None]:
@@ -346,6 +351,8 @@ class ProtocolEmitter:
             return []
         if tool_call_id in self._tool_started_ids:
             return []
+        if isinstance(tool_name, str):
+            self._tool_names[tool_call_id] = tool_name
         self._tool_started_ids.add(tool_call_id)
         return [
             ev.tool_started(
@@ -374,7 +381,7 @@ class ProtocolEmitter:
         if kind == "tool-error":
             if not tool_call_id or tool_call_id in self._tool_finished_ids:
                 return []
-            if self._is_bubbling_interrupt(data.get("message")):
+            if self._is_bubbling_interrupt(str(tool_call_id), data.get("message")):
                 # A subagent's approval interrupt bubbles up through the
                 # `task` tool, and langgraph reports that to the parent's
                 # tool callbacks as a failure. It is not one: the call is
@@ -400,19 +407,23 @@ class ProtocolEmitter:
         # `tool-output-delta` is not part of the client contract yet.
         return []
 
-    def _is_bubbling_interrupt(self, message: Any) -> bool:
-        """Whether a `tool-error` message is a `GraphInterrupt` in flight.
+    def _is_bubbling_interrupt(self, tool_call_id: str, message: Any) -> bool:
+        """Whether a `task` call's `tool-error` is a `GraphInterrupt` in flight.
 
         langgraph stringifies the exception: ``(Interrupt(value=..., id='…'),)``.
-        The subagent's own `values` envelope announced that id just before,
-        so the id is the primary match; the repr shape is the fallback for an
-        ordering we did not observe.
+        Three checks, so a genuine failure is never mistaken for a pause: the
+        failing call is the `task` tool (name recorded at `tool-started`), the
+        message has the repr's shape, and every interrupt id it names is one
+        the subagent's own `values` envelope announced just before.
         """
-        if not isinstance(message, str):
+        if self._tool_names.get(tool_call_id) != "task":
             return False
-        if any(interrupt_id in message for interrupt_id in self._interrupt_ids):
-            return "Interrupt(" in message
-        return _INTERRUPT_REPR.match(message) is not None
+        if not isinstance(message, str) or _INTERRUPT_REPR.match(message) is None:
+            return False
+        named = _INTERRUPT_ID_IN_REPR.findall(message)
+        return not named or all(
+            interrupt_id in self._interrupt_ids for interrupt_id in named
+        )
 
     def _tool_result(
         self, namespace: list[str], tool_call_id: str, output: Any

--- a/backend/app/agents/protocol/service.py
+++ b/backend/app/agents/protocol/service.py
@@ -26,7 +26,7 @@ from typing import Any
 from langchain_core.messages import ToolMessage
 from redis.asyncio import Redis
 
-from app.agents.hitl import pending_interrupt
+from app.agents.hitl import load_interrupt_scope
 from app.agents.protocol.events import terminal_lifecycle
 from app.agents.protocol.filter import StreamFilter
 from app.agents.protocol.messages import serialize_message
@@ -279,19 +279,31 @@ class ProtocolService:
                 values["todos"] = todos
             if (structured := channel_values.get("structured_response")) is not None:
                 values["structured_response"] = structured
-            interrupt = pending_interrupt(checkpoint_tuple)
+            scope = await load_interrupt_scope(
+                checkpointer, thread_id, root=checkpoint_tuple
+            )
+            interrupt = scope.interrupt if scope else None
 
         active = await self.runs.get_active(thread_id)
         # `next` non-empty ⇔ a run is executing or a resume is awaited — the
         # client's activity gate opens its live pumps only then.
         next_nodes = ["agent"] if active is not None or interrupt is not None else []
         tasks = []
-        if interrupt is not None:
+        if interrupt is not None and scope is not None:
+            # `namespace` is the paused agent's — `[]` for the parent, the
+            # subagent's `["tools:<task-id>"]` otherwise — so hydration lands
+            # the approval on the same card the live stream would.
             tasks.append(
                 {
                     "id": interrupt.id or "interrupt",
                     "name": "agent",
-                    "interrupts": [{"id": interrupt.id, "value": interrupt.value}],
+                    "interrupts": [
+                        {
+                            "id": interrupt.id,
+                            "value": interrupt.value,
+                            "namespace": scope.namespace_path,
+                        }
+                    ],
                 }
             )
         return {"values": values, "next": next_nodes, "tasks": tasks}

--- a/backend/app/agents/protocol/service.py
+++ b/backend/app/agents/protocol/service.py
@@ -26,7 +26,7 @@ from typing import Any
 from langchain_core.messages import ToolMessage
 from redis.asyncio import Redis
 
-from app.agents.hitl import load_interrupt_scope
+from app.agents.hitl import InterruptScope, load_interrupt_scopes
 from app.agents.protocol.events import terminal_lifecycle
 from app.agents.protocol.filter import StreamFilter
 from app.agents.protocol.messages import serialize_message
@@ -267,7 +267,7 @@ class ProtocolService:
                 config={"configurable": {"thread_id": thread_id}}
             )
         values: dict[str, Any] = {"messages": []}
-        interrupt = None
+        scopes: list[InterruptScope] = []
         if checkpoint_tuple is not None:
             channel_values = checkpoint_tuple.checkpoint.get("channel_values", {})
             values = {
@@ -279,33 +279,30 @@ class ProtocolService:
                 values["todos"] = todos
             if (structured := channel_values.get("structured_response")) is not None:
                 values["structured_response"] = structured
-            scope = await load_interrupt_scope(
+            scopes = await load_interrupt_scopes(
                 checkpointer, thread_id, root=checkpoint_tuple
             )
-            interrupt = scope.interrupt if scope else None
 
         active = await self.runs.get_active(thread_id)
         # `next` non-empty ⇔ a run is executing or a resume is awaited — the
         # client's activity gate opens its live pumps only then.
-        next_nodes = ["agent"] if active is not None or interrupt is not None else []
-        tasks = []
-        if interrupt is not None and scope is not None:
-            # `namespace` is the paused agent's — `[]` for the parent, the
-            # subagent's `["tools:<task-id>"]` otherwise — so hydration lands
-            # the approval on the same card the live stream would.
-            tasks.append(
-                {
-                    "id": interrupt.id or "interrupt",
-                    "name": "agent",
-                    "interrupts": [
-                        {
-                            "id": interrupt.id,
-                            "value": interrupt.value,
-                            "namespace": scope.namespace_path,
-                        }
-                    ],
-                }
-            )
+        next_nodes = ["agent"] if active is not None or scopes else []
+        # One task per pending interrupt (parallel subagents can pause
+        # together), each with the namespace the client should pin it to.
+        tasks = [
+            {
+                "id": scope.interrupt.id or "interrupt",
+                "name": "agent",
+                "interrupts": [
+                    {
+                        "id": scope.interrupt.id,
+                        "value": scope.interrupt.value,
+                        "namespace": _hydration_namespace(scope),
+                    }
+                ],
+            }
+            for scope in scopes
+        ]
         return {"values": values, "next": next_nodes, "tasks": tasks}
 
     async def thread_history(self, thread_id: str, checkpoint_ns: str | None) -> list:
@@ -341,6 +338,29 @@ class ProtocolService:
 
 
 _TOOLS_NS_PREFIX = "tools:"
+
+
+def _hydration_namespace(scope: InterruptScope) -> list[str]:
+    """The namespace a hydrating client can pin the interrupt to.
+
+    Live, a subagent's events carry its execution namespace
+    (`tools:<pregel task id>`), which the SDK binds onto the discovery
+    snapshot as they stream. A page that hydrates instead rebuilds the
+    snapshot from history under the SDK's *discovery* key,
+    `tools:<task tool_call_id>`, and never learns the execution namespace
+    until the subagent streams again. So the hydrated interrupt is addressed
+    with that key, which the card recognises in either state. A parent
+    approval is `[]`; a nested subagent's (no single task call to name) keeps
+    its real path.
+    """
+    if scope.namespace and scope.subagent_call and _NS_SEP not in scope.namespace:
+        call_id = scope.subagent_call.get("id")
+        if isinstance(call_id, str) and call_id:
+            return [f"{_TOOLS_NS_PREFIX}{call_id}"]
+    return scope.namespace_path
+
+
+_NS_SEP = "|"
 
 
 async def _subagent_messages(checkpointer, thread_id: str, tool_call_id: str) -> list:

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -128,10 +128,21 @@ class RunService:
         """
         if not is_addressed_resume(command.get("resume")):
             return command
+        # Addressed by id: with parallel subagents paused together the resume
+        # must target the one the client answered, not the first pending.
+        interrupt_id = command["resume"].get("interrupt_id")
         async with get_checkpointer() as checkpointer:
-            scope = await load_interrupt_scope(checkpointer, thread_id)
+            scope = await load_interrupt_scope(
+                checkpointer,
+                thread_id,
+                interrupt_id=interrupt_id if isinstance(interrupt_id, str) else None,
+            )
         if scope is None:
-            raise StaleApprovalError("No approval is pending on this thread.")
+            raise StaleApprovalError(
+                "No approval is pending on this thread."
+                if interrupt_id is None
+                else "This approval request was already handled."
+            )
         # The decisions are matched against the checkpoint that holds the
         # gated tool calls — a subagent's own when a subagent paused.
         return build_resume_command(scope.root, command["resume"], scope.checkpoint)

--- a/backend/app/agents/runs/service.py
+++ b/backend/app/agents/runs/service.py
@@ -18,7 +18,11 @@ from uuid import UUID
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agents.hitl import build_resume_command, is_addressed_resume
+from app.agents.hitl import (
+    build_resume_command,
+    is_addressed_resume,
+    load_interrupt_scope,
+)
 from app.agents.runs import keys
 from app.agents.runs.control import RunControl
 from app.agents.runs.events import RunEventStream, terminal_entry
@@ -28,7 +32,7 @@ from app.agents.runs.repository import RunRepository
 from app.agents.runs.settings import run_settings
 from app.agents.runs.state import MultitaskStrategy, RunStatus, is_terminal
 from app.database import AsyncSessionLocal, get_checkpointer
-from app.exceptions import DomainValidationError, NotFoundError
+from app.exceptions import DomainValidationError, NotFoundError, StaleApprovalError
 from app.model_providers.service import ModelService
 from app.redis_client import get_redis
 from app.threads.models import ThreadDB
@@ -125,10 +129,12 @@ class RunService:
         if not is_addressed_resume(command.get("resume")):
             return command
         async with get_checkpointer() as checkpointer:
-            checkpoint = await checkpointer.aget_tuple(
-                config={"configurable": {"thread_id": thread_id}}
-            )
-        return build_resume_command(checkpoint, command["resume"])
+            scope = await load_interrupt_scope(checkpointer, thread_id)
+        if scope is None:
+            raise StaleApprovalError("No approval is pending on this thread.")
+        # The decisions are matched against the checkpoint that holds the
+        # gated tool calls — a subagent's own when a subagent paused.
+        return build_resume_command(scope.root, command["resume"], scope.checkpoint)
 
     @staticmethod
     async def _ensure_runnable_thread(db: AsyncSession, thread_id: str) -> None:

--- a/backend/app/agents/runtime.py
+++ b/backend/app/agents/runtime.py
@@ -61,8 +61,9 @@ from app.threads.models import ThreadDB
 logger = logging.getLogger(__name__)
 
 
-# LangGraph's default recursion limit — what a subagent actually runs under,
-# since the deepagents task tool builds a fresh config without ours.
+# LangGraph's default recursion limit — what a subagent actually runs under:
+# the deepagents ``task`` tool forwards the parent's ``configurable`` (and so
+# its checkpointer and namespace) but not its ``recursion_limit``.
 SUBAGENT_RECURSION_LIMIT = 25
 
 RECURSION_LIMIT_MESSAGE = (
@@ -202,19 +203,21 @@ def build_agent_middleware(
     calls stay in invalid_tool_calls (invisible to HITL) until Repair promotes
     them into tool_calls answered by error ToolMessages.
 
-    Parent and subagent differ in exactly two documented ways:
+    ``interrupt_on`` — a mapping (even an empty one) means this agent runs
+    against a checkpointer, so it can be interrupted for approval and can have
+    dangling tool calls persisted by an aborted turn; ``None`` drops both the
+    approval gate and the patcher. Parent *and* subagents are checkpointed:
+    the deepagents ``task`` tool spreads the parent's ``configurable`` into the
+    subagent, which carries the checkpointer and the ``tools:<task-id>``
+    namespace, so a subagent's interrupt propagates to the root checkpoint
+    (with an id that encodes its namespace) and an id-keyed resume routes back
+    into it — see ``app/agents/hitl.py``. Only tests and the structured-output
+    formatting turn pass ``None``.
 
-    - ``interrupt_on`` — a mapping (even an empty one) means this agent runs
-      against a checkpointer, so it can be interrupted for approval and can
-      have dangling tool calls persisted by an aborted turn. A subagent has
-      neither: the deepagents ``task`` tool invokes CompiledSubAgent runnables
-      with a fresh config and no checkpointer, so it passes ``None`` and loses
-      both the approval gate and the patcher. Approval gates on subagent tools
-      being silently dropped is a known product gap: issue #301.
-    - ``recursion_limit`` — the tool budget is sized to end the run gracefully
-      one step before the graph's own recursion limit trips. A subagent runs
-      under langgraph's default (``SUBAGENT_RECURSION_LIMIT``) rather than
-      ours, because ``task`` doesn't propagate the parent's config.
+    ``recursion_limit`` — the tool budget is sized to end the run gracefully
+    one step before the graph's own recursion limit trips. A subagent runs
+    under langgraph's default (``SUBAGENT_RECURSION_LIMIT``) rather than ours,
+    because ``task`` doesn't forward the parent's ``recursion_limit``.
     """
     checkpointed = interrupt_on is not None
     return [
@@ -318,13 +321,14 @@ class ResolvedAgent:
         subagent's system prompt by ``CurrentDateMiddleware``.
 
         A subagent gets its own copy of the shared middleware stack rather than
-        inheriting the parent's: the deepagents ``task`` tool invokes it with a
-        fresh config (parent middleware and recursion_limit don't propagate)
-        and reports back only ``messages[-1].text``, so a subagent that exits
-        its loop silently (invalid tool-call JSON) would return an empty
-        ToolMessage and one that blows the recursion limit would discard its
-        progress. It runs without a checkpointer, which is what drops the
-        approval gate — see ``build_agent_middleware`` for both differences.
+        inheriting the parent's: the deepagents ``task`` tool invokes it as a
+        nested subgraph (parent middleware and recursion_limit don't propagate,
+        the checkpointer does) and reports back only ``messages[-1].text``, so
+        a subagent that exits its loop silently (invalid tool-call JSON) would
+        return an empty ToolMessage and one that blows the recursion limit
+        would discard its progress. Its own ``interrupt_on`` gates its tools:
+        the interrupt surfaces on the root checkpoint and the web client /
+        Slack approve it like a parent's (issue #301).
         """
         sandbox = self.sandbox is not None
         # Subagent sandboxes get no turn-end persist hook: CompiledSubAgent
@@ -337,7 +341,9 @@ class ResolvedAgent:
             sandbox_backend=LazySandboxBackend() if sandbox else None,
             sandbox_provider=self.sandbox.provider if self.sandbox else None,
             base_middleware=build_agent_middleware(
-                created_at, recursion_limit=SUBAGENT_RECURSION_LIMIT
+                created_at,
+                recursion_limit=SUBAGENT_RECURSION_LIMIT,
+                interrupt_on=self.prepared.interrupt_on,
             ),
         )
         return CompiledSubAgent(

--- a/backend/app/integrations/slack/blocks.py
+++ b/backend/app/integrations/slack/blocks.py
@@ -13,6 +13,11 @@ def _quote_lines(lines: list[str]) -> str:
     return "\n".join(f"> {physical}" for line in lines for physical in line.split("\n"))
 
 
+def _escape_mrkdwn(text: str) -> str:
+    """Slack mrkdwn control characters, so a name renders as typed."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 def _format_tool_input(obj: Any, indent: int = 0) -> str:
     """Convert a JSON-compatible object into a clean YAML-like string."""
 
@@ -149,7 +154,10 @@ def build_tool_approval_blocks(
             {
                 "type": "context",
                 "elements": [
-                    {"type": "mrkdwn", "text": f"Requested by subagent *{subagent}*"}
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Requested by subagent *{_escape_mrkdwn(subagent)}*",
+                    }
                 ],
             }
         )

--- a/backend/app/integrations/slack/blocks.py
+++ b/backend/app/integrations/slack/blocks.py
@@ -105,12 +105,15 @@ def build_tool_approval_blocks(
     tool_call_id: str,
     tool_input: dict,
     interrupt_id: str | None = None,
+    subagent: str | None = None,
 ) -> list[dict]:
     """Build Block Kit blocks for a tool approval request with Approve/Reject buttons.
 
     The tool name is intentionally *not* repeated here: the streamed tool label
     (`format_tool_streamer_label`) already shows it immediately above this card,
-    so a header would be redundant.
+    so a header would be redundant. `subagent` names the subagent that asked,
+    when one did: its tool activity is not streamed to Slack, so without it a
+    card would appear to belong to the agent the user is talking to.
 
     The actions block carries a machine-readable ``block_id``
     (``hitl:<interrupt_id>:<tool_call_id>``) that ties the card to the
@@ -140,7 +143,18 @@ def build_tool_approval_blocks(
     }
     if interrupt_id is not None:
         actions_block["block_id"] = f"hitl:{interrupt_id}:{tool_call_id}"
+    blocks: list[dict] = []
+    if subagent:
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "mrkdwn", "text": f"Requested by subagent *{subagent}*"}
+                ],
+            }
+        )
     return [
+        *blocks,
         {
             "type": "section",
             "text": {"type": "mrkdwn", "text": _format_tool_input(tool_input)},

--- a/backend/app/integrations/slack/consumer.py
+++ b/backend/app/integrations/slack/consumer.py
@@ -16,7 +16,7 @@ from typing import Any, Final, Literal, TypedDict, cast
 from redis.asyncio import Redis
 from slack_sdk.web.async_client import AsyncWebClient
 
-from app.agents.hitl import pending_approval_requests, pending_interrupt
+from app.agents.hitl import load_interrupt_scope, pending_approval_requests
 from app.agents.protocol.wire import decode_event
 from app.agents.runs.delivery import DeliveryConsumer
 from app.agents.runs.models import RunDB
@@ -278,22 +278,27 @@ class SlackRunConsumer(DeliveryConsumer):
     async def _post_approvals(self, channel_id: str, thread_ts: str) -> None:
         """Post a Block Kit approve/reject message per pending tool call."""
         async with get_checkpointer() as checkpointer:
-            checkpoint = await checkpointer.aget_tuple(
-                config={"configurable": {"thread_id": self.record.thread_id}}
-            )
-        interrupt = pending_interrupt(checkpoint)
-        interrupt_id = interrupt.id if interrupt else None
-        for request in pending_approval_requests(checkpoint):
+            scope = await load_interrupt_scope(checkpointer, self.record.thread_id)
+        if scope is None:
+            return
+        # A subagent's gated calls live in its own checkpoint; the card says
+        # which subagent asked, since the tool name alone is ambiguous.
+        subagent = scope.subagent_type
+        for request in pending_approval_requests(scope.root, scope.checkpoint):
             blocks = build_tool_approval_blocks(
                 request["tool_call_id"],
                 request["input"],
-                interrupt_id=interrupt_id,
+                interrupt_id=scope.interrupt.id,
+                subagent=subagent,
             )
+            text = f"Approve {request['tool_name']}?"
+            if subagent:
+                text = f"Approve {request['tool_name']} for {subagent}?"
             await self.client.chat_postMessage(
                 channel=channel_id,
                 thread_ts=thread_ts,
                 blocks=blocks,
-                text=f"Approve {request['tool_name']}?",
+                text=text,
             )
 
     async def _post_auxilia_link(self, channel_id: str, thread_ts: str) -> None:

--- a/backend/app/integrations/slack/handlers.py
+++ b/backend/app/integrations/slack/handlers.py
@@ -13,8 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agents.core.service import AgentService
 from app.agents.hitl import (
     PendingInterrupt,
+    load_interrupt_scope,
     pending_approval_requests,
-    pending_interrupt,
 )
 from app.agents.runs.service import RunService
 from app.auth.settings import auth_settings
@@ -238,13 +238,11 @@ async def _pending_hitl_state(
     and what exposes a card whose interrupt was already resolved elsewhere.
     """
     async with get_checkpointer() as checkpointer:
-        checkpoint = await checkpointer.aget_tuple(
-            config={"configurable": {"thread_id": thread_id}}
-        )
-    interrupt = pending_interrupt(checkpoint)
-    if interrupt is None:
+        scope = await load_interrupt_scope(checkpointer, thread_id)
+    if scope is None:
         return None
-    return interrupt, pending_approval_requests(checkpoint)
+    # A subagent's approvals are matched in its own checkpoint (`scope`).
+    return scope.interrupt, pending_approval_requests(scope.root, scope.checkpoint)
 
 
 def _collect_batch_command(

--- a/backend/tests/agents/protocol/test_emit.py
+++ b/backend/tests/agents/protocol/test_emit.py
@@ -642,10 +642,15 @@ def test_only_the_task_tools_own_interrupt_is_swallowed():
     assert _kinds(_errored(emitter, "call_task", f"state dump: {iid}")) == [
         "tool-error"
     ]
-    # …and an interrupt id nobody announced is not ours to hide.
+    # …an interrupt id nobody announced is not ours to hide…
     _started(emitter, "call_task_2", "task")
     other = f"(Interrupt(value={{}}, id='{'cd' * 16}'),)"
     assert _kinds(_errored(emitter, "call_task_2", other)) == ["tool-error"]
+    # …nor is the shape without any id (langgraph's repr always names one).
+    _started(emitter, "call_task_3", "task")
+    assert _kinds(_errored(emitter, "call_task_3", "(Interrupt(value={}),)")) == [
+        "tool-error"
+    ]
 
 
 async def test_graph_failure_propagates_after_buffered_events():

--- a/backend/tests/agents/protocol/test_emit.py
+++ b/backend/tests/agents/protocol/test_emit.py
@@ -229,6 +229,75 @@ def scenario():
     return agent, config, checkpointer
 
 
+@tool
+def send_email(to: str) -> str:
+    """Send an email."""
+    return f"sent to {to}"
+
+
+@pytest.fixture
+def subagent_scenario():
+    """A root agent that delegates to a subagent whose own tool is HITL-gated:
+    the subagent pauses mid-`task`, the root answers after the resume."""
+    now = datetime.now(UTC)
+    mailer = CompiledSubAgent(
+        name="mailer",
+        description="mailer: sends mail",
+        runnable=build_runnable(
+            model=ScriptedModel(
+                script=[
+                    AIMessage(
+                        content="",
+                        id="sub-ai-1",
+                        tool_calls=[
+                            {
+                                "id": "sub_call_1",
+                                "name": "send_email",
+                                "args": {"to": "a@b.c"},
+                            }
+                        ],
+                    ),
+                    AIMessage(content="mail sent", id="sub-ai-2"),
+                ]
+            ),
+            tools=[send_email],
+            system_prompt="you send mail",
+            base_middleware=build_agent_middleware(
+                now, recursion_limit=25, interrupt_on={"send_email": True}
+            ),
+        ),
+    )
+    root_model = ScriptedModel(
+        script=[
+            AIMessage(
+                content="",
+                id="root-ai-1",
+                tool_calls=[
+                    {
+                        "id": "call_task_1",
+                        "name": "task",
+                        "args": {"description": "mail them", "subagent_type": "mailer"},
+                    }
+                ],
+            ),
+            AIMessage(content="Done.", id="root-ai-2"),
+        ]
+    )
+    checkpointer = MemorySaver()
+    agent = build_runnable(
+        model=root_model,
+        tools=[],
+        system_prompt="you are root",
+        base_middleware=build_agent_middleware(
+            now, recursion_limit=50, interrupt_on={}
+        ),
+        subagents=[mailer],
+        checkpointer=checkpointer,
+    )
+    config = {"configurable": {"thread_id": "emit-sub-test"}, "recursion_limit": 50}
+    return agent, config, checkpointer
+
+
 # ── End to end: a real v3 run ─────────────────────────────────────────────
 
 
@@ -455,6 +524,88 @@ async def test_rejected_tool_call_is_completed_with_tool_error(scenario):
         and _data(e).get("tool_call_id") == "call_w_1"
     ]
     assert len(tool_role_starts) == 1
+
+
+async def test_subagent_interrupt_is_requested_under_its_namespace(subagent_scenario):
+    """A subagent's approval: `input.requested` carries the subagent's
+    namespace (the client pins it to that card), exactly once even though the
+    root's `values` repeats the interrupt, and its id is the root checkpoint's
+    pending interrupt — what the id-keyed resume addresses."""
+    agent, config, checkpointer = subagent_scenario
+    events = await _collect(
+        agent, {"messages": [HumanMessage(content="hi", id="human-1")]}, config
+    )
+    [requested] = _of(events, "input.requested")
+    ns = requested["params"]["namespace"]
+    assert len(ns) == 1 and ns[0].startswith("tools:")
+    payload = _data(requested)["payload"]
+    assert payload["action_requests"][0]["name"] == "send_email"
+
+    checkpoint = await checkpointer.aget_tuple(config)
+    [(task_id, channel, value)] = checkpoint.pending_writes
+    assert channel == "__interrupt__"
+    assert value[0].id == _data(requested)["interrupt_id"]
+    assert ns == [f"tools:{task_id}"]
+
+    # The subagent's own lifecycle reports the pause.
+    assert _kinds(_of(events, "lifecycle", ns)) == ["started", "interrupted"]
+
+
+async def test_bubbling_interrupt_does_not_fail_the_task_call(subagent_scenario):
+    """langgraph reports the interrupt bubbling through `task` to the parent's
+    tool callbacks as a `tool-error`; forwarded, the client would mark the
+    subagent card errored for the length of the pause. The call stays open
+    and completes normally on the resumed run."""
+    agent, config, _ = subagent_scenario
+    events = await _collect(
+        agent, {"messages": [HumanMessage(content="hi", id="human-1")]}, config
+    )
+    task_events = [
+        e for e in _of(events, "tools", []) if _data(e)["tool_call_id"] == "call_task_1"
+    ]
+    assert _kinds(task_events) == ["tool-started"]
+
+    resumed = await _collect(
+        agent, Command(resume={"decisions": [{"type": "approve"}]}), config
+    )
+    assert _of(resumed, "input.requested") == []
+    ns = next(e["params"]["namespace"] for e in resumed if e["params"]["namespace"])
+    sub_tool = [
+        e for e in _of(resumed, "tools", ns) if _data(e)["tool_call_id"] == "sub_call_1"
+    ]
+    assert "tool-finished" in _kinds(sub_tool)
+    task_events = [
+        e
+        for e in _of(resumed, "tools", [])
+        if _data(e)["tool_call_id"] == "call_task_1"
+    ]
+    assert _kinds(task_events)[-1] == "tool-finished"
+    assert _kinds(_of(resumed, "lifecycle", ns)) == ["started", "completed"]
+
+
+def test_tool_error_that_is_an_interrupt_repr_is_swallowed():
+    emitter = ProtocolEmitter()
+    events = emitter.translate(
+        _envelope(
+            "tools",
+            [],
+            {
+                "event": "tool-error",
+                "tool_call_id": "call_task",
+                "message": "(Interrupt(value={'action_requests': []}, id='ab'),)",
+            },
+        )
+    )
+    assert events == []
+    # A genuine failure of the same call is still reported.
+    events = emitter.translate(
+        _envelope(
+            "tools",
+            [],
+            {"event": "tool-error", "tool_call_id": "call_task", "message": "boom"},
+        )
+    )
+    assert _kinds(events) == ["tool-error"]
 
 
 async def test_graph_failure_propagates_after_buffered_events():

--- a/backend/tests/agents/protocol/test_emit.py
+++ b/backend/tests/agents/protocol/test_emit.py
@@ -583,29 +583,69 @@ async def test_bubbling_interrupt_does_not_fail_the_task_call(subagent_scenario)
     assert _kinds(_of(resumed, "lifecycle", ns)) == ["started", "completed"]
 
 
-def test_tool_error_that_is_an_interrupt_repr_is_swallowed():
-    emitter = ProtocolEmitter()
-    events = emitter.translate(
+def _started(emitter, tool_call_id, tool_name):
+    emitter.translate(
         _envelope(
             "tools",
             [],
             {
-                "event": "tool-error",
-                "tool_call_id": "call_task",
-                "message": "(Interrupt(value={'action_requests': []}, id='ab'),)",
+                "event": "tool-started",
+                "tool_call_id": tool_call_id,
+                "tool_name": tool_name,
+                "input": {},
             },
         )
     )
-    assert events == []
-    # A genuine failure of the same call is still reported.
-    events = emitter.translate(
+
+
+def _errored(emitter, tool_call_id, message):
+    return emitter.translate(
         _envelope(
             "tools",
             [],
-            {"event": "tool-error", "tool_call_id": "call_task", "message": "boom"},
+            {"event": "tool-error", "tool_call_id": tool_call_id, "message": message},
         )
     )
-    assert _kinds(events) == ["tool-error"]
+
+
+def test_tool_error_that_is_an_interrupt_repr_is_swallowed():
+    iid = "ab" * 16
+    repr_ = f"(Interrupt(value={{'action_requests': []}}, id='{iid}'),)"
+    emitter = ProtocolEmitter()
+    _started(emitter, "call_task", "task")
+    # The subagent's values envelope announced the interrupt first.
+    emitter.translate(
+        _envelope(
+            "values",
+            ["tools:t1"],
+            {},
+            interrupts=(Interrupt(value={"action_requests": []}, id=iid),),
+        )
+    )
+    assert _errored(emitter, "call_task", repr_) == []
+    # A genuine failure of the same call is still reported…
+    assert _kinds(_errored(emitter, "call_task", "boom")) == ["tool-error"]
+
+
+def test_only_the_task_tools_own_interrupt_is_swallowed():
+    iid = "ab" * 16
+    repr_ = f"(Interrupt(value={{}}, id='{iid}'),)"
+    emitter = ProtocolEmitter()
+    emitter.translate(
+        _envelope("values", ["tools:t1"], {}, interrupts=(Interrupt(value={}, id=iid),))
+    )
+    # …a non-`task` tool raising the same shape is a failure…
+    _started(emitter, "call_w", "get_weather")
+    assert _kinds(_errored(emitter, "call_w", repr_)) == ["tool-error"]
+    # …an error that merely mentions the id is a failure…
+    _started(emitter, "call_task", "task")
+    assert _kinds(_errored(emitter, "call_task", f"state dump: {iid}")) == [
+        "tool-error"
+    ]
+    # …and an interrupt id nobody announced is not ours to hide.
+    _started(emitter, "call_task_2", "task")
+    other = f"(Interrupt(value={{}}, id='{'cd' * 16}'),)"
+    assert _kinds(_errored(emitter, "call_task_2", other)) == ["tool-error"]
 
 
 async def test_graph_failure_propagates_after_buffered_events():

--- a/backend/tests/agents/protocol/test_service.py
+++ b/backend/tests/agents/protocol/test_service.py
@@ -301,3 +301,74 @@ async def test_history_maps_duplicate_descriptions_by_task_id(monkeypatch):
 
     assert one[0]["values"]["messages"][-1]["content"] == "first result"
     assert two[0]["values"]["messages"][-1]["content"] == "second result"
+
+
+# ── thread_state: the hydration snapshot names the paused agent ─────────────
+
+
+class _NsCheckpointer:
+    def __init__(self, by_ns):
+        self.by_ns = by_ns
+
+    async def aget_tuple(self, config):
+        return self.by_ns.get(config["configurable"].get("checkpoint_ns", ""))
+
+
+def _paused(messages, interrupt_id, task_id):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        pending_writes=[
+            (
+                task_id,
+                "__interrupt__",
+                [SimpleNamespace(value={"action_requests": []}, id=interrupt_id)],
+            )
+        ],
+        checkpoint={"channel_values": {"messages": messages}},
+    )
+
+
+@pytest.mark.parametrize(
+    ("by_ns_factory", "expected_namespace"),
+    [
+        (lambda iid: {"": _paused([], iid, "hitl-task")}, []),
+        (
+            lambda iid: {
+                "": _paused([], iid, "task-1"),
+                "tools:task-1": _paused([HumanMessage("do it")], iid, "hitl-task"),
+            },
+            ["tools:task-1"],
+        ),
+    ],
+)
+async def test_thread_state_interrupt_carries_the_paused_agents_namespace(
+    monkeypatch, by_ns_factory, expected_namespace
+):
+    """A subagent's interrupt hydrates with its namespace so the client lands
+    the approval on that card, exactly as the live `input.requested` does."""
+    from contextlib import asynccontextmanager
+
+    from app.agents.protocol import service as service_mod
+
+    iid = "ab" * 16
+    checkpointer = _NsCheckpointer(by_ns_factory(iid))
+
+    @asynccontextmanager
+    async def _checkpointer():
+        yield checkpointer
+
+    monkeypatch.setattr(service_mod, "get_checkpointer", _checkpointer)
+    service = _service()
+
+    async def _no_active(_thread_id):
+        return None
+
+    monkeypatch.setattr(service.runs, "get_active", _no_active)
+
+    state = await service.thread_state("t1")
+    assert state["next"] == ["agent"]
+    [task] = state["tasks"]
+    assert task["interrupts"] == [
+        {"id": iid, "value": {"action_requests": []}, "namespace": expected_namespace}
+    ]

--- a/backend/tests/agents/protocol/test_service.py
+++ b/backend/tests/agents/protocol/test_service.py
@@ -329,10 +329,32 @@ def _paused(messages, interrupt_id, task_id):
     )
 
 
+_TASK_CALL = AIMessage(
+    content="",
+    tool_calls=[
+        {
+            "id": "call_task",
+            "name": "task",
+            "args": {"description": "do it", "subagent_type": "w"},
+        }
+    ],
+)
+
+
 @pytest.mark.parametrize(
     ("by_ns_factory", "expected_namespace"),
     [
         (lambda iid: {"": _paused([], iid, "hitl-task")}, []),
+        # The paused subagent's `task` call is known: address the interrupt
+        # with the SDK's discovery key, `tools:<tool_call_id>`.
+        (
+            lambda iid: {
+                "": _paused([_TASK_CALL], iid, "task-1"),
+                "tools:task-1": _paused([HumanMessage("do it")], iid, "hitl-task"),
+            },
+            ["tools:call_task"],
+        ),
+        # No task call to name (older checkpoint): the execution namespace.
         (
             lambda iid: {
                 "": _paused([], iid, "task-1"),

--- a/backend/tests/agents/runs/test_canonical_command.py
+++ b/backend/tests/agents/runs/test_canonical_command.py
@@ -55,7 +55,8 @@ def _paused_checkpoint():
 
 @pytest.fixture
 def service(run_db, monkeypatch):
-    """A RunService whose checkpointer serves `_paused_checkpoint`, counting reads."""
+    """A RunService whose checkpointer serves `_paused_checkpoint` at the root
+    (and nothing under any subagent namespace), counting reads."""
     monkeypatch.setattr(
         service_mod.ModelService, "list_whitelisted", AsyncMock(return_value=[])
     )
@@ -65,6 +66,8 @@ def service(run_db, monkeypatch):
     async def _checkpointer():
         async def _aget_tuple(config):
             reads["count"] += 1
+            if config["configurable"].get("checkpoint_ns"):
+                return None
             return _paused_checkpoint()
 
         yield SimpleNamespace(aget_tuple=_aget_tuple)
@@ -108,7 +111,9 @@ async def test_addressed_resume_is_stored_canonical(service, run_db):
             INTERRUPT_ID: {"decisions": [{"type": "approve"}, {"type": "reject"}]}
         }
     }
-    assert service._checkpoint_reads["count"] == 1
+    # The root checkpoint, plus one probe for a subagent namespace under the
+    # interrupting task (`hitl.load_interrupt_scope`) — nothing more.
+    assert service._checkpoint_reads["count"] == 2
 
 
 async def test_stale_addressed_resume_is_rejected_before_a_run_row_exists(

--- a/backend/tests/agents/test_hitl.py
+++ b/backend/tests/agents/test_hitl.py
@@ -9,8 +9,10 @@ from app.agents.hitl import (
     build_resume_command,
     is_addressed_resume,
     load_interrupt_scope,
+    load_interrupt_scopes,
     pending_approval_requests,
     pending_interrupt,
+    pending_interrupts,
 )
 from app.exceptions import DomainValidationError, StaleApprovalError
 
@@ -446,6 +448,68 @@ async def test_load_interrupt_scope_follows_the_task_into_the_subagent():
     assert pending_approval_requests(scope.root, scope.checkpoint) == [
         {"tool_call_id": "sub_call", "tool_name": "send_email", "input": {}}
     ]
+
+
+async def test_parallel_subagent_interrupts_are_addressed_by_id():
+    """Two subagents paused in one superstep: two root pending writes. An
+    addressed resume picks its own interrupt and follows *its* task, not the
+    first one's."""
+    from types import SimpleNamespace
+
+    id_a, id_b = "aa" * 16, "bb" * 16
+    calls = [
+        {
+            "id": "call_a",
+            "name": "task",
+            "args": {"description": "A", "subagent_type": "a"},
+        },
+        {
+            "id": "call_b",
+            "name": "task",
+            "args": {"description": "B", "subagent_type": "b"},
+        },
+    ]
+    root = SimpleNamespace(
+        pending_writes=[
+            (
+                "task-a",
+                "__interrupt__",
+                [SimpleNamespace(value={"action_requests": []}, id=id_a)],
+            ),
+            (
+                "task-b",
+                "__interrupt__",
+                [SimpleNamespace(value={"action_requests": []}, id=id_b)],
+            ),
+        ],
+        checkpoint={
+            "channel_values": {"messages": [AIMessage(content="", tool_calls=calls)]}
+        },
+    )
+    sub_a = _checkpoint({"action_requests": []}, [HumanMessage("A")], interrupt_id=id_a)
+    sub_b = _checkpoint({"action_requests": []}, [HumanMessage("B")], interrupt_id=id_b)
+    checkpointer = _Checkpointer(
+        {"": root, "tools:task-a": sub_a, "tools:task-b": sub_b}
+    )
+
+    assert [i.id for i in pending_interrupts(root)] == [id_a, id_b]
+    assert pending_interrupt(root).id == id_a
+    assert pending_interrupt(root, id_b).id == id_b
+    assert pending_interrupt(root, "cd" * 16) is None
+
+    scope_b = await load_interrupt_scope(checkpointer, "t", interrupt_id=id_b)
+    assert scope_b is not None
+    assert scope_b.namespace == "tools:task-b"
+    assert scope_b.subagent_type == "b"
+    scopes = await load_interrupt_scopes(checkpointer, "t")
+    assert [(s.interrupt.id, s.namespace, s.subagent_type) for s in scopes] == [
+        (id_a, "tools:task-a", "a"),
+        (id_b, "tools:task-b", "b"),
+    ]
+    with pytest.raises(StaleApprovalError):
+        build_resume_command(
+            root, {"interrupt_id": "cd" * 16, "decisions": []}, scope_b.checkpoint
+        )
 
 
 async def test_load_interrupt_scope_descent_is_bounded():

--- a/backend/tests/agents/test_hitl.py
+++ b/backend/tests/agents/test_hitl.py
@@ -3,11 +3,12 @@
 from types import SimpleNamespace
 
 import pytest
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 from app.agents.hitl import (
     build_resume_command,
     is_addressed_resume,
+    load_interrupt_scope,
     pending_approval_requests,
     pending_interrupt,
 )
@@ -80,7 +81,7 @@ def test_pending_interrupt_tolerates_dict_shape():
         checkpoint={"channel_values": {}},
     )
     out = pending_interrupt(cp)
-    assert out == (INTERRUPT_ID, {"a": 1})
+    assert out == (INTERRUPT_ID, {"a": 1}, "t")
 
 
 def test_pending_interrupt_id_none_when_absent():
@@ -319,3 +320,265 @@ async def test_extracted_id_resumes_a_real_graph_via_the_map_form():
 
     out = await graph.ainvoke(Command(resume=command["resume"]), config)
     assert out["answer"] == "approve"
+
+
+# ---------------------------------------------------------------------------
+# Subagent approvals — the interrupt is on the root, the tool call is not
+# ---------------------------------------------------------------------------
+
+
+def test_pending_approval_requests_reads_tool_calls_from_the_scope():
+    """A subagent's interrupt bubbles to the root, whose last AI message only
+    carries the `task` call; the gated call is in the subagent's checkpoint."""
+    root = _checkpoint(
+        {"action_requests": [{"name": "send_email", "args": {"to": "a@b.c"}}]},
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_task",
+                        "name": "task",
+                        "args": {"description": "mail them", "subagent_type": "w"},
+                    }
+                ],
+            )
+        ],
+    )
+    sub = _checkpoint(
+        None,
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"id": "sub_call", "name": "send_email", "args": {"to": "a@b.c"}}
+                ],
+            )
+        ],
+    )
+    assert pending_approval_requests(root)[0]["tool_call_id"] == "approval-0"
+    assert pending_approval_requests(root, sub)[0]["tool_call_id"] == "sub_call"
+    command = build_resume_command(
+        root,
+        {
+            "interrupt_id": INTERRUPT_ID,
+            "decisions": [{"tool_call_id": "sub_call", "type": "reject"}],
+        },
+        sub,
+    )
+    assert command == {"resume": {INTERRUPT_ID: {"decisions": [{"type": "reject"}]}}}
+
+
+class _Checkpointer:
+    """`aget_tuple` over a dict keyed by checkpoint namespace."""
+
+    def __init__(self, by_ns):
+        self.by_ns = by_ns
+
+    async def aget_tuple(self, config):
+        return self.by_ns.get(config["configurable"].get("checkpoint_ns", ""))
+
+
+async def test_load_interrupt_scope_stays_at_the_root_for_a_parent_approval():
+    root = _two_call_checkpoint()
+    scope = await load_interrupt_scope(_Checkpointer({"": root}), "t")
+    assert scope is not None
+    assert scope.namespace == ""
+    assert scope.namespace_path == []
+    assert scope.checkpoint is root
+    assert scope.subagent_call is None
+    assert scope.subagent_type is None
+    assert scope.interrupt.id == INTERRUPT_ID
+    assert scope.interrupt.task_id == "task-1"
+
+
+async def test_load_interrupt_scope_is_none_when_nothing_pends():
+    assert (
+        await load_interrupt_scope(_Checkpointer({"": _checkpoint(None, [])}), "t")
+        is None
+    )
+    assert await load_interrupt_scope(_Checkpointer({}), "t") is None
+
+
+async def test_load_interrupt_scope_follows_the_task_into_the_subagent():
+    """The root pending write's task is the parent's `tools` task; the subagent
+    checkpointed under `tools:<that id>` pends on the same interrupt."""
+    value = {"action_requests": [{"name": "send_email", "args": {}}]}
+    task_call = {
+        "id": "call_task",
+        "name": "task",
+        "args": {"description": "mail them", "subagent_type": "mailer"},
+    }
+    other_call = {
+        "id": "call_task_2",
+        "name": "task",
+        "args": {"description": "something else", "subagent_type": "other"},
+    }
+    root = _checkpoint(
+        value, [AIMessage(content="", tool_calls=[other_call, task_call])]
+    )
+    sub = _checkpoint(
+        value,
+        [
+            HumanMessage(content="mail them"),
+            AIMessage(
+                content="",
+                tool_calls=[{"id": "sub_call", "name": "send_email", "args": {}}],
+            ),
+        ],
+    )
+    sub.pending_writes[0] = ("hitl-task", "__interrupt__", sub.pending_writes[0][2])
+    unrelated = _checkpoint(value, [], interrupt_id="cd" * 16)
+    checkpointer = _Checkpointer(
+        {"": root, "tools:task-1": sub, "tools:task-1|tools:hitl-task": unrelated}
+    )
+
+    scope = await load_interrupt_scope(checkpointer, "t")
+    assert scope is not None
+    assert scope.namespace == "tools:task-1"  # stops: the deeper one is another id
+    assert scope.namespace_path == ["tools:task-1"]
+    assert scope.checkpoint is sub
+    assert scope.root is root
+    # Told apart from the parallel sibling by the subagent's seed message.
+    assert scope.subagent_call is not None
+    assert scope.subagent_call["id"] == task_call["id"]
+    assert scope.subagent_type == "mailer"
+    assert pending_approval_requests(scope.root, scope.checkpoint) == [
+        {"tool_call_id": "sub_call", "tool_name": "send_email", "input": {}}
+    ]
+
+
+async def test_load_interrupt_scope_descent_is_bounded():
+    """A checkpointer that answers every namespace with the same paused
+    checkpoint (a test double, a misbehaving store) must not loop forever."""
+    from app.agents.hitl import MAX_SUBAGENT_DEPTH
+
+    class _Everywhere:
+        async def aget_tuple(self, config):
+            return _two_call_checkpoint()
+
+    scope = await load_interrupt_scope(_Everywhere(), "t")
+    assert scope is not None
+    assert scope.namespace.count("tools:") == MAX_SUBAGENT_DEPTH
+
+
+async def test_load_interrupt_scope_end_to_end_through_a_gated_subagent():
+    """The real thing: a supervisor delegates through deepagents' `task` to a
+    subagent whose tool is gated by our middleware stack. The interrupt lands
+    on the root checkpoint, the scope resolves to the subagent's namespace with
+    the real tool_call_id, and the canonical resume finishes both agents."""
+    from datetime import UTC, datetime
+
+    from deepagents.middleware.subagents import CompiledSubAgent
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.messages import HumanMessage
+    from langchain_core.tools import tool
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.types import Command
+
+    from app.agents.runtime import build_agent_middleware, build_runnable
+
+    class _ToolFake(GenericFakeChatModel):
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+    @tool
+    def send_email(to: str) -> str:
+        """Send an email."""
+        return f"sent to {to}"
+
+    now = datetime.now(UTC)
+    worker = CompiledSubAgent(
+        name="mailer",
+        description="mailer: sends mail",
+        runnable=build_runnable(
+            model=_ToolFake(
+                messages=iter(
+                    [
+                        AIMessage(
+                            content="",
+                            id="sub-ai-1",
+                            tool_calls=[
+                                {
+                                    "id": "sub_call",
+                                    "name": "send_email",
+                                    "args": {"to": "a@b.c"},
+                                }
+                            ],
+                        ),
+                        AIMessage(content="mail sent", id="sub-ai-2"),
+                    ]
+                )
+            ),
+            tools=[send_email],
+            system_prompt="mailer",
+            base_middleware=build_agent_middleware(
+                now, recursion_limit=25, interrupt_on={"send_email": True}
+            ),
+        ),
+    )
+    saver = InMemorySaver()
+    parent = build_runnable(
+        model=_ToolFake(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        id="root-ai-1",
+                        tool_calls=[
+                            {
+                                "id": "call_task",
+                                "name": "task",
+                                "args": {
+                                    "description": "mail them",
+                                    "subagent_type": "mailer",
+                                },
+                            }
+                        ],
+                    ),
+                    AIMessage(content="done", id="root-ai-2"),
+                ]
+            )
+        ),
+        tools=[],
+        system_prompt="supervisor",
+        base_middleware=build_agent_middleware(
+            now, recursion_limit=50, interrupt_on={}
+        ),
+        subagents=[worker],
+        checkpointer=saver,
+    )
+    config = {"configurable": {"thread_id": "t-sub-hitl"}}
+    await parent.ainvoke({"messages": [HumanMessage("go")]}, config)  # pauses
+
+    scope = await load_interrupt_scope(saver, "t-sub-hitl")
+    assert scope is not None
+    assert scope.namespace.startswith("tools:")
+    assert scope.subagent_type == "mailer"
+    assert scope.interrupt.id is not None and len(scope.interrupt.id) == 32
+    requests = pending_approval_requests(scope.root, scope.checkpoint)
+    assert requests == [
+        {
+            "tool_call_id": "sub_call",
+            "tool_name": "send_email",
+            "input": {"to": "a@b.c"},
+        }
+    ]
+
+    command = build_resume_command(
+        scope.root,
+        {
+            "interrupt_id": scope.interrupt.id,
+            "decisions": [{"tool_call_id": "sub_call", "type": "approve"}],
+        },
+        scope.checkpoint,
+    )
+    out = await parent.ainvoke(Command(resume=command["resume"]), config)
+    assert out["messages"][-1].content == "done"
+    assert await load_interrupt_scope(saver, "t-sub-hitl") is None
+    sub_state = await saver.aget_tuple(
+        {"configurable": {"thread_id": "t-sub-hitl", "checkpoint_ns": scope.namespace}}
+    )
+    sub_messages = sub_state.checkpoint["channel_values"]["messages"]
+    assert [m.type for m in sub_messages] == ["human", "ai", "tool", "ai"]
+    assert sub_messages[2].content == "sent to a@b.c"

--- a/backend/tests/agents/test_hitl.py
+++ b/backend/tests/agents/test_hitl.py
@@ -512,6 +512,27 @@ async def test_parallel_subagent_interrupts_are_addressed_by_id():
         )
 
 
+async def test_id_less_parallel_interrupts_resolve_by_their_own_write():
+    """Older checkpoints carry no interrupt id: the plural load must still
+    follow each pending write's task, not resolve every entry to the first."""
+    from types import SimpleNamespace
+
+    root = SimpleNamespace(
+        pending_writes=[
+            ("task-a", "__interrupt__", [SimpleNamespace(value={}, id=None)]),
+            ("task-b", "__interrupt__", [SimpleNamespace(value={}, id=None)]),
+        ],
+        checkpoint={"channel_values": {"messages": []}},
+    )
+    sub_a = _checkpoint({}, [HumanMessage("A")], interrupt_id=None)
+    sub_b = _checkpoint({}, [HumanMessage("B")], interrupt_id=None)
+    checkpointer = _Checkpointer(
+        {"": root, "tools:task-a": sub_a, "tools:task-b": sub_b}
+    )
+    scopes = await load_interrupt_scopes(checkpointer, "t")
+    assert [s.namespace for s in scopes] == ["tools:task-a", "tools:task-b"]
+
+
 async def test_load_interrupt_scope_descent_is_bounded():
     """A checkpointer that answers every namespace with the same paused
     checkpoint (a test double, a misbehaving store) must not loop forever."""

--- a/backend/tests/integrations/slack/test_consumer.py
+++ b/backend/tests/integrations/slack/test_consumer.py
@@ -179,6 +179,21 @@ async def test_consumer_streams_text_and_posts_link_on_success(monkeypatch):
     assert fake.streamer.kwargs["recipient_user_id"] == "U1"
 
 
+def _scope(interrupt, subagent_type=None):
+    """A `load_interrupt_scope` stand-in: the located pending interrupt."""
+
+    async def _load(_checkpointer, _thread_id):
+        return SimpleNamespace(
+            root=None,
+            checkpoint=None,
+            interrupt=interrupt,
+            namespace="tools:x" if subagent_type else "",
+            subagent_type=subagent_type,
+        )
+
+    return _load
+
+
 async def test_consumer_posts_approval_blocks_on_interrupt(monkeypatch):
     monkeypatch.setattr(
         consumer_mod.RunService, "stream", _log(status=RunStatus.interrupted)
@@ -191,9 +206,12 @@ async def test_consumer_posts_approval_blocks_on_interrupt(monkeypatch):
 
     monkeypatch.setattr(consumer_mod, "get_checkpointer", _checkpointer)
     monkeypatch.setattr(
+        consumer_mod, "load_interrupt_scope", _scope(SimpleNamespace(id=None, value={}))
+    )
+    monkeypatch.setattr(
         consumer_mod,
         "pending_approval_requests",
-        lambda _cp: [
+        lambda _root, _scope: [
             {
                 "tool_call_id": "call_1",
                 "tool_name": "get_weather",
@@ -235,13 +253,15 @@ async def test_approval_cards_carry_the_interrupt_id_block_id(monkeypatch):
     iid = "ab" * 16
     monkeypatch.setattr(
         consumer_mod,
-        "pending_interrupt",
-        lambda _cp: SimpleNamespace(id=iid, value={}),
+        "load_interrupt_scope",
+        _scope(SimpleNamespace(id=iid, value={}), subagent_type="mailer"),
     )
     monkeypatch.setattr(
         consumer_mod,
         "pending_approval_requests",
-        lambda _cp: [{"tool_call_id": "call_1", "tool_name": "t", "input": {}}],
+        lambda _root, _scope: [
+            {"tool_call_id": "call_1", "tool_name": "t", "input": {}}
+        ],
     )
 
     consumer = SlackRunConsumer(_record(_slack_delivery()))
@@ -251,6 +271,10 @@ async def test_approval_cards_carry_the_interrupt_id_block_id(monkeypatch):
 
     actions = next(b for b in fake.posts[0]["blocks"] if b.get("type") == "actions")
     assert actions["block_id"] == f"hitl:{iid}:call_1"
+    # A subagent's request says which subagent asked.
+    context = next(b for b in fake.posts[0]["blocks"] if b.get("type") == "context")
+    assert "mailer" in context["elements"][0]["text"]
+    assert fake.posts[0]["text"] == "Approve t for mailer?"
 
 
 async def test_consumer_posts_failure_notice_on_error(monkeypatch):

--- a/subagent-hitl-assessment.md
+++ b/subagent-hitl-assessment.md
@@ -5,7 +5,7 @@ Assessment written 2026-09-04, verified by spike 2026-09-05 (see the update belo
 
 ## Status 2026-09-05 — implemented (uncommitted, in the working tree)
 
-Everything in "Revised work, with sizes" below except the optional SDK bump is done:
+Everything in "Revised work, with sizes" below is done (the optional SDK bump is not needed):
 
 - Backend: `ResolvedAgent.compile` gates subagents; `hitl.load_interrupt_scope` follows the
   root pending write into `tools:<task-id>` (nested levels too, bounded by
@@ -36,6 +36,14 @@ Everything in "Revised work, with sizes" below except the optional SDK bump is d
   recorded decision auto-resubmitted. Fix: `web/src/hooks/use-subagent-projections.ts` — the
   SDK's own projection specs, subscribing through a thread whose handles resume across runs;
   the card uses those. Unit-tested; the live flow still needs a second try.
+- Review round (Codacy + cubic): addressed resumes pick their interrupt by id and
+  `thread_state` reports every pending interrupt, so two subagents pausing together each
+  resume in turn (a card holds its completed batch while a run is in flight); a hydrated
+  interrupt is addressed with the SDK's discovery key `tools:<tool_call_id>` and the card
+  accepts either key, so no matching by content remains; the emitter swallows a
+  `tool-error` only for the `task` tool, with the repr shape and an exactly announced id;
+  the Slack context line is mrkdwn-escaped; the resuming iterator is an explicit
+  async-iterator object with a finished flag.
 
 ## Update 2026-09-05 — verified by running it
 
@@ -95,7 +103,7 @@ subagent namespace. The emitter today produces:
 `aget_state` after the pause: `next=("tools",)`, `tasks=[("tools", [<id>])]` — the same
 shape a root HITL pause has, so `thread_state` needs only the namespace added.
 
-### Revised work, with sizes
+### Revised work, with sizes — the plan as executed (see Status above; names below are the final ones)
 
 Backend (≈1.5–2 days)
 
@@ -103,10 +111,12 @@ Backend (≈1.5–2 days)
    three stale "no checkpointer" docstrings (`build_agent_middleware`, `compile`,
    `SUBAGENT_RECURSION_LIMIT`). ~0.5 h.
 2. Namespace-aware approvals. `pending_interrupt` also returns the pending write's
-   `task_id`; add an async `pending_approvals(checkpointer, thread_id)` in `hitl.py` that
-   loads the root tuple, follows `tools:<task_id>` when the interrupting namespace is a
-   subagent, and runs the *existing* matcher on that tuple. Same for the checkpoint
-   `build_resume_command` validates against. Call sites: `threads/router.py`,
+   `task_id`; `hitl.load_interrupt_scope(checkpointer, thread_id, interrupt_id=…)` loads
+   the root tuple, follows `tools:<task_id>` when the interrupting namespace is a subagent
+   (depth-capped), and `pending_approval_requests(root, scope)` runs the *existing* matcher
+   on that tuple. Same for the checkpoint `build_resume_command` validates against.
+   Parallel subagents pausing together: `pending_interrupts` lists them all,
+   `load_interrupt_scopes` locates each, an addressed resume picks its own by id. Call sites: `threads/router.py`,
    `protocol/service.thread_state`, `slack/consumer.py`, `slack/handlers.py`,
    `RunService._canonical_command`; `runs/worker.py` only uses `pending_interrupt` and
    is untouched. ~0.5 day incl. tests.

--- a/subagent-hitl-assessment.md
+++ b/subagent-hitl-assessment.md
@@ -1,7 +1,151 @@
 # Subagent HITL: what `@langchain/react` 1.0.33 changes, and what it implies for auxilia
 
-Assessment written 2026-09-04. No code changed. Companion to issue #301
+Assessment written 2026-09-04, verified by spike 2026-09-05 (see the update below). No code changed. Companion to issue #301
 ("Subagent tool approvals are silently dropped at run time").
+
+## Status 2026-09-05 — implemented (uncommitted, in the working tree)
+
+Everything in "Revised work, with sizes" below except the optional SDK bump is done:
+
+- Backend: `ResolvedAgent.compile` gates subagents; `hitl.load_interrupt_scope` follows the
+  root pending write into `tools:<task-id>` (nested levels too, bounded by
+  `MAX_SUBAGENT_DEPTH`; a root approval costs one extra keyed probe) and exposes the paused
+  `task` call; `pending_approval_requests` / `build_resume_command` take that scope;
+  `RunService._canonical_command`, `ProtocolService.thread_state` (interrupt `namespace`),
+  the Slack consumer (card names the subagent) and handlers use it. `ProtocolEmitter`
+  emits `input.requested` under the paused agent's namespace and swallows the `task`
+  `tool-error` that is the interrupt bubbling up.
+- Web: `page.tsx` splits `stream.interrupts` into the root one and the subagents' (keyed
+  by content so the memoized body is not re-rendered per token); `SubAgentCard` claims its
+  interrupt (`findSubagentInterrupt`: namespace first, action-request fallback after a
+  reload), renders nested `ToolStep`s as awaiting approval with the approve/deny footer,
+  shows the needs-approval badge instead of the spinner, and resumes through its own
+  `useHitlApprovals`; the chain stays open while a card is paused.
+- Tests: `tests/agents/test_hitl.py` (scope resolution, real gated subagent end to end),
+  `tests/agents/protocol/test_emit.py` (`subagent_scenario`: namespaced request, no task
+  tool-error, resume), `test_service.py` (state namespace), Slack consumer;
+  `message-helpers.test.ts` for the split/claim helpers. Backend suite 1035 passed, web
+  vitest/tsc/eslint clean.
+- First live test (2026-09-05, Slides subagent): the interrupt fired and the first approval
+  resumed correctly, but the card froze afterwards and the second approval failed with a 400
+  ("Decisions do not match the pending approvals"). Cause: the SDK pauses every subscription
+  on a run's terminal lifecycle and the scoped projections behind `useMessages` /
+  `useToolCalls` / `useValues` never resume (`resumeOnPause` is off for them, upstream `main`
+  included), so the resumed run's subagent events (tool result, retried call, new interrupt's
+  target) never reached the card; the stale call matched the new interrupt by name and the
+  recorded decision auto-resubmitted. Fix: `web/src/hooks/use-subagent-projections.ts` — the
+  SDK's own projection specs, subscribing through a thread whose handles resume across runs;
+  the card uses those. Unit-tested; the live flow still needs a second try.
+
+## Update 2026-09-05 — verified by running it
+
+Re-checked after the user reported that "latest langchain/langgraph detect subagent HITL".
+Upstream since the 09-04 assessment: langchain 1.4.0 (09-03) is the `langchain.mcp`
+adapter, nothing about subagents; deepagents 0.7.12/0.7.13 add subagent forking modes;
+langgraph Python is still 1.2.11 (08-11). The only relevant release is
+`@langchain/langgraph-sdk` 1.10.2 / `@langchain/react` 1.0.35 (09-04, langgraphjs#2780):
+`stream.interrupts` stays truthful after sequential `respond()` calls on parallel
+interrupts. Corroborating evidence that upstream treats nested subagent HITL as a working
+feature: deepagents-code #4771 "keep `task` timers monotonic across nested subagent HITL"
+and langchain-quickjs #4401 "propagate JS `task()` subagent interrupts" (July 2026).
+
+So nothing new is required from upstream: **the detection already works on the versions
+we have installed** (langgraph 1.2.11, deepagents 0.5.6, langchain 1.3.17, sdk 1.10.0).
+Two scratch spikes proved the 09-04 table instead of reasoning from source. Both used
+`build_runnable` + `build_agent_middleware` (our real stack), a scripted model, an
+`InMemorySaver`, and the real `hitl.py` helpers; the only change from production was
+passing `interrupt_on={"dangerous": True}` to the subagent's middleware.
+
+### Spike 1 — `astream(subgraphs=True)`, checkpoint, resume
+
+| Claim | Result |
+| --- | --- |
+| Subagent's gated tool interrupts | yes — `__interrupt__` on the `tools:<task-id>` values envelope |
+| Interrupt reaches the root checkpoint | yes — root `pending_writes` = `(<parent tools task id>, "__interrupt__", (Interrupt,))` |
+| Id is 32-hex, same in both namespaces | yes — e.g. `67678b50…7ab429` on root and on `tools:<task-id>` |
+| `hitl.pending_interrupt(root)` | works unchanged |
+| `hitl.pending_approval_requests(root)` | **wrong id**: `approval-0` (root's last AI call is `task`) |
+| `hitl.pending_approval_requests(<tools:<task-id>> tuple)` | **right id**: `sub-call-0` — the existing matcher is correct, it is just fed the wrong checkpoint |
+| Namespace derivation | `tools:<task_id of the root pending write>` — identical to `protocol/service._task_namespace` |
+| `build_resume_command` + `Command(resume={id: {...}})` | resumes; subagent ToolMessage lands under `tools:<task-id>`, parent continues to its final answer |
+| Two sequential gated calls in one subagent (deepagents #1762 caveat) | both interrupt with distinct ids and both resume cleanly |
+
+### Spike 2 — `astream_events(version="v3")` through `ProtocolEmitter` (the real wire)
+
+Envelope order at the pause: `values` on `["tools:<task-id>"]` carrying `interrupts=[…]`,
+then root `tools` **`tool-error` for the `task` call** with `message="(Interrupt(…),)"`,
+then root `values` carrying the same interrupt, then `lifecycle interrupted` for the
+subagent namespace. The emitter today produces:
+
+- `input.requested` once, with `namespace: []` — because `_on_values` returns early in the
+  namespaced branch before looking at `interrupts`, so the root copy is the one emitted.
+  Detection works; card scoping does not.
+- **`tools.tool-error` for `task-call-1`** — new finding, not in the 09-04 table. langgraph
+  reports the `GraphInterrupt` that bubbles through the `task` tool as a tool failure. The
+  SDK's `SubagentManager.complete(id, message, "error")` then marks the card *errored*
+  with the `Interrupt(...)` repr as its error text for the whole pause. On resume the
+  subagent streams again and `markRunning` flips it back, so it self-heals, but the paused
+  state is displayed as a failure. The emitter must swallow that one event (the message
+  starts with `(Interrupt(`; or hold `tool-error` until the next root `values` and drop
+  it when that envelope carries an interrupt).
+- On resume: root `tool-started` for the same `task-call-1` again, subagent `lifecycle
+  started` again, then the subagent's `dangerous` `tool-finished`, then `task`
+  `tool-finished` and `lifecycle completed`. Nothing to fix there.
+
+`aget_state` after the pause: `next=("tools",)`, `tasks=[("tools", [<id>])]` — the same
+shape a root HITL pause has, so `thread_state` needs only the namespace added.
+
+### Revised work, with sizes
+
+Backend (≈1.5–2 days)
+
+1. `ResolvedAgent.compile` passes `interrupt_on=self.prepared.interrupt_on`; rewrite the
+   three stale "no checkpointer" docstrings (`build_agent_middleware`, `compile`,
+   `SUBAGENT_RECURSION_LIMIT`). ~0.5 h.
+2. Namespace-aware approvals. `pending_interrupt` also returns the pending write's
+   `task_id`; add an async `pending_approvals(checkpointer, thread_id)` in `hitl.py` that
+   loads the root tuple, follows `tools:<task_id>` when the interrupting namespace is a
+   subagent, and runs the *existing* matcher on that tuple. Same for the checkpoint
+   `build_resume_command` validates against. Call sites: `threads/router.py`,
+   `protocol/service.thread_state`, `slack/consumer.py`, `slack/handlers.py`,
+   `RunService._canonical_command`; `runs/worker.py` only uses `pending_interrupt` and
+   is untouched. ~0.5 day incl. tests.
+3. Emitter: (a) handle `interrupts` in the namespaced `_on_values` branch and emit
+   `input.requested` with the real namespace (the id dedupe already drops the root copy);
+   (b) suppress the `task` `tool-error` caused by the interrupt and keep it out of
+   `_tool_finished_ids`. `tests/agents/protocol/test_emit.py` already drives a real
+   `create_agent` + `task` subagent with a scripted model, so the new case is one more
+   scenario. ~3 h.
+4. `thread_state`: put `namespace: ["tools:<task-id>"]` on the interrupt entry so a
+   reload lands the approval on the right card (SDK `Interrupt.namespace` exists). ~1 h.
+5. Slack: prefix the card title with the subagent name. ~1 h.
+
+Frontend (≈1.5 days)
+
+1. `SubAgentCard` picks `stream.interrupts.filter(i => sameNamespace(i.namespace,
+   subagent.namespace))`; fallback (until backend 3a ships): an interrupt with
+   `namespace: []` whose `action_requests` match none of the root tool calls but match the
+   card's. ~2 h.
+2. Nested `ToolStep` gets `state=getToolStepState(tc, cardInterrupted, cardHitlNames)`
+   and the `approval` prop; card `meta` shows the needs-approval badge instead of the
+   spinner; `ChainOfThought.lockOpen` includes nested pending approvals. ~3 h.
+3. One `useHitlApprovals` per card (the hook is already generic) calling
+   `stream.respond(response, { interruptId })`; the SDK resolves the namespace. ~2 h.
+4. Local "paused" status derived from the scoped interrupt (the SDK snapshot has no such
+   status). ~1 h.
+5. Reload path, depends on backend 4 and on how the SDK's hydrate copies
+   `tasks[].interrupts[].namespace` — verify before relying on it. ~2–3 h.
+
+Optional: bump `@langchain/langgraph-sdk` to 1.10.2 / `@langchain/react` to 1.0.35 for
+langgraphjs#2780 (parallel subagents each pausing) and #2788. Not a prerequisite.
+
+Total ≈ 3.5–4 developer-days for a complete feature (web + Slack + reload), about one
+day for the minimum that makes approvals stop being silently dropped (backend 1–3a +
+frontend 1–3). The editor toggle stays; drop the "hide the setting" suggestion from #301.
+
+Spike scripts (scratch, not committed): `subagent_hitl_spike.py`,
+`subagent_hitl_v3_spike.py` in the session scratchpad; the logic is small enough to
+re-create from the tables above.
 
 ## TL;DR
 

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
@@ -56,7 +56,7 @@ import {
   getToolStepState,
   groupChains,
   sanitizeToolIdentifier,
-  sameNamespace,
+  claimsInterrupt,
 } from "./message-helpers";
 import {
   SubAgentCard,
@@ -188,6 +188,7 @@ export const ConversationBody = memo(function ConversationBody({
                 recordDecision={recordDecision}
                 nestedInterrupts={nestedInterrupts}
                 respond={respond}
+                resumeInFlight={isLoading}
                 modelUnavailable={modelUnavailable}
                 coordinatorStreaming={assistantStreaming && isLast}
               />
@@ -317,6 +318,8 @@ type ChainProps = {
   recordDecision: (toolCallId: string, decision: HitlDecision) => void;
   nestedInterrupts: Interrupt[];
   respond: (response: HitlResponse, interruptId: string | null) => void;
+  /** A run is executing: a card's approval waits for it to settle. */
+  resumeInFlight: boolean;
   modelUnavailable: boolean;
   coordinatorStreaming: boolean;
 };
@@ -349,6 +352,7 @@ const Chain = ({
   recordDecision,
   nestedInterrupts,
   respond,
+  resumeInFlight,
   modelUnavailable,
   coordinatorStreaming,
 }: ChainProps) => {
@@ -369,17 +373,12 @@ const Chain = ({
   const reasoningStreaming = rows.some(
     (r) => r.kind === "reasoning" && r.messageId === reasoningStreamingId,
   );
-  // A subagent of this chain may be paused on an approval. Exact by
-  // namespace when the SDK has bound it; otherwise any running card could be
-  // the one (the card itself matches by content), so keep the chain open.
+  // A subagent of this chain paused on an approval: its card shows the
+  // approval, the chain stays open and stops reading as active.
   const pausedSubagents = chainSubagents.filter(
     (s) =>
       s.status === "running" &&
-      (nestedInterrupts.some((i) => sameNamespace(i.namespace, s.namespace)) ||
-        (nestedInterrupts.length > 0 &&
-          !nestedInterrupts.some((i) =>
-            chainSubagents.some((c) => sameNamespace(i.namespace, c.namespace)),
-          ))),
+      nestedInterrupts.some((i) => claimsInterrupt(i, s)),
   );
 
   return (
@@ -422,6 +421,7 @@ const Chain = ({
               agent={findAgent(sub.name)}
               interrupts={nestedInterrupts}
               respond={respond}
+              resumeInFlight={resumeInFlight}
               modelUnavailable={modelUnavailable}
             />
           ) : (

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/conversation-body.tsx
@@ -9,6 +9,7 @@ import {
   isToolMessage,
 } from "@langchain/core/messages";
 import type { AnyStream, SubagentDiscoverySnapshot } from "@langchain/react";
+import type { Interrupt } from "@langchain/langgraph-sdk";
 import { CopyIcon, RefreshCcwIcon } from "lucide-react";
 import {
   Message,
@@ -42,7 +43,7 @@ import { TodoList } from "@/components/ai-elements/todo-list";
 import type { Todo } from "@/components/ai-elements/todo-list";
 import { useMcpServersStore } from "@/stores/mcp-servers-store";
 import { useAgentsStore } from "@/stores/agents-store";
-import type { HitlDecision } from "@/hooks/use-hitl-approvals";
+import type { HitlDecision, HitlResponse } from "@/hooks/use-hitl-approvals";
 import { McpAppWidget } from "../components/mcp-app-widget";
 import {
   type ChainStepData,
@@ -55,6 +56,7 @@ import {
   getToolStepState,
   groupChains,
   sanitizeToolIdentifier,
+  sameNamespace,
 } from "./message-helpers";
 import {
   SubAgentCard,
@@ -78,6 +80,11 @@ export type ConversationBodyProps = {
   hitlToolNames: Set<string> | null;
   decisions: Partial<Record<string, HitlDecision>>;
   recordDecision: (toolCallId: string, decision: HitlDecision) => void;
+  /** Interrupts raised inside subagents (`stream.interrupts` minus the root
+   *  one); each card claims its own and approves it itself. */
+  nestedInterrupts: Interrupt[];
+  /** Resume an interrupt — `stream.respond(response, { interruptId })`. */
+  respond: (response: HitlResponse, interruptId: string | null) => void;
   modelUnavailable: boolean;
   onRegenerate: () => void;
   error: unknown;
@@ -100,6 +107,8 @@ export const ConversationBody = memo(function ConversationBody({
   hitlToolNames,
   decisions,
   recordDecision,
+  nestedInterrupts,
+  respond,
   modelUnavailable,
   onRegenerate,
   error,
@@ -177,6 +186,8 @@ export const ConversationBody = memo(function ConversationBody({
                 hitlToolNames={hitlToolNames}
                 decisions={decisions}
                 recordDecision={recordDecision}
+                nestedInterrupts={nestedInterrupts}
+                respond={respond}
                 modelUnavailable={modelUnavailable}
                 coordinatorStreaming={assistantStreaming && isLast}
               />
@@ -304,6 +315,8 @@ type ChainProps = {
   hitlToolNames: Set<string> | null;
   decisions: Partial<Record<string, HitlDecision>>;
   recordDecision: (toolCallId: string, decision: HitlDecision) => void;
+  nestedInterrupts: Interrupt[];
+  respond: (response: HitlResponse, interruptId: string | null) => void;
   modelUnavailable: boolean;
   coordinatorStreaming: boolean;
 };
@@ -334,6 +347,8 @@ const Chain = ({
   hitlToolNames,
   decisions,
   recordDecision,
+  nestedInterrupts,
+  respond,
   modelUnavailable,
   coordinatorStreaming,
 }: ChainProps) => {
@@ -354,6 +369,18 @@ const Chain = ({
   const reasoningStreaming = rows.some(
     (r) => r.kind === "reasoning" && r.messageId === reasoningStreamingId,
   );
+  // A subagent of this chain may be paused on an approval. Exact by
+  // namespace when the SDK has bound it; otherwise any running card could be
+  // the one (the card itself matches by content), so keep the chain open.
+  const pausedSubagents = chainSubagents.filter(
+    (s) =>
+      s.status === "running" &&
+      (nestedInterrupts.some((i) => sameNamespace(i.namespace, s.namespace)) ||
+        (nestedInterrupts.length > 0 &&
+          !nestedInterrupts.some((i) =>
+            chainSubagents.some((c) => sameNamespace(i.namespace, c.namespace)),
+          ))),
+  );
 
   return (
     <div className="w-full space-y-2">
@@ -361,12 +388,17 @@ const Chain = ({
         active={
           reasoningStreaming ||
           tools.some((r) =>
-            r.sub ? r.sub.status === "running" : r.state === "running",
+            r.sub
+              ? r.sub.status === "running" && !pausedSubagents.includes(r.sub)
+              : r.state === "running",
           )
         }
-        lockOpen={tools.some(
-          (r) => !r.sub && r.state === "awaiting-approval" && !decisions[r.tc.id],
-        )}
+        lockOpen={
+          pausedSubagents.length > 0 ||
+          tools.some(
+            (r) => !r.sub && r.state === "awaiting-approval" && !decisions[r.tc.id],
+          )
+        }
         toolCount={tools.length - chainSubagents.length}
         subagentCount={chainSubagents.length}
       >
@@ -388,6 +420,9 @@ const Chain = ({
               stream={stream}
               describe={describe}
               agent={findAgent(sub.name)}
+              interrupts={nestedInterrupts}
+              respond={respond}
+              modelUnavailable={modelUnavailable}
             />
           ) : (
             <ToolStep

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.test.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.test.ts
@@ -3,11 +3,13 @@ import type { AssembledToolCall } from "@langchain/react";
 import { describe, expect, it } from "vitest";
 import {
   extractHitlToolNames,
+  findSubagentInterrupt,
   getMcpAppInfo,
   getReasoning,
   getToolStepState,
   groupChains,
   pairToolCalls,
+  splitInterrupts,
 } from "./message-helpers";
 
 const ai = (id: string, calls: { id: string; name: string; args?: object }[], text = "") =>
@@ -173,5 +175,52 @@ describe("getReasoning", () => {
     });
     expect(getReasoning(legacy)).toBe("old think");
     expect(getReasoning(new AIMessage("plain"))).toBeNull();
+  });
+});
+
+describe("subagent interrupts", () => {
+  const rootInterrupt = { id: "r".repeat(32), value: { action_requests: [] }, namespace: [] };
+  const nested = {
+    id: "n".repeat(32),
+    value: { action_requests: [{ name: "send_email", args: { to: "a@b.c" } }] },
+    namespace: ["tools:task-1"],
+  };
+
+  it("splits the root interrupt from the subagents'", () => {
+    expect(splitInterrupts([nested, rootInterrupt])).toEqual({
+      root: rootInterrupt,
+      nested: [nested],
+    });
+    expect(splitInterrupts([{ id: "x", value: {} }]).root?.id).toBe("x");
+    expect(splitInterrupts([]).root).toBeNull();
+  });
+
+  it("claims a subagent's interrupt by namespace first", () => {
+    const sub = { namespace: ["tools:task-1"] };
+    expect(findSubagentInterrupt([nested], sub, [])).toBe(nested);
+    expect(findSubagentInterrupt([nested], { namespace: ["tools:other"] }, [])).toBeNull();
+  });
+
+  it("falls back to matching the action requests against pending calls", () => {
+    // After a reload the SDK's snapshot namespace is `tools:<tool_call_id>`.
+    const sub = { namespace: ["tools:call_task_1"] };
+    const calls = pairToolCalls(
+      [ai("m1", [{ id: "c1", name: "send_email", args: { to: "a@b.c" } }])],
+      [],
+    );
+    expect(findSubagentInterrupt([nested], sub, calls)).toBe(nested);
+    const otherArgs = pairToolCalls(
+      [ai("m1", [{ id: "c1", name: "send_email", args: { to: "x@y.z" } }])],
+      [],
+    );
+    expect(findSubagentInterrupt([nested], sub, otherArgs)).toBeNull();
+    const finished = pairToolCalls(
+      [
+        ai("m1", [{ id: "c1", name: "send_email", args: { to: "a@b.c" } }]),
+        new ToolMessage({ tool_call_id: "c1", content: "sent" }),
+      ],
+      [],
+    );
+    expect(findSubagentInterrupt([nested], sub, finished)).toBeNull();
   });
 });

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.test.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.test.ts
@@ -195,32 +195,22 @@ describe("subagent interrupts", () => {
     expect(splitInterrupts([]).root).toBeNull();
   });
 
-  it("claims a subagent's interrupt by namespace first", () => {
-    const sub = { namespace: ["tools:task-1"] };
-    expect(findSubagentInterrupt([nested], sub, [])).toBe(nested);
-    expect(findSubagentInterrupt([nested], { namespace: ["tools:other"] }, [])).toBeNull();
+  it("claims a subagent's interrupt by execution namespace or discovery key", () => {
+    // Live: the SDK bound the execution namespace onto the snapshot.
+    expect(findSubagentInterrupt([nested], { id: "call_1", namespace: ["tools:task-1"] })).toBe(
+      nested,
+    );
+    // Hydrated: the snapshot sits on `tools:<tool_call_id>` and the backend
+    // addresses the interrupt with the same key.
+    const hydrated = { ...nested, namespace: ["tools:call_1"] };
+    expect(findSubagentInterrupt([hydrated], { id: "call_1", namespace: ["tools:call_1"] })).toBe(
+      hydrated,
+    );
+    expect(findSubagentInterrupt([nested], { id: "call_9", namespace: ["tools:other"] })).toBeNull();
   });
 
-  it("falls back to matching the action requests against pending calls", () => {
-    // After a reload the SDK's snapshot namespace is `tools:<tool_call_id>`.
-    const sub = { namespace: ["tools:call_task_1"] };
-    const calls = pairToolCalls(
-      [ai("m1", [{ id: "c1", name: "send_email", args: { to: "a@b.c" } }])],
-      [],
-    );
-    expect(findSubagentInterrupt([nested], sub, calls)).toBe(nested);
-    const otherArgs = pairToolCalls(
-      [ai("m1", [{ id: "c1", name: "send_email", args: { to: "x@y.z" } }])],
-      [],
-    );
-    expect(findSubagentInterrupt([nested], sub, otherArgs)).toBeNull();
-    const finished = pairToolCalls(
-      [
-        ai("m1", [{ id: "c1", name: "send_email", args: { to: "a@b.c" } }]),
-        new ToolMessage({ tool_call_id: "c1", content: "sent" }),
-      ],
-      [],
-    );
-    expect(findSubagentInterrupt([nested], sub, finished)).toBeNull();
+  it("never matches by content: identical siblings do not share an interrupt", () => {
+    const sibling = { id: "call_2", namespace: ["tools:call_2"] };
+    expect(findSubagentInterrupt([nested], sibling)).toBeNull();
   });
 });

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
@@ -19,6 +19,7 @@ import {
   isToolMessage,
 } from "@langchain/core/messages";
 import type { AssembledToolCall, ToolCallStatus } from "@langchain/react";
+import type { Interrupt } from "@langchain/langgraph-sdk";
 import { parseToolPayload } from "@langchain/langgraph-sdk/stream";
 import type { AttachmentData } from "@/components/ai-elements/attachments";
 import { extractToolErrorText } from "@/lib/utils/tool-content";
@@ -235,6 +236,92 @@ export function getToolStepState(
   }
   return "running";
 }
+
+// ---------------------------------------------------------------------------
+// Interrupts — root vs. subagent
+// ---------------------------------------------------------------------------
+
+/** `stream.interrupts` mirrors every namespace's pending interrupt; the root
+ *  one drives the root chain's approval UI, the nested ones belong to the
+ *  subagent cards (`findSubagentInterrupt`). */
+export function splitInterrupts(interrupts: readonly Interrupt[]): {
+  root: Interrupt | null;
+  nested: Interrupt[];
+} {
+  let root: Interrupt | null = null;
+  const nested: Interrupt[] = [];
+  for (const interrupt of interrupts) {
+    if (isRootNamespace(interrupt.namespace)) root ??= interrupt;
+    else nested.push(interrupt);
+  }
+  return { root, nested };
+}
+
+const isRootNamespace = (namespace: readonly string[] | undefined) =>
+  namespace == null || namespace.length === 0;
+
+export const sameNamespace = (
+  a: readonly string[] | undefined,
+  b: readonly string[],
+) => a != null && a.length === b.length && a.every((seg, i) => seg === b[i]);
+
+/**
+ * The pending interrupt raised inside one subagent, if any.
+ *
+ * Live, the backend stamps the subagent's checkpoint namespace
+ * (`tools:<pregel task id>`) on `input.requested`, and the SDK binds the same
+ * namespace onto the discovery snapshot — an exact match. After a reload the
+ * SDK rebuilds snapshots from history with a `tools:<tool_call_id>` namespace
+ * instead, so fall back to content: the interrupt's `action_requests` must
+ * all correspond to a still-pending call in this card (by name, and by args
+ * when both sides have them).
+ */
+export function findSubagentInterrupt(
+  nested: readonly Interrupt[],
+  subagent: { namespace: readonly string[] },
+  toolCalls: readonly ToolCallView[],
+): Interrupt | null {
+  const exact = nested.find((i) => sameNamespace(i.namespace, subagent.namespace));
+  if (exact) return exact;
+  const pending = toolCalls.filter((tc) => tc.status === "running");
+  if (pending.length === 0) return null;
+  return (
+    nested.find((interrupt) => {
+      const requests = actionRequests(interrupt.value);
+      return (
+        requests != null &&
+        requests.length > 0 &&
+        requests.every((r) =>
+          pending.some(
+            (tc) =>
+              tc.name === r.name &&
+              (r.args == null || tc.args == null || sameArgs(tc.args, r.args)),
+          ),
+        )
+      );
+    }) ?? null
+  );
+}
+
+type ActionRequest = { name: string; args?: Record<string, unknown> };
+
+function actionRequests(value: unknown): ActionRequest[] | null {
+  if (!value || typeof value !== "object") return null;
+  const requests = (value as { action_requests?: unknown }).action_requests;
+  if (!Array.isArray(requests)) return null;
+  return requests.filter(
+    (r): r is ActionRequest =>
+      r != null && typeof r === "object" && typeof (r as { name?: unknown }).name === "string",
+  );
+}
+
+const sameArgs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
+  try {
+    return JSON.stringify(a, Object.keys(a).sort()) === JSON.stringify(b, Object.keys(b).sort());
+  } catch {
+    return false;
+  }
+};
 
 /** The HITL middleware only hangs the tool calls named in the interrupt's
  *  `action_requests`; sibling calls in the same turn run on resume. */

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
@@ -263,7 +263,7 @@ const isRootNamespace = (namespace: readonly string[] | undefined) =>
 export const sameNamespace = (
   a: readonly string[] | undefined,
   b: readonly string[],
-) => a != null && a.length === b.length && a.every((seg, i) => seg === b[i]);
+) => a != null && a.length === b.length && a.join("|") === b.join("|");
 
 /**
  * The pending interrupt raised inside one subagent, if any.

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
@@ -266,62 +266,34 @@ export const sameNamespace = (
 ) => a != null && a.length === b.length && a.join("|") === b.join("|");
 
 /**
- * The pending interrupt raised inside one subagent, if any.
+ * Whether an interrupt was raised inside this subagent.
  *
- * Live, the backend stamps the subagent's checkpoint namespace
+ * Live, the backend stamps the subagent's execution namespace
  * (`tools:<pregel task id>`) on `input.requested`, and the SDK binds the same
- * namespace onto the discovery snapshot — an exact match. After a reload the
- * SDK rebuilds snapshots from history with a `tools:<tool_call_id>` namespace
- * instead, so fall back to content: the interrupt's `action_requests` must
- * all correspond to a still-pending call in this card (by name, and by args
- * when both sides have them).
+ * namespace onto the discovery snapshot as the subagent streams. A page that
+ * hydrates instead rebuilds the snapshot under the SDK's discovery key,
+ * `tools:<tool_call_id>`, and the backend addresses a hydrated interrupt with
+ * that key — so both are accepted, and nothing is matched by content (two
+ * siblings calling the same tool with the same arguments would otherwise
+ * claim one interrupt).
  */
+export function claimsInterrupt(
+  interrupt: Interrupt,
+  subagent: { id: string; namespace: readonly string[] },
+): boolean {
+  return (
+    sameNamespace(interrupt.namespace, subagent.namespace) ||
+    sameNamespace(interrupt.namespace, [`tools:${subagent.id}`])
+  );
+}
+
+/** The pending interrupt raised inside one subagent, if any. */
 export function findSubagentInterrupt(
   nested: readonly Interrupt[],
-  subagent: { namespace: readonly string[] },
-  toolCalls: readonly ToolCallView[],
+  subagent: { id: string; namespace: readonly string[] },
 ): Interrupt | null {
-  const exact = nested.find((i) => sameNamespace(i.namespace, subagent.namespace));
-  if (exact) return exact;
-  const pending = toolCalls.filter((tc) => tc.status === "running");
-  if (pending.length === 0) return null;
-  return (
-    nested.find((interrupt) => {
-      const requests = actionRequests(interrupt.value);
-      return (
-        requests != null &&
-        requests.length > 0 &&
-        requests.every((r) =>
-          pending.some(
-            (tc) =>
-              tc.name === r.name &&
-              (r.args == null || tc.args == null || sameArgs(tc.args, r.args)),
-          ),
-        )
-      );
-    }) ?? null
-  );
+  return nested.find((interrupt) => claimsInterrupt(interrupt, subagent)) ?? null;
 }
-
-type ActionRequest = { name: string; args?: Record<string, unknown> };
-
-function actionRequests(value: unknown): ActionRequest[] | null {
-  if (!value || typeof value !== "object") return null;
-  const requests = (value as { action_requests?: unknown }).action_requests;
-  if (!Array.isArray(requests)) return null;
-  return requests.filter(
-    (r): r is ActionRequest =>
-      r != null && typeof r === "object" && typeof (r as { name?: unknown }).name === "string",
-  );
-}
-
-const sameArgs = (a: Record<string, unknown>, b: Record<string, unknown>) => {
-  try {
-    return JSON.stringify(a, Object.keys(a).sort()) === JSON.stringify(b, Object.keys(b).sort());
-  } catch {
-    return false;
-  }
-};
 
 /** The HITL middleware only hangs the tool calls named in the interrupt's
  *  `action_requests`; sibling calls in the same turn run on resume. */

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -124,18 +124,23 @@ const ChatPage = () => {
   const { isLoading, error, interrupts } = stream;
   // The root interrupt drives the root chain's approval UI; a subagent's
   // (namespaced) interrupt is handed to its card, which approves it itself.
-  // The hook rebuilds the `interrupts` array on every store tick, so the split
-  // is keyed by content (ids + namespaces) — otherwise the memoized body would
-  // re-render at token rate.
-  const interruptsRef = useRef(interrupts);
-  interruptsRef.current = interrupts;
+  // The hook rebuilds the `interrupts` array on every store tick, so hold the
+  // last array whose content (ids + namespaces) changed and split that one —
+  // otherwise the memoized body would re-render at token rate. Adjusting
+  // state during render is React's pattern for state derived from props.
   const interruptsKey = interrupts
     .map((i) => `${i.id ?? ""}@${(i.namespace ?? []).join("/")}`)
     .join(",");
+  const [heldInterrupts, setHeldInterrupts] = useState({
+    key: interruptsKey,
+    list: interrupts,
+  });
+  if (heldInterrupts.key !== interruptsKey) {
+    setHeldInterrupts({ key: interruptsKey, list: interrupts });
+  }
   const { root: interrupt, nested: nestedInterrupts } = useMemo(
-    () => splitInterrupts(interruptsRef.current),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by content, see above
-    [interruptsKey],
+    () => splitInterrupts(heldInterrupts.list),
+    [heldInterrupts],
   );
 
   // Identity-stable handle for selector hooks inside memoized children

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/page.tsx
@@ -29,6 +29,7 @@ import { ConversationBody } from "./conversation-body";
 import {
   extractHitlToolNames,
   getToolStepState,
+  splitInterrupts,
   pairToolCalls,
 } from "./message-helpers";
 
@@ -120,7 +121,22 @@ const ChatPage = () => {
     },
   });
 
-  const { isLoading, error, interrupt } = stream;
+  const { isLoading, error, interrupts } = stream;
+  // The root interrupt drives the root chain's approval UI; a subagent's
+  // (namespaced) interrupt is handed to its card, which approves it itself.
+  // The hook rebuilds the `interrupts` array on every store tick, so the split
+  // is keyed by content (ids + namespaces) — otherwise the memoized body would
+  // re-render at token rate.
+  const interruptsRef = useRef(interrupts);
+  interruptsRef.current = interrupts;
+  const interruptsKey = interrupts
+    .map((i) => `${i.id ?? ""}@${(i.namespace ?? []).join("/")}`)
+    .join(",");
+  const { root: interrupt, nested: nestedInterrupts } = useMemo(
+    () => splitInterrupts(interruptsRef.current),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by content, see above
+    [interruptsKey],
+  );
 
   // Identity-stable handle for selector hooks inside memoized children
   // (SubAgentCard's scoped useMessages/useValues) and for callbacks that
@@ -403,6 +419,8 @@ const ChatPage = () => {
               hitlToolNames={hitlToolNames}
               decisions={decisions}
               recordDecision={recordDecision}
+              nestedInterrupts={nestedInterrupts}
+              respond={respondToInterrupt}
               modelUnavailable={modelUnavailable}
               onRegenerate={handleRegenerate}
               error={error}

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/subagent-card.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/subagent-card.tsx
@@ -4,23 +4,36 @@ import { Fragment, memo, useMemo, useState } from "react";
 import { Loader2, XCircleIcon } from "lucide-react";
 import { isAIMessage } from "@langchain/core/messages";
 import type { BaseMessage } from "@langchain/core/messages";
-import { useMessages, useToolCalls, useValues } from "@langchain/react";
 import type { AnyStream, SubagentDiscoverySnapshot } from "@langchain/react";
+import type { Interrupt } from "@langchain/langgraph-sdk";
 import { Loader } from "@/components/ai-elements/loader";
 import {
   ChainBand,
   ChainRail,
   ChainReasoningLine,
   ChainStep,
+  NeedsApprovalBadge,
   StepCode,
   StepSection,
 } from "@/components/ai-elements/chain-of-thought";
+import {
+  type HitlDecision,
+  type HitlResponse,
+  useHitlApprovals,
+} from "@/hooks/use-hitl-approvals";
+import {
+  useSubagentMessages,
+  useSubagentToolCalls,
+  useSubagentValues,
+} from "@/hooks/use-subagent-projections";
 import { AgentAvatar } from "@/components/ui/agent-avatar";
 import { TodoList } from "@/components/ai-elements/todo-list";
 import type { Todo } from "@/components/ai-elements/todo-list";
 import { cn } from "@/lib/utils";
 import {
   type ToolCallView,
+  extractHitlToolNames,
+  findSubagentInterrupt,
   getToolStepState,
   pairToolCalls,
 } from "./message-helpers";
@@ -40,11 +53,22 @@ const SubAgentConversation = memo(function SubAgentConversation({
   toolCalls,
   isStreaming,
   describe,
+  isInterrupted,
+  hitlToolNames,
+  decisions,
+  recordDecision,
+  approvalsDisabled,
 }: {
   messages: BaseMessage[];
   toolCalls: ToolCallView[];
   isStreaming: boolean;
   describe: DescribeTool;
+  /** This subagent is paused on an approval. */
+  isInterrupted: boolean;
+  hitlToolNames: Set<string> | null;
+  decisions: Partial<Record<string, HitlDecision>>;
+  recordDecision: (toolCallId: string, decision: HitlDecision) => void;
+  approvalsDisabled: boolean;
 }) {
   const byMessage = new Map<string, ToolCallView[]>();
   for (const tc of toolCalls) {
@@ -67,15 +91,29 @@ const SubAgentConversation = memo(function SubAgentConversation({
                 streaming={isStreaming && i === last && calls.length === 0}
               />
             )}
-            {calls.map((tc) => (
-              <ToolStep
-                key={tc.id}
-                tc={tc}
-                state={getToolStepState(tc)}
-                describe={describe}
-                nested
-              />
-            ))}
+            {calls.map((tc) => {
+              const state = getToolStepState(tc, isInterrupted, hitlToolNames);
+              return (
+                <ToolStep
+                  key={tc.id}
+                  tc={tc}
+                  state={state}
+                  describe={describe}
+                  nested
+                  approval={
+                    state === "awaiting-approval"
+                      ? {
+                          decided: decisions[tc.id],
+                          disabled: approvalsDisabled,
+                          onDecide: (decision) => {
+                            recordDecision(tc.id, decision);
+                          },
+                        }
+                      : undefined
+                  }
+                />
+              );
+            })}
           </Fragment>
         );
       })}
@@ -87,12 +125,17 @@ export type SubAgentCardProps = {
   /** Discovery snapshot from `stream.subagents` (keyed by task tool-call id). */
   subagent: SubagentDiscoverySnapshot;
   /** The card opens its own scoped projections on the subagent's namespace
-   *  (mount = subscribe, unmount = unsubscribe); an idle thread's history is
-   *  seeded by the SDK from `POST /threads/{id}/history`. */
+   *  (mount = subscribe, unmount = unsubscribe, resumed across runs); an idle
+   *  thread's history is seeded by the SDK from `POST /threads/{id}/history`. */
   stream: AnyStream;
   describe: DescribeTool;
   /** The workspace agent behind this subagent, for its emoji/pastel tile. */
   agent?: { name: string; emoji?: string | null; color?: string | null };
+  /** Interrupts raised inside subagents; the card claims its own. */
+  interrupts: readonly Interrupt[];
+  /** Resume — `stream.respond(response, { interruptId })`. */
+  respond: (response: HitlResponse, interruptId: string | null) => void;
+  modelUnavailable: boolean;
 };
 
 export const SubAgentCard = memo(function SubAgentCard({
@@ -100,17 +143,54 @@ export const SubAgentCard = memo(function SubAgentCard({
   stream,
   describe,
   agent,
+  interrupts,
+  respond,
+  modelUnavailable,
 }: SubAgentCardProps) {
   const { status, startedAt, completedAt } = subagent;
-  const messages = useMessages(stream, subagent);
-  const liveToolCalls = useToolCalls(stream, subagent);
-  const values = useValues<Record<string, unknown>>(stream, subagent);
+  // Scoped projections that keep flowing across a HITL pause (the SDK's own
+  // end at the first terminal lifecycle — see the hook module).
+  const messages = useSubagentMessages(stream, subagent);
+  const liveToolCalls = useSubagentToolCalls(stream, subagent);
+  const values = useSubagentValues(stream, subagent);
   const toolCalls = useMemo(
     () => pairToolCalls(messages, liveToolCalls),
     [messages, liveToolCalls],
   );
 
-  const isStreaming = status === "running";
+  // A subagent's gated tool pauses the whole run on an interrupt raised in
+  // its namespace. The SDK has no "paused" status for it (the `task` call
+  // is still running), so the card derives one from the interrupt it owns
+  // and approves it in place — same collector as the root chain, one batch
+  // per interrupt id, resumed through `input.respond`.
+  const interrupt = useMemo(
+    () => findSubagentInterrupt(interrupts, subagent, toolCalls),
+    [interrupts, subagent, toolCalls],
+  );
+  const isInterrupted = interrupt != null;
+  const hitlToolNames = useMemo(
+    () => extractHitlToolNames(interrupt?.value),
+    [interrupt],
+  );
+  const pendingToolCalls = useMemo(
+    () =>
+      toolCalls.filter(
+        (tc) =>
+          getToolStepState(tc, isInterrupted, hitlToolNames) ===
+          "awaiting-approval",
+      ),
+    [toolCalls, isInterrupted, hitlToolNames],
+  );
+  // Calls persisted without an id can only be resumed positionally.
+  const pendingIdsAreReal = pendingToolCalls.every((tc) => tc.callId != null);
+  const { decisions, recordDecision } = useHitlApprovals({
+    interruptId: pendingIdsAreReal ? (interrupt?.id ?? null) : null,
+    pendingToolCalls,
+    respond,
+  });
+  const awaitingDecision = pendingToolCalls.some((tc) => !decisions[tc.id]);
+
+  const isStreaming = status === "running" && !isInterrupted;
   const isError = status === "error";
   const todos = (values?.todos ?? []) as Todo[];
   // Hydrated snapshots stamp both dates at load time — nothing to show then.
@@ -131,21 +211,27 @@ export const SubAgentCard = memo(function SubAgentCard({
   return (
     <ChainStep
       node={
-        <AgentAvatar
-          color={agent?.color}
-          emoji={agent?.emoji}
-          size="2xs"
-          className="relative z-[1]"
-        />
+        // Same 22px square as the other rail nodes. The pastel is translucent
+        // (~8% alpha), so an opaque card layer sits under it to hide the rail.
+        <span className="relative z-[1] flex size-[22px] shrink-0 rounded-[6px] bg-card">
+          <AgentAvatar
+            color={agent?.color}
+            emoji={agent?.emoji}
+            size="2xs"
+            shape="tile"
+          />
+        </span>
       }
       title={`Ask ${agent?.name ?? subagent.name.replaceAll("_", " ")}`}
       summary={subagent.taskInput}
-      lockOpen={autoOpen}
+      lockOpen={autoOpen || (isInterrupted && awaitingDecision)}
       onOpenChange={() => {
         setAutoOpen(false);
       }}
       meta={
-        isStreaming ? (
+        isInterrupted ? (
+          <NeedsApprovalBadge />
+        ) : isStreaming ? (
           <Loader2 className="size-3 animate-spin text-petrol" />
         ) : isError ? (
           <XCircleIcon className="size-3.5 text-destructive" />
@@ -163,6 +249,11 @@ export const SubAgentCard = memo(function SubAgentCard({
           toolCalls={toolCalls}
           isStreaming={isStreaming}
           describe={describe}
+          isInterrupted={isInterrupted}
+          hitlToolNames={hitlToolNames}
+          decisions={decisions}
+          recordDecision={recordDecision}
+          approvalsDisabled={modelUnavailable}
         />
         {isError && subagent.error != null && (
           <StepSection label="ERROR" error className="mt-2">

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/subagent-card.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/subagent-card.tsx
@@ -135,6 +135,8 @@ export type SubAgentCardProps = {
   interrupts: readonly Interrupt[];
   /** Resume — `stream.respond(response, { interruptId })`. */
   respond: (response: HitlResponse, interruptId: string | null) => void;
+  /** A run is executing; approvals are held until it settles. */
+  resumeInFlight: boolean;
   modelUnavailable: boolean;
 };
 
@@ -145,6 +147,7 @@ export const SubAgentCard = memo(function SubAgentCard({
   agent,
   interrupts,
   respond,
+  resumeInFlight,
   modelUnavailable,
 }: SubAgentCardProps) {
   const { status, startedAt, completedAt } = subagent;
@@ -164,8 +167,8 @@ export const SubAgentCard = memo(function SubAgentCard({
   // and approves it in place — same collector as the root chain, one batch
   // per interrupt id, resumed through `input.respond`.
   const interrupt = useMemo(
-    () => findSubagentInterrupt(interrupts, subagent, toolCalls),
-    [interrupts, subagent, toolCalls],
+    () => findSubagentInterrupt(interrupts, subagent),
+    [interrupts, subagent],
   );
   const isInterrupted = interrupt != null;
   const hitlToolNames = useMemo(
@@ -183,10 +186,14 @@ export const SubAgentCard = memo(function SubAgentCard({
   );
   // Calls persisted without an id can only be resumed positionally.
   const pendingIdsAreReal = pendingToolCalls.every((tc) => tc.callId != null);
+  // Parallel subagents can pause together, each with its own interrupt;
+  // the thread runs one resume at a time, so a completed batch waits for
+  // the run in flight to settle and is sent when its interrupt still pends.
   const { decisions, recordDecision } = useHitlApprovals({
     interruptId: pendingIdsAreReal ? (interrupt?.id ?? null) : null,
     pendingToolCalls,
     respond,
+    enabled: !resumeInFlight,
   });
   const awaitingDecision = pendingToolCalls.some((tc) => !decisions[tc.id]);
 

--- a/web/src/components/ai-elements/chain-of-thought.tsx
+++ b/web/src/components/ai-elements/chain-of-thought.tsx
@@ -492,7 +492,10 @@ export const ChainReasoningLine = ({
 					"[&>*>*:last-child]:after:ml-0.5 [&>*>*:last-child]:after:inline-block [&>*>*:last-child]:after:h-3 [&>*>*:last-child]:after:w-1 [&>*>*:last-child]:after:animate-pulse [&>*>*:last-child]:after:rounded-sm [&>*>*:last-child]:after:bg-petrol [&>*>*:last-child]:after:align-text-bottom [&>*>*:last-child]:after:content-['']",
 			)}
 		>
-			<MessageResponse className="text-[12.5px] italic leading-[1.6] text-muted-foreground [&_[data-streamdown=strong]]:not-italic [&_[data-streamdown=strong]]:text-foreground">
+			{/* The italic is the subagent's "voice" for prose; bold and markdown
+			    headings (data-streamdown="heading-N") stay upright so a
+			    structured result reads as a document, not as an aside. */}
+			<MessageResponse className="text-[12.5px] italic leading-[1.6] text-muted-foreground [&_[data-streamdown=strong]]:not-italic [&_[data-streamdown=strong]]:text-foreground [&_[data-streamdown^=heading-]]:not-italic [&_[data-streamdown^=heading-]]:text-foreground">
 				{text}
 			</MessageResponse>
 		</div>

--- a/web/src/hooks/use-hitl-approvals.ts
+++ b/web/src/hooks/use-hitl-approvals.ts
@@ -21,6 +21,9 @@ type UseHitlApprovalsArgs<TPending extends { id: string }> = {
 	pendingToolCalls: TPending[];
 	/** Resume the run — `stream.respond(response, { interruptId })`. */
 	respond: (response: HitlResponse, interruptId: string | null) => void;
+	/** Hold a complete batch until this is true (e.g. another resume is in
+	 *  flight — the thread accepts one run at a time). Default: send at once. */
+	enabled?: boolean;
 };
 
 /**
@@ -31,12 +34,13 @@ export function useHitlApprovals<TPending extends { id: string }>({
 	interruptId,
 	pendingToolCalls,
 	respond,
+	enabled = true,
 }: UseHitlApprovalsArgs<TPending>) {
 	const [decisions, setDecisions] = useState<Record<string, HitlDecision>>({});
 	const submittedBatch = useRef<string | null>(null);
 
 	useEffect(() => {
-		if (pendingToolCalls.length === 0) return;
+		if (!enabled || pendingToolCalls.length === 0) return;
 		if (!pendingToolCalls.every((tc) => decisions[tc.id])) return;
 
 		const batchKey =
@@ -54,7 +58,7 @@ export function useHitlApprovals<TPending extends { id: string }>({
 			},
 			interruptId,
 		);
-	}, [interruptId, pendingToolCalls, decisions, respond]);
+	}, [enabled, interruptId, pendingToolCalls, decisions, respond]);
 
 	const recordDecision = useCallback(
 		(toolCallId: string, type: HitlDecision) => {

--- a/web/src/hooks/use-subagent-projections.test.ts
+++ b/web/src/hooks/use-subagent-projections.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { resumingIterator } from "./use-subagent-projections";
+
+/** The SDK's SubscriptionHandle, reduced to the behaviour under test: an
+ *  iterator that ends on pause (and on close), a resume that wakes waiters,
+ *  events buffered while paused. */
+class FakeHandle<T> {
+  closed = false;
+  paused = false;
+  private queue: T[] = [];
+  private waiters: ((r: IteratorResult<T>) => void)[] = [];
+  private resumeResolve: (() => void) | undefined;
+
+  push(event: T) {
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ done: false, value: event });
+    else this.queue.push(event);
+  }
+  pause() {
+    this.paused = true;
+    while (this.waiters.length) this.waiters.shift()?.({ done: true, value: undefined });
+  }
+  resume() {
+    this.paused = false;
+    this.resumeResolve?.();
+    this.resumeResolve = undefined;
+  }
+  close() {
+    this.closed = true;
+    this.paused = false;
+    while (this.waiters.length) this.waiters.shift()?.({ done: true, value: undefined });
+    this.resumeResolve?.();
+  }
+  get isPaused() {
+    return this.paused;
+  }
+  waitForResume(): Promise<void> {
+    if (!this.paused) return Promise.resolve();
+    return new Promise((resolve) => {
+      this.resumeResolve = resolve;
+    });
+  }
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: async () => {
+        if (this.queue.length > 0) return { done: false, value: this.queue.shift() as T };
+        if (this.closed || this.paused) return { done: true, value: undefined };
+        return new Promise((resolve) => {
+          this.waiters.push(resolve);
+        });
+      },
+      return: async () => {
+        this.close();
+        return { done: true, value: undefined };
+      },
+    };
+  }
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("resumingIterator", () => {
+  it("keeps yielding across a pause and ends on close", async () => {
+    const handle = new FakeHandle<string>();
+    const seen: string[] = [];
+    let ended = false;
+    const consume = (async () => {
+      for await (const e of resumingIterator(handle)) seen.push(e);
+      ended = true;
+    })();
+
+    handle.push("run1-a");
+    await tick();
+    handle.pause(); // terminal lifecycle of run 1
+    await tick();
+    expect(seen).toEqual(["run1-a"]);
+    expect(ended).toBe(false);
+
+    handle.push("run2-buffered"); // arrives while paused: buffered
+    handle.resume(); // input.respond accepted → next run
+    await tick();
+    handle.push("run2-b");
+    await tick();
+    expect(seen).toEqual(["run1-a", "run2-buffered", "run2-b"]);
+
+    handle.close();
+    await consume;
+    expect(ended).toBe(true);
+  });
+
+  it("the SDK's plain iteration ends at the pause (the behaviour worked around)", async () => {
+    const handle = new FakeHandle<string>();
+    const seen: string[] = [];
+    const consume = (async () => {
+      for await (const e of handle) seen.push(e);
+    })();
+    handle.push("a");
+    await tick();
+    handle.pause();
+    await consume; // ends here
+    handle.resume();
+    handle.push("b");
+    expect(seen).toEqual(["a"]);
+  });
+
+  it("closing the consumer closes the handle", async () => {
+    const handle = new FakeHandle<string>();
+    const it = resumingIterator(handle);
+    handle.push("a");
+    expect((await it.next()).value).toBe("a");
+    await it.return();
+    expect(handle.closed).toBe(true);
+  });
+});

--- a/web/src/hooks/use-subagent-projections.test.ts
+++ b/web/src/hooks/use-subagent-projections.test.ts
@@ -108,7 +108,7 @@ describe("resumingIterator", () => {
     const it = resumingIterator(handle);
     handle.push("a");
     expect((await it.next()).value).toBe("a");
-    await it.return();
+    await it.return?.();
     expect(handle.closed).toBe(true);
   });
 });

--- a/web/src/hooks/use-subagent-projections.test.ts
+++ b/web/src/hooks/use-subagent-projections.test.ts
@@ -103,12 +103,16 @@ describe("resumingIterator", () => {
     expect(seen).toEqual(["a"]);
   });
 
-  it("closing the consumer closes the handle", async () => {
+  it("closing the consumer closes the handle and stays finished", async () => {
     const handle = new FakeHandle<string>();
     const it = resumingIterator(handle);
     handle.push("a");
     expect((await it.next()).value).toBe("a");
     await it.return?.();
     expect(handle.closed).toBe(true);
+    // A late next() after return() never re-enters the SDK iterator.
+    handle.closed = false;
+    handle.push("late");
+    expect((await it.next()).done).toBe(true);
   });
 });

--- a/web/src/hooks/use-subagent-projections.ts
+++ b/web/src/hooks/use-subagent-projections.ts
@@ -182,12 +182,15 @@ export function resumingIterator<T>(
         for (;;) {
           inner ??= iteratorOf(handle);
           const result = await inner.next();
+          // `return()` may have run while we awaited: nothing after cleanup.
+          if (finished) break;
           if (!result.done) return result;
           // The SDK's handle ends an iterator for a pause or a close.
           inner = null;
           if (isClosed(handle)) break;
           if (handle.isPaused) {
             await handle.waitForResume();
+            if (finished) break;
             continue;
           }
           // Neither paused nor known-closed: treat as closed.

--- a/web/src/hooks/use-subagent-projections.ts
+++ b/web/src/hooks/use-subagent-projections.ts
@@ -166,27 +166,49 @@ export function resumingHandle<H extends SubscriptionHandle>(handle: H): H {
 /** Ends only when the handle is closed (unsubscribed or the session ended).
  *  A failing handle ends the iteration too — the same outcome as the SDK's
  *  own projection loop, which catches and stops. */
-export async function* resumingIterator<T>(
+export function resumingIterator<T>(
   handle: AsyncIterable<T> & {
     readonly isPaused: boolean;
     waitForResume(): Promise<void>;
   },
-): AsyncGenerator<T, void, undefined> {
-  try {
-    for (;;) {
-      for await (const event of handle) yield event;
-      if (isClosed(handle)) return;
-      if (handle.isPaused) {
-        await handle.waitForResume();
-        continue;
+): AsyncIterableIterator<T> {
+  const done: IteratorReturnResult<undefined> = { done: true, value: undefined };
+  let inner: AsyncIterator<T> | null = null;
+  return {
+    async next() {
+      try {
+        for (;;) {
+          inner ??= handle[Symbol.asyncIterator]();
+          const result = await inner.next();
+          if (!result.done) return result;
+          // The SDK's handle ends an iterator for a pause or a close.
+          inner = null;
+          if (isClosed(handle)) return done;
+          if (handle.isPaused) {
+            await handle.waitForResume();
+            continue;
+          }
+          // Neither paused nor known-closed: treat as closed.
+          if (!knowsClosed(handle)) return done;
+        }
+      } catch {
+        return done;
       }
-      // Neither paused nor known-closed: the SDK's handle only ends an
-      // iterator for one of the two, so treat this as closed.
-      if (!knowsClosed(handle)) return;
-    }
-  } catch {
-    return;
-  }
+    },
+    async return() {
+      const current = inner ?? handle[Symbol.asyncIterator]();
+      inner = null;
+      try {
+        await current.return?.();
+      } catch {
+        // Closing a handle that is already gone is not an error.
+      }
+      return done;
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
 }
 
 // `closed` is a TypeScript-private field on the SDK's handle but a plain

--- a/web/src/hooks/use-subagent-projections.ts
+++ b/web/src/hooks/use-subagent-projections.ts
@@ -174,29 +174,34 @@ export function resumingIterator<T>(
 ): AsyncIterableIterator<T> {
   const done: IteratorReturnResult<undefined> = { done: true, value: undefined };
   let inner: AsyncIterator<T> | null = null;
+  let finished = false;
   return {
     async next() {
+      if (finished) return done;
       try {
         for (;;) {
-          inner ??= handle[Symbol.asyncIterator]();
+          inner ??= iteratorOf(handle);
           const result = await inner.next();
           if (!result.done) return result;
           // The SDK's handle ends an iterator for a pause or a close.
           inner = null;
-          if (isClosed(handle)) return done;
+          if (isClosed(handle)) break;
           if (handle.isPaused) {
             await handle.waitForResume();
             continue;
           }
           // Neither paused nor known-closed: treat as closed.
-          if (!knowsClosed(handle)) return done;
+          if (!knowsClosed(handle)) break;
         }
       } catch {
-        return done;
+        // A failing handle ends the iteration, as in the SDK's own loop.
       }
+      finished = true;
+      return done;
     },
     async return() {
-      const current = inner ?? handle[Symbol.asyncIterator]();
+      finished = true;
+      const current = inner ?? iteratorOf(handle);
       inner = null;
       try {
         await current.return?.();
@@ -209,6 +214,12 @@ export function resumingIterator<T>(
       return this;
     },
   };
+}
+
+/** `iterable[Symbol.asyncIterator]()` without a computed member call. */
+function iteratorOf<T>(iterable: AsyncIterable<T>): AsyncIterator<T> {
+  const { [Symbol.asyncIterator]: open } = iterable;
+  return open.call(iterable);
 }
 
 // `closed` is a TypeScript-private field on the SDK's handle but a plain

--- a/web/src/hooks/use-subagent-projections.ts
+++ b/web/src/hooks/use-subagent-projections.ts
@@ -175,22 +175,26 @@ export function resumingIterator<T>(
   const done: IteratorReturnResult<undefined> = { done: true, value: undefined };
   let inner: AsyncIterator<T> | null = null;
   let finished = false;
+  // Read through a call: TypeScript would otherwise narrow `finished` to
+  // `false` for the rest of `next()` after the first check, although
+  // `return()` can flip it while we await.
+  const isFinished = () => finished;
   return {
     async next() {
-      if (finished) return done;
+      if (isFinished()) return done;
       try {
         for (;;) {
           inner ??= iteratorOf(handle);
           const result = await inner.next();
           // `return()` may have run while we awaited: nothing after cleanup.
-          if (finished) break;
+          if (isFinished()) break;
           if (!result.done) return result;
           // The SDK's handle ends an iterator for a pause or a close.
           inner = null;
           if (isClosed(handle)) break;
           if (handle.isPaused) {
             await handle.waitForResume();
-            if (finished) break;
+            if (isFinished()) break;
             continue;
           }
           // Neither paused nor known-closed: treat as closed.

--- a/web/src/hooks/use-subagent-projections.ts
+++ b/web/src/hooks/use-subagent-projections.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect } from "react";
+import type { BaseMessage } from "@langchain/core/messages";
+import { STREAM_CONTROLLER, useProjection } from "@langchain/react";
+import type {
+  AnyStream,
+  AssembledToolCall,
+  SubagentDiscoverySnapshot,
+} from "@langchain/react";
+import {
+  messagesProjection,
+  toolCallsProjection,
+  valuesProjection,
+} from "@langchain/langgraph-sdk/stream";
+import type { ProjectionSpec } from "@langchain/langgraph-sdk/stream";
+import type {
+  SubscriptionHandle,
+  ThreadStream,
+} from "@langchain/langgraph-sdk/client";
+
+/**
+ * Subagent-scoped projections that survive a run boundary.
+ *
+ * The SDK's `useMessages` / `useToolCalls` / `useValues` open one server
+ * subscription per subagent namespace and iterate it with a single
+ * `for await`. When the root run reaches a terminal lifecycle the thread
+ * client *pauses* every user subscription; the SDK's scoped projections do
+ * not opt into resuming (`resumeOnPause` is reserved for `useChannel` /
+ * `useExtension`), so their loop ends there and the card is frozen for the
+ * rest of the page's life — even though the handle is resumed and keeps
+ * buffering events when the next run starts.
+ *
+ * That is exactly the HITL shape: a subagent's gated tool interrupts the
+ * run (terminal `interrupted`), the user approves, the resumed run streams
+ * the tool result and the subagent's next turn under the same namespace…
+ * into a dead projection. The card kept showing the pre-approval call as
+ * pending, and the approval collector re-sent the stale decision against the
+ * next interrupt (a 400 from the backend).
+ *
+ * These hooks reuse the SDK's own projection specs and only wrap the thread
+ * they subscribe through, so a paused handle's iterator waits for the
+ * resume instead of finishing. Upstream `main` still has the default, so
+ * this cannot be fixed by a version bump yet.
+ */
+
+const EMPTY_MESSAGES: BaseMessage[] = [];
+const EMPTY_TOOL_CALLS: AssembledToolCall[] = [];
+const KEY_SUFFIX = "resume-across-runs";
+
+export function useSubagentMessages(
+  stream: AnyStream,
+  subagent: SubagentDiscoverySnapshot,
+): BaseMessage[] {
+  useResolveSubagentNamespace(stream, subagent);
+  const namespace = subagent.namespace;
+  return useProjection(
+    registryOf(stream),
+    () => resumeAcrossRuns(messagesProjection(namespace)),
+    `messages|${namespace.join("|")}|${KEY_SUFFIX}`,
+    EMPTY_MESSAGES,
+  );
+}
+
+export function useSubagentToolCalls(
+  stream: AnyStream,
+  subagent: SubagentDiscoverySnapshot,
+): AssembledToolCall[] {
+  useResolveSubagentNamespace(stream, subagent);
+  const namespace = subagent.namespace;
+  return useProjection(
+    registryOf(stream),
+    () => resumeAcrossRuns(toolCallsProjection(namespace)),
+    `toolCalls|${namespace.join("|")}|${KEY_SUFFIX}`,
+    EMPTY_TOOL_CALLS,
+  );
+}
+
+export function useSubagentValues(
+  stream: AnyStream,
+  subagent: SubagentDiscoverySnapshot,
+): Record<string, unknown> | undefined {
+  const namespace = subagent.namespace;
+  return useProjection<Record<string, unknown> | undefined>(
+    registryOf(stream),
+    () =>
+      resumeAcrossRuns(
+        valuesProjection<Record<string, unknown>>(namespace, "messages"),
+      ),
+    `values|messages|${namespace.join("|")}|${KEY_SUFFIX}`,
+    undefined,
+  );
+}
+
+const registryOf = (stream: AnyStream) => stream[STREAM_CONTROLLER].registry;
+
+/** Mirror of the SDK's internal `useResolveSubagentNamespace`: a snapshot
+ *  still on its default `tools:<toolCallId>` namespace needs the controller
+ *  to look up the real execution namespace before a scoped projection can
+ *  target it. The controller de-dupes the call. */
+function useResolveSubagentNamespace(
+  stream: AnyStream,
+  subagent: SubagentDiscoverySnapshot,
+) {
+  const controller = stream[STREAM_CONTROLLER];
+  const needsResolution =
+    subagent.namespace.length === 1 &&
+    subagent.namespace[0] === `tools:${subagent.id}`;
+  const toolCallId = needsResolution ? subagent.id : null;
+  useEffect(() => {
+    if (toolCallId == null) return;
+    void controller.resolveSubagentNamespace(toolCallId);
+  }, [controller, toolCallId]);
+}
+
+/** The same projection, subscribing through a thread whose subscriptions
+ *  resume across runs. A distinct key keeps it apart from the SDK's own
+ *  registry entry for the namespace. */
+export function resumeAcrossRuns<T>(spec: ProjectionSpec<T>): ProjectionSpec<T> {
+  return {
+    ...spec,
+    key: `${spec.key}|${KEY_SUFFIX}`,
+    open: (params) =>
+      spec.open({ ...params, thread: withResumingSubscribe(params.thread) }),
+  };
+}
+
+function withResumingSubscribe(thread: ThreadStream): ThreadStream {
+  return new Proxy(thread, {
+    get(target, prop) {
+      if (prop === "subscribe") {
+        return async (...args: Parameters<ThreadStream["subscribe"]>) =>
+          resumingHandle(await target.subscribe(...args));
+      }
+      const value: unknown = Reflect.get(target, prop, target);
+      return typeof value === "function"
+        ? (value as (...a: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  });
+}
+
+/** A handle whose async iteration outlives a pause: the SDK ends the
+ *  iterator when the thread client pauses on a terminal lifecycle; this one
+ *  waits for the resume and keeps yielding (buffered events included). */
+export function resumingHandle<H extends SubscriptionHandle>(handle: H): H {
+  return new Proxy(handle, {
+    get(target, prop) {
+      if (prop === Symbol.asyncIterator) {
+        return () => resumingIterator(target);
+      }
+      const value: unknown = Reflect.get(target, prop, target);
+      return typeof value === "function"
+        ? (value as (...a: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  });
+}
+
+/** Ends only when the handle is closed (unsubscribed or the session ended). */
+export async function* resumingIterator<T>(
+  handle: AsyncIterable<T> & {
+    readonly isPaused: boolean;
+    waitForResume(): Promise<void>;
+  },
+): AsyncGenerator<T, void, undefined> {
+  for (;;) {
+    for await (const event of handle) yield event;
+    if (isClosed(handle)) return;
+    if (handle.isPaused) {
+      await handle.waitForResume();
+      continue;
+    }
+    // Neither paused nor known-closed: the SDK's handle only ends an
+    // iterator for one of the two, so treat this as closed.
+    if (!knowsClosed(handle)) return;
+  }
+}
+
+// `closed` is a TypeScript-private field on the SDK's handle but a plain
+// public property at runtime; it is what tells a pause from the end.
+const knowsClosed = (handle: object): boolean =>
+  typeof (handle as { closed?: unknown }).closed === "boolean";
+const isClosed = (handle: object): boolean =>
+  (handle as { closed?: unknown }).closed === true;

--- a/web/src/hooks/use-subagent-projections.ts
+++ b/web/src/hooks/use-subagent-projections.ts
@@ -92,7 +92,13 @@ export function useSubagentValues(
   );
 }
 
-const registryOf = (stream: AnyStream) => stream[STREAM_CONTROLLER].registry;
+/** The stream's controller (the SDK exposes it under a well-known symbol). */
+function controllerOf(stream: AnyStream) {
+  const { [STREAM_CONTROLLER]: controller } = stream;
+  return controller;
+}
+
+const registryOf = (stream: AnyStream) => controllerOf(stream).registry;
 
 /** Mirror of the SDK's internal `useResolveSubagentNamespace`: a snapshot
  *  still on its default `tools:<toolCallId>` namespace needs the controller
@@ -102,7 +108,7 @@ function useResolveSubagentNamespace(
   stream: AnyStream,
   subagent: SubagentDiscoverySnapshot,
 ) {
-  const controller = stream[STREAM_CONTROLLER];
+  const controller = controllerOf(stream);
   const needsResolution =
     subagent.namespace.length === 1 &&
     subagent.namespace[0] === `tools:${subagent.id}`;
@@ -157,23 +163,29 @@ export function resumingHandle<H extends SubscriptionHandle>(handle: H): H {
   });
 }
 
-/** Ends only when the handle is closed (unsubscribed or the session ended). */
+/** Ends only when the handle is closed (unsubscribed or the session ended).
+ *  A failing handle ends the iteration too — the same outcome as the SDK's
+ *  own projection loop, which catches and stops. */
 export async function* resumingIterator<T>(
   handle: AsyncIterable<T> & {
     readonly isPaused: boolean;
     waitForResume(): Promise<void>;
   },
 ): AsyncGenerator<T, void, undefined> {
-  for (;;) {
-    for await (const event of handle) yield event;
-    if (isClosed(handle)) return;
-    if (handle.isPaused) {
-      await handle.waitForResume();
-      continue;
+  try {
+    for (;;) {
+      for await (const event of handle) yield event;
+      if (isClosed(handle)) return;
+      if (handle.isPaused) {
+        await handle.waitForResume();
+        continue;
+      }
+      // Neither paused nor known-closed: the SDK's handle only ends an
+      // iterator for one of the two, so treat this as closed.
+      if (!knowsClosed(handle)) return;
     }
-    // Neither paused nor known-closed: the SDK's handle only ends an
-    // iterator for one of the two, so treat this as closed.
-    if (!knowsClosed(handle)) return;
+  } catch {
+    return;
   }
 }
 


### PR DESCRIPTION
## Summary

A subagent's "requires approval" tools were silently ignored at run time (#301). The premise behind that was wrong: deepagents' `task` runs the subagent as a nested subgraph on the parent's checkpointer, so its interrupt already propagates to the root checkpoint with an id that encodes its namespace, and an id-keyed resume routes back into it. This PR adds the plumbing so a subagent's approval shows up and resumes like a parent's — on the web, in Slack and after a reload.

Full investigation, verified by spike, and the live-test finding: `subagent-hitl-assessment.md`.

## Backend

- `ResolvedAgent.compile` passes the subagent's `interrupt_on`; the stale "runs without a checkpointer" docstrings are rewritten.
- `hitl.load_interrupt_scope` follows the root pending write into the subagent's `tools:<task-id>` checkpoint (nested levels too, depth-capped) so approvals carry the real `tool_call_id`. `pending_approval_requests` / `build_resume_command` take that scope. Used by `RunService._canonical_command`, `ProtocolService.thread_state` (interrupt `namespace` for hydration), the Slack consumer (cards say which subagent asked) and handlers.
- `ProtocolEmitter` emits `input.requested` under the paused agent's namespace, and swallows the `task` `tool-error` that is the interrupt bubbling up — forwarded, it marked the subagent card errored for the whole pause.

## Web

- `page.tsx` splits `stream.interrupts` into the root one and the subagents' (keyed by content so the memoized body isn't re-rendered per token).
- `SubAgentCard` claims its interrupt (namespace first, action-request fallback after a reload), renders nested tool steps as awaiting approval with the approve/deny footer, shows the needs-approval badge instead of the spinner, and resumes through its own `useHitlApprovals`. The chain stays open while a card is paused.
- `hooks/use-subagent-projections.ts` (found in the first live test): the SDK's scoped `useMessages` / `useToolCalls` / `useValues` stop receiving events after a run's terminal lifecycle — the thread client pauses the subscription and the scoped projections never resume (`resumeOnPause` is off for them, upstream `main` included). After the first approval the card froze and auto-resubmitted a stale decision (400). The hooks reuse the SDK's own projection specs through a thread whose subscriptions resume across runs; no package patching.
- Rail polish: square, opaque subagent avatar; markdown headings in the subagent's lines are no longer italic.

## Tests

- `tests/agents/test_hitl.py`: scope resolution (root, subagent, parallel siblings, depth cap) and a real gated subagent end to end through `build_runnable`.
- `tests/agents/protocol/test_emit.py`: `subagent_scenario` — namespaced `input.requested`, no `task` tool-error, resume.
- `tests/agents/protocol/test_service.py`: state snapshot namespace. Slack consumer seam updated.
- Web: `message-helpers.test.ts` (interrupt split / card claim), `use-subagent-projections.test.ts` (resume across a pause).
- Backend suite 1035 passed; web vitest / tsc / strict eslint clean. Live-tested on a Slides subagent: interrupt → approve → retry → approve → completion.

## Notes for the issue

#301 suggested hiding the approval toggle on subagent tools. It now works, so the toggle stays.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Subagent tool approvals were silently ignored at runtime; they now surface and resume like the parent's in the web UI, Slack, and after a reload. Parallel subagents pausing together each get their own addressed resume, so approving one no longer marks the other stale. Closes #301.

**Backend**
- `ResolvedAgent.compile` passes the subagent's `interrupt_on`, so gated tools are no longer skipped.
- `hitl.pending_interrupts` lists every pending interrupt; an id-addressed resume picks its own, so parallel cards each approve without a stale 409.
- `thread_state` reports one task per pending interrupt.
- The emitter sends `input.requested` under the paused agent's namespace and swallows the `task` tool-error only when it matches the interrupt repr and every id it names was announced.
- Slack approval cards name the requesting subagent, mrkdwn-escaped.

**Web**
- `SubAgentCard` claims its interrupt via the execution namespace or the SDK's discovery key after a reload, shows the needs-approval badge with approve/deny controls, and resumes through its own decision collector; it holds a completed decision batch while a run is in flight.
- The chain stays open while a card is paused.
- New `use-subagent-projections` hooks keep the card's scoped message and tool-call subscriptions flowing across a pause; the SDK's own stop at the first terminal lifecycle, which froze the card and caused stale decisions.
- Subagent lines render markdown headings upright, and the avatar is a square opaque tile.

<sup>Written for commit 7f7b8e0af91606cd39c48562e14078673b7bc65e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

