### PR TITLE
chore(demo): shopping assistant demo video (Choose Shop MCP app)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
 		"demo:seed": "node tests/demo/seed-demo.mjs",
 		"demo:web": "NEXT_DIST_DIR=.next-demo next build && NEXT_DIST_DIR=.next-demo next start -p \"${DEMO_PORT:-3100}\"",
 		"demo:video": "PLAYWRIGHT_BASE_URL=\"${PLAYWRIGHT_BASE_URL:-http://localhost:${DEMO_PORT:-3100}}\" playwright test --project=demo",
+		"demo:video:shopping": "DEMO_SPEED=\"${DEMO_SPEED:-4}\" PLAYWRIGHT_BASE_URL=\"${PLAYWRIGHT_BASE_URL:-http://localhost:${DEMO_PORT:-3100}}\" playwright test --project=demo tests/demo/shopping.demo.spec.ts",
 		"docs:screenshots": "PLAYWRIGHT_BASE_URL=\"${PLAYWRIGHT_BASE_URL:-http://localhost:${DEMO_PORT:-3100}}\" playwright test --project=docs",
 		"test:visual:update": "docker run --rm -v \"$PWD\":/work -v auxilia-web-node-modules:/work/node_modules -w /work -e HOME=/root mcr.microsoft.com/playwright:v1.61.1-noble sh -lc \"npm ci && npx playwright test --project=visual --update-snapshots\""
 	},

--- a/web/tests/demo/README.md
+++ b/web/tests/demo/README.md
@@ -112,6 +112,61 @@ By default the demo/docs projects target `http://localhost:3100` (the
 `localhost` URL — Next.js dev-origin protection 403s the JS chunks when the
 page is addressed as `127.0.0.1`, leaving pages unhydrated.
 
+## 2b. Record the Shopping assistant demo
+
+```sh
+cd web && npm run demo:video:shopping
+```
+
+`tests/demo/shopping.demo.spec.ts` is a second, shorter video about one agent
+bound to the **Choose Shop** MCP server — an [MCP App](https://modelcontextprotocol.io/docs/extensions/apps):
+its tool results render as an interactive carousel in a sandboxed iframe
+inside the conversation. It is not seeded by `demo:seed`; it expects, in the
+workspace the demo admin signs into:
+
+- an agent named **Shopping assistant** (override with `DEMO_SHOPPING_AGENT`)
+  bound to the Choose Shop server (`…/shop/mcp`, API-key auth) with all three
+  tools (`search_sales`, `search_products`, `get_product`) allowed — the app
+  drills down by calling them itself;
+- the **DeepSeek V4 Pro** model enabled. The spec picks it in the composer on
+  camera (unless it is the workspace default) together with reasoning effort
+  **Off** — `DEMO_MODEL_NAME` / `DEMO_REASONING_EFFORT` override both. That
+  configuration ran a single search for the gift prompt in 3 takes out of 5
+  (Pro with thinking on: 1 in 3; Flash: never; Flash with thinking off went
+  wild with 14–51 calls), so by default the spec re-records when that prompt
+  produced more than one carousel (`DEMO_SINGLE_SEARCH=0` to accept
+  multi-search takes). For the record, GPT-4o mini was single-search in 3/3
+  trials; Claude and Gemini models fanned out into 2–10 searches.
+
+Storyline: the product demo's intro card, then straight to the assistant's
+starter screen — the session is authenticated with a cookie, so there is no
+sign-in or agent picking on camera — a title slide about the assistant, then
+two French-language parts:
+
+1. **Entrée par les ventes** — "y a des ventes de mode homme en ce moment ?"
+   (`DEMO_SALES_PROMPT`) → sales carousel → click the first sale (the app
+   fetches its products) → add the first in-stock product to the (demo) cart
+   → back. The men's-clothing wording of the original storyline is a valid
+   override, but `search_sales` matches free text against the sale taxonomy
+   and the carousel is empty whenever no live sale mentions "homme".
+2. **Entrée par les produits** — a gift request with a budget
+   (`DEMO_GIFT_PROMPT`) → one product search → open a product sheet → browse
+   the gallery → add to cart.
+
+An empty carousel (or a multi-search gift take, see above) fails the test and
+Playwright re-records from scratch (`DEMO_RETRIES`, default 4) — a model can
+still pick a filter that matches nothing.
+
+The Choose carousel lives two iframes deep (`/sandbox.html` → a `blob:` app
+page); the spec drives it with `frameLocator`s, so the cursor and clicks are
+real. Re-runs delete the demo admin's previous threads on that agent first.
+
+The UI steps run at `DEMO_SPEED=4` by default (twice the walkthrough's pace;
+title cards keep their own timing) — override the variable to slow down.
+
+Output: `web/demo-output/auxilia-shopping-demo.webm` (1440×900); convert with
+the same ffmpeg command as above.
+
 ## 3. Capture docs screenshots
 
 ```sh

--- a/web/tests/demo/shopping.demo.spec.ts
+++ b/web/tests/demo/shopping.demo.spec.ts
@@ -1,0 +1,354 @@
+import { expect, test, type FrameLocator, type Page } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import {
+	agentIdByName,
+	api,
+	authenticate,
+	beat,
+	brandCard,
+	cursorClick,
+	paced,
+	titleCard,
+} from "../utils/demo";
+
+/**
+ * Records the Shopping assistant demo as a video — a companion to
+ * walkthrough.demo.spec.ts focused on one agent bound to the Choose Shop MCP
+ * server (an MCP App: tool results render as an interactive carousel in a
+ * sandboxed iframe inside the conversation).
+ *
+ * Storyline: the product demo's intro card → a title slide about the
+ * Shopping assistant, opening on its starter screen (the session is
+ * authenticated with a cookie: no sign-in or agent picking on camera) →
+ * part 1 "Entrée par les ventes" (ask for live sales,
+ * open the first sale from the carousel, add a product to the cart, go back)
+ * → part 2 "Entrée par les produits" (describe a gift, one product search,
+ * open a product sheet, add it to the cart) → close card.
+ *
+ * Prerequisites: a running backend, a production frontend (npm run demo:web →
+ * :3100), the demo admin (DEMO_EMAIL / DEMO_PASSWORD) and an agent named
+ * `DEMO_SHOPPING_AGENT` (default "Shopping assistant") bound to the Choose
+ * Shop MCP server, with its tools synced. The Choose Shop tools drill down
+ * by calling the server from inside the app (search_products / get_product),
+ * so none of them may be disabled for the agent.
+ *
+ * Run: npm run demo:video:shopping
+ * Output: web/demo-output/auxilia-shopping-demo.webm
+ */
+
+const OUTPUT = path.join(
+	process.cwd(),
+	"demo-output",
+	"auxilia-shopping-demo.webm",
+);
+
+const TAGLINE = "The open-source MCP client for teams";
+const AGENT_NAME = process.env.DEMO_SHOPPING_AGENT ?? "Shopping assistant";
+/**
+ * Display name of the model to chat with, picked in the composer on camera
+ * unless it is already the workspace default. Reasoning effort is picked the
+ * same way (`DEMO_REASONING_EFFORT` is the menu label; "" keeps the default).
+ *
+ * Why DeepSeek V4 Pro with thinking Off: trials on the gift prompt (which
+ * should trigger exactly one search — every extra call is another carousel):
+ *   DeepSeek V4 Pro, Off      1·1·1·4·3 calls, 8–16 s   ← used
+ *   DeepSeek V4 Pro, default  3·1·4
+ *   DeepSeek V4 Flash, default 2·2·4 (and 5·5·4·4·5 on camera)
+ *   DeepSeek V4 Flash, Off    14·31·51 (!)
+ *   GPT-4o mini 1·1·1 · Haiku 4.5 2 · Sonnet 4.6 4 · Sonnet 5 5 · Gemini 3 Flash 10
+ * The single-search check + retries below cover the remaining takes.
+ */
+const MODEL_NAME = process.env.DEMO_MODEL_NAME ?? "DeepSeek V4 Pro";
+const REASONING_EFFORT = process.env.DEMO_REASONING_EFFORT ?? "Off";
+/** Re-record when the gift prompt triggered more than one tool call (default on). */
+const SINGLE_SEARCH = (process.env.DEMO_SINGLE_SEARCH ?? "1") !== "0";
+
+/**
+ * Part 1 prompt. The original storyline asked for men's clothing ("y a des
+ * ventes de vêtements pour homme en ce moment ?") but search_sales matches
+ * free text against the sale taxonomy, and on 2026-09-06 no live sale
+ * mentioned "homme" (0 of 120) — the carousel came back empty unless the
+ * model dropped the word. "mode" matches the Mode section whichever filter
+ * the model picks. Override with DEMO_SALES_PROMPT when men's sales are live.
+ */
+const SALES_PROMPT =
+	process.env.DEMO_SALES_PROMPT ??
+	"y a des ventes de mode homme en ce moment ?";
+const GIFT_PROMPT =
+	process.env.DEMO_GIFT_PROMPT ??
+	"Je cherche un cadeau pour la fille de 3 ans d'un ami, avec un budget max de 40€. Plutôt ludique.";
+
+/** The Choose carousel lives two iframes deep: /sandbox.html → blob: app page. */
+const appFrame = (page: Page): FrameLocator =>
+	page
+		.frameLocator('iframe[src*="sandbox.html"]')
+		.last()
+		.frameLocator("#mcp-app-frame");
+
+/** Scroll the (last) MCP-app widget to the middle of the conversation pane. */
+async function revealWidget(page: Page): Promise<void> {
+	const widget = page.locator('iframe[src*="sandbox.html"]').last();
+	await widget.evaluate((el) => {
+		el.scrollIntoView({ block: "center", behavior: "smooth" });
+	});
+	await beat(page, 900);
+}
+
+/** Pick the demo model in the composer if the starter page defaulted to another one. */
+async function ensureModel(page: Page): Promise<void> {
+	const composer = page.locator('form:has(textarea[name="message"])');
+	if (
+		await composer
+			.getByRole("button", { name: MODEL_NAME })
+			.isVisible()
+			.catch(() => false)
+	) {
+		return;
+	}
+	const pill = composer
+		.getByRole("button")
+		.filter({
+			hasText: /Select model|GPT|Claude|Gemini|DeepSeek|GLM|MiMo|Muse/,
+		})
+		.first();
+	await cursorClick(page, pill);
+	const dialog = page.getByRole("dialog");
+	await dialog.getByPlaceholder("Search models...").fill(MODEL_NAME);
+	await cursorClick(page, dialog.getByRole("button", { name: MODEL_NAME }));
+	await expect(dialog).toBeHidden();
+	await beat(page, 400);
+}
+
+/** Pick the reasoning-effort level in the composer's brain menu (skipped when empty). */
+async function ensureEffort(page: Page): Promise<void> {
+	if (!REASONING_EFFORT) return;
+	const composer = page.locator('form:has(textarea[name="message"])');
+	const pill = composer
+		.getByRole("button")
+		.filter({
+			hasText: /^(Auto|Default|Off|Minimal|Low|Medium|High|Extra high|Max)/,
+		})
+		.first();
+	if ((await pill.innerText().catch(() => "")).trim() === REASONING_EFFORT)
+		return;
+	await cursorClick(page, pill);
+	const item = page
+		.getByRole("menuitem", { name: REASONING_EFFORT, exact: true })
+		.or(page.getByText(REASONING_EFFORT, { exact: true }))
+		.first();
+	await cursorClick(page, item);
+	await beat(page, 400);
+}
+
+/** Type the prompt into the starter composer, send it, and wait for the reply to finish. */
+async function ask(page: Page, prompt: string): Promise<void> {
+	const composer = page.locator('textarea[name="message"]');
+	await expect(composer).toBeEnabled({ timeout: 30_000 });
+	await cursorClick(page, composer);
+	await composer.pressSequentially(prompt, { delay: paced(25) });
+	await beat(page, 600);
+	await composer.press("Enter");
+	await page.waitForURL(/\/chat\/[0-9a-f-]{36}$/, { timeout: 30_000 });
+	const done = page.getByRole("button", { name: "Retry" });
+	await expect(done.first()).toBeVisible({ timeout: 240_000 });
+}
+
+/** Product cards with a real price (out-of-stock items show "—" and no amount). */
+const pricedProduct = (app: FrameLocator) =>
+	app.locator(".card[data-kind=product]:has(span.price:not([style]))").first();
+
+/** Delete the demo user's earlier threads on this agent so the sidebar starts clean. */
+async function resetShoppingThreads(agentId: string): Promise<void> {
+	const page = await api<{ items: { id: string; agent_id: string }[] }>(
+		"GET",
+		"/threads/?limit=200",
+	);
+	for (const thread of page?.items ?? []) {
+		if (thread.agent_id === agentId) {
+			await api("DELETE", `/threads/${thread.id}`).catch(() => {});
+		}
+	}
+}
+
+let agentId = "";
+
+// A model can still pick a filter that matches nothing (an empty carousel is
+// not a demo). The spec asserts on the carousel content, and a retry re-records
+// the whole video from scratch — Playwright discards the failed attempt's file.
+test.describe.configure({ retries: Number(process.env.DEMO_RETRIES ?? 4) });
+
+test.beforeEach(async () => {
+	agentId = await agentIdByName(AGENT_NAME);
+	await resetShoppingThreads(agentId);
+});
+
+test("shopping assistant demo", async ({ page, baseURL }) => {
+	await page.emulateMedia({ colorScheme: "light" });
+	await page
+		.context()
+		.addCookies([
+			{
+				name: "sidebar_state",
+				value: "true",
+				domain: new URL(baseURL!).hostname,
+				path: "/",
+			},
+		]);
+
+	const starterPath = `/agents/${agentId}/chat`;
+
+	await test.step("intro card", async () => {
+		// Open the starter screen already signed in, hidden behind a white
+		// cover showing the logo row at the brand card's exact spot, so the
+		// video's first frame is the brand card and the page never blinks.
+		await authenticate(page.context(), baseURL!);
+		const rowUri = `data:image/png;base64,${fs
+			.readFileSync(
+				path.join(process.cwd(), "tests", "demo", "assets", "brand-row.png"),
+			)
+			.toString("base64")}`;
+		const coverStyle =
+			'<style id="__demo_cover">html::before{content:"";position:fixed;' +
+			`inset:0;z-index:2147483646;background:#fff url("${rowUri}") ` +
+			"567px 384px / 306px 76px no-repeat;}</style>";
+		await page.route(
+			(url) => url.pathname === starterPath,
+			async (route) => {
+				if (route.request().resourceType() !== "document")
+					return route.continue();
+				const response = await route.fetch();
+				const body = (await response.text()).replace(
+					"</head>",
+					`${coverStyle}</head>`,
+				);
+				await route.fulfill({ response, body });
+			},
+		);
+		await page.goto(starterPath);
+		await page.unrouteAll();
+		await expect(page.locator('textarea[name="message"]')).toBeVisible({
+			timeout: 30_000,
+		});
+		await brandCard(page, { tagline: TAGLINE, holdMs: 2200, instant: true });
+	});
+
+	await test.step("shopping assistant slide", async () => {
+		await beat(page, 900);
+		await titleCard(page, {
+			eyebrow: "// MCP APPS",
+			title: "Shopping assistant",
+			sub: "Un agent auxilia branché sur le serveur MCP de Choose — ventes, produits et panier s'affichent directement dans la conversation.",
+		});
+		await expect(page.getByRole("heading", { name: AGENT_NAME })).toBeVisible();
+		await beat(page, 2200);
+	});
+
+	await test.step("part 1 — entrée par les ventes", async () => {
+		await titleCard(page, {
+			index: 1,
+			total: 2,
+			eyebrow: "// SHOPPING ASSISTANT",
+			title: "Entrée par les ventes",
+			sub: "Demandez ce qui est en vente : l'agent répond avec un carrousel interactif. Ouvrez une vente, ajoutez au panier — sans quitter la conversation.",
+		});
+		await ensureModel(page);
+		await ensureEffort(page);
+		await ask(page, SALES_PROMPT);
+
+		const app = appFrame(page);
+		const saleCards = app.locator(".card[data-kind=sale]");
+		await expect(saleCards.first()).toBeVisible({ timeout: 60_000 });
+		await beat(page, 1800);
+		await revealWidget(page);
+		await beat(page, 1400);
+
+		// Drill into the first sale: the app calls search_products itself.
+		await cursorClick(page, saleCards.first());
+		const productCards = app.locator(".card[data-kind=product]");
+		await expect(productCards.first()).toBeVisible({ timeout: 60_000 });
+		await beat(page, 2400);
+
+		const priced = pricedProduct(app);
+		const product = (await priced.count()) > 0 ? priced : productCards.first();
+		await cursorClick(page, product.locator("button[data-add]"));
+		await expect(app.locator("#toast.show")).toBeVisible();
+		await beat(page, 2400);
+
+		await cursorClick(page, app.locator("#back"));
+		await expect(saleCards.first()).toBeVisible();
+		await beat(page, 2200);
+	});
+
+	await test.step("part 2 — entrée par les produits", async () => {
+		await titleCard(page, {
+			index: 2,
+			total: 2,
+			eyebrow: "// SHOPPING ASSISTANT",
+			title: "Entrée par les produits",
+			sub: "Décrivez le cadeau idéal : une recherche dans tout le catalogue, la fiche produit, et le panier.",
+		});
+		await cursorClick(page, page.getByRole("button", { name: "New thread" }));
+		await page.waitForURL(/\/agents\/[0-9a-f-]{36}\/chat$/, {
+			timeout: 30_000,
+		});
+		await beat(page, 1200);
+		await ensureModel(page);
+		await ensureEffort(page);
+		await ask(page, GIFT_PROMPT);
+
+		const widgets = await page.locator('iframe[src*="sandbox.html"]').count();
+		if (SINGLE_SEARCH && widgets !== 1) {
+			throw new Error(
+				`gift prompt rendered ${widgets} carousels (expected exactly one search) — retrying the take`,
+			);
+		}
+
+		const app = appFrame(page);
+		const productCards = app.locator(".card[data-kind=product]");
+		await expect(productCards.first()).toBeVisible({ timeout: 60_000 });
+		await beat(page, 1800);
+		await revealWidget(page);
+		await beat(page, 1600);
+
+		// Open the product sheet (the app calls get_product itself).
+		const priced = pricedProduct(app);
+		const product = (await priced.count()) > 0 ? priced : productCards.first();
+		await cursorClick(page, product.locator("button.soft[data-drill]"));
+		const addToCart = app.locator("#add");
+		await expect(addToCart).toBeVisible({ timeout: 60_000 });
+		await beat(page, 2400);
+
+		const nextImage = app.locator(".gallery .nav.next");
+		if (await nextImage.isVisible().catch(() => false)) {
+			await cursorClick(page, nextImage);
+			await beat(page, 1400);
+		}
+
+		await cursorClick(page, addToCart);
+		await expect(app.locator("#toast.show")).toBeVisible();
+		await beat(page, 2800);
+	});
+
+	await test.step("close card", async () => {
+		await brandCard(page, {
+			tagline: TAGLINE,
+			footer: "github.com/keurcien/auxilia",
+			holdMs: 2800,
+			leaveUp: true,
+		});
+	});
+
+	await test.step("save the recording", async () => {
+		const video = page.video();
+		await page.close();
+		if (video) {
+			fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+			await video.saveAs(OUTPUT);
+			console.log(`\nShopping demo video saved to ${OUTPUT}`);
+			console.log(
+				"Convert to mp4 with: ffmpeg -ss 0.3 -i demo-output/auxilia-shopping-demo.webm -c:v libx264 -pix_fmt yuv420p demo-output/auxilia-shopping-demo.mp4",
+			);
+		}
+	});
+});

--- a/web/tests/utils/demo.ts
+++ b/web/tests/utils/demo.ts
@@ -240,8 +240,9 @@ async function playCard(page: Page, inner: CardInner): Promise<void> {
 const pad2 = (n: number) => String(n).padStart(2, "0");
 
 export type TitleCardOpts = {
-	index: number;
-	total: number;
+	/** Chapter counter (`01 / 03`); omit both for an un-numbered card. */
+	index?: number;
+	total?: number;
 	eyebrow: string;
 	title: string;
 	sub: string;
@@ -256,10 +257,14 @@ export async function titleCard(page: Page, opts: TitleCardOpts): Promise<void> 
 				`<span class="dc-word" style="animation-delay:${140 + i * 90}ms">${w}</span>`,
 		)
 		.join(" ");
+	const counter =
+		opts.index !== undefined && opts.total !== undefined
+			? `<span style="color:#8a9aa0;font-weight:500;">${pad2(opts.index)} / ${pad2(opts.total)}</span>`
+			: "";
 	const html = `
 		<div class="dc-fade" style="animation-delay:80ms;display:flex;align-items:baseline;gap:16px;margin-bottom:28px;font-family:var(--font-ibm-plex-mono),ui-monospace,monospace;font-size:13px;font-weight:600;letter-spacing:0.16em;">
 			<span style="color:#16606e;">${opts.eyebrow}</span>
-			<span style="color:#8a9aa0;font-weight:500;">${pad2(opts.index)} / ${pad2(opts.total)}</span>
+			${counter}
 		</div>
 		<h1 style="margin:0;font-family:var(--font-space-grotesk),sans-serif;font-weight:700;font-size:64px;line-height:1.06;letter-spacing:-0.03em;color:#101820;">${words}</h1>
 		<div class="dc-bar" style="height:3px;background:#16606e;border-radius:2px;margin-top:28px;"></div>


### PR DESCRIPTION
## Summary

- New scripted demo video, `npm run demo:video:shopping` (`web/tests/demo/shopping.demo.spec.ts`), recording the **Shopping assistant** agent bound to the Choose Shop MCP server — an MCP App whose tool results render as an interactive carousel in a sandboxed iframe inside the conversation.
- Storyline: the product demo's intro card → a "Shopping assistant" title slide, opening directly on the agent's starter screen (cookie-authenticated, no sign-in or agent picking on camera) → **Entrée par les ventes** (sales carousel, drill into the first sale, add a product to the demo cart, back) → **Entrée par les produits** (gift request, one product search, product sheet, gallery, add to cart) → close card.
- The carousel lives two iframes deep (`/sandbox.html` → `blob:` app page); the spec drives it with frame locators so the fake cursor and the clicks are real.
- Model + reasoning effort are picked in the composer on camera (defaults: DeepSeek V4 Pro, thinking **Off** — the configuration that most often runs a single search for the gift prompt). An empty carousel, or a gift take that rendered more than one carousel, fails the test so Playwright re-records from scratch (`DEMO_RETRIES`, default 4).
- UI steps run at `DEMO_SPEED=4` by default (title cards keep their own pace).
- `titleCard` in `tests/utils/demo.ts`: the `01 / 02` counter is now optional.
- README section 2b documents prerequisites and every `DEMO_*` override (`DEMO_SHOPPING_AGENT`, `DEMO_MODEL_NAME`, `DEMO_REASONING_EFFORT`, `DEMO_SALES_PROMPT`, `DEMO_GIFT_PROMPT`, `DEMO_SINGLE_SEARCH`, `DEMO_RETRIES`).

Not seeded by `demo:seed`: expects a "Shopping assistant" agent bound to `…/shop/mcp` with its three tools allowed, and the demo admin account. Recordings go to the gitignored `web/demo-output/`.

## Test plan

- [x] `npm run demo:video:shopping` against a live stack (backend + `npm run demo:web` on :3100) — passes, 46 s take, verified frame by frame
- [x] `eslint -c eslint.precommit.mjs` and `tsc --noEmit` clean on the touched files
- [x] `npm run demo:video` (the existing walkthrough) untouched apart from the optional counter type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scripted demo video, `npm run demo:video:shopping`, recording the Shopping assistant agent bound to the Choose Shop MCP server.

**New Features**
- The spec records an intro card, a title slide, two French storyline parts (sales carousel drill-down and a product search), and a close card.
- The Choose Shop carousel renders as an interactive MCP App two iframes deep; the spec drives it with frame locators so the cursor and clicks are real.
- Model and reasoning effort are picked in the composer on camera (DeepSeek V4 Pro with thinking Off by default).
- The test fails and re-records from scratch when a gift take renders more than one carousel or none (`DEMO_RETRIES`, default 4).
- `titleCard`'s chapter counter is now optional.
- The README documents prerequisites and all `DEMO_*` overrides.
- Running the demo expects an agent named "Shopping assistant" bound to the Choose Shop server with all three tools allowed, plus the demo admin account.

<sup>Written for commit af0172c576ab3a2a64fb3772c27ee5c609321cf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/keurcien/auxilia/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

