### PR TITLE
feat(threads)!: bound tool results in snapshots, cap MCP artifacts, load outputs on demand

### DIFF
--- a/backend/app/agents/protocol/messages.py
+++ b/backend/app/agents/protocol/messages.py
@@ -58,6 +58,42 @@ def serialize_message(msg: Any) -> dict[str, Any]:
     return d
 
 
+# A tool result in a hydration snapshot is cut at this many characters. The
+# whole result stays one request away (`GET /threads/{id}/messages/{id}`), so
+# a thread's snapshot costs O(messages), not O(bytes the tools ever returned).
+TOOL_PREVIEW_CHARS = 16_000
+
+# The one artifact the client reads whole: an MCP-app tool's, whose
+# `structuredContent` feeds the app iframe. Every other artifact is a copy of
+# `content` (`structured_content`), i.e. dead weight on the wire.
+_APP_ARTIFACT_KEY = "mcp_app_resource_uri"
+
+
+def serialize_message_preview(
+    msg: Any, *, limit: int = TOOL_PREVIEW_CHARS
+) -> dict[str, Any]:
+    """`serialize_message`, bounded for a thread snapshot.
+
+    Tool messages only: `content` longer than `limit` characters is replaced
+    by its first `limit` characters (as text), with the full length recorded in
+    `additional_kwargs["truncated"]["chars"]` so the client can offer the rest;
+    a non-app `artifact` is dropped. Every other message is serialized whole.
+    """
+    d = serialize_message(msg)
+    if d.get("type") != "tool":
+        return d
+    artifact = d.get("artifact")
+    if isinstance(artifact, dict) and not artifact.get(_APP_ARTIFACT_KEY):
+        del d["artifact"]
+    text = text_of(d.get("content"))
+    if len(text) > limit:
+        d["content"] = text[:limit]
+        kwargs = dict(d.get("additional_kwargs") or {})
+        kwargs["truncated"] = {"chars": len(text)}
+        d["additional_kwargs"] = kwargs
+    return d
+
+
 def json_default(obj: Any) -> Any:
     """`json.dumps(default=…)` for anything a LangGraph run can put in an
     event: messages, UUIDs, dataclasses (`Interrupt`), pydantic models, the

--- a/backend/app/agents/protocol/messages.py
+++ b/backend/app/agents/protocol/messages.py
@@ -83,7 +83,9 @@ def serialize_message_preview(
     if d.get("type") != "tool":
         return d
     artifact = d.get("artifact")
-    if isinstance(artifact, dict) and not artifact.get(_APP_ARTIFACT_KEY):
+    if artifact is not None and (
+        not isinstance(artifact, dict) or not artifact.get(_APP_ARTIFACT_KEY)
+    ):
         del d["artifact"]
     text = text_of(d.get("content"))
     if len(text) > limit:

--- a/backend/app/agents/protocol/repository.py
+++ b/backend/app/agents/protocol/repository.py
@@ -1,0 +1,34 @@
+"""SQL over the LangGraph checkpoint tables the protocol facade reads directly.
+
+langgraph's Postgres saver keeps, next to every checkpoint, the writes each
+task produced (`checkpoint_writes`): one row per task per channel, holding
+just that task's output — one tool result, one model turn. A checkpoint's
+channel value, by contrast, is the whole conversation. So a single message is
+cheapest to recover from the writes: scan the `messages`-channel rows and stop
+at the first that carries the id, never materialising the thread.
+"""
+
+from collections.abc import AsyncIterator
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class CheckpointWriteRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def iter_message_writes(
+        self, thread_id: str
+    ) -> AsyncIterator[tuple[str, bytes]]:
+        """`(type, blob)` of every `messages`-channel write of the thread, in
+        every namespace, newest checkpoint first — streamed, so a caller that
+        stops early never holds more than one write."""
+        stmt = text(
+            "SELECT type, blob FROM checkpoint_writes "
+            "WHERE thread_id = :thread_id AND channel = 'messages' "
+            "ORDER BY checkpoint_id DESC, idx ASC"
+        )
+        result = await self.db.stream(stmt, {"thread_id": thread_id})
+        async for row in result:
+            yield row.type, bytes(row.blob)

--- a/backend/app/agents/protocol/router.py
+++ b/backend/app/agents/protocol/router.py
@@ -106,3 +106,16 @@ async def get_state(
     client hydration. Served raw (never camelized) — the protocol client
     fetches it outside the axios interceptor."""
     return await service.thread_state(thread_id)
+
+
+@router.get("/messages/{message_id}")
+async def get_message(
+    thread_id: str,
+    message_id: str,
+    _: ThreadResponse = Depends(authorize_thread),
+    service: ProtocolService = Depends(get_protocol_service),
+) -> dict:
+    """One message, whole. `/state` and `/history` ship tool results cut at
+    `TOOL_PREVIEW_CHARS`; the client fetches the rest from here on demand.
+    Served raw, like `/state`."""
+    return await service.message(thread_id, message_id)

--- a/backend/app/agents/protocol/router.py
+++ b/backend/app/agents/protocol/router.py
@@ -4,6 +4,11 @@ Default `@langchain/langgraph-sdk` `HttpAgentServerAdapter` paths are served
 as-is — `/threads/{id}/commands`, `/threads/{id}/stream/events`,
 `/threads/{id}/state` — so the frontend needs no `paths` override, only the
 `/api/backend` proxy prefix in `apiUrl`.
+
+Authorization: the read endpoints (`/state`, `/history`, `/messages/{id}`,
+`/stream/events`) accept the thread's owner *and* an admin of its agent
+(`authorize_thread_read`) — the same audience `GET /threads/{id}` serves, so an
+admin's read-only view hydrates. `/commands` stays owner-only.
 """
 
 from fastapi import APIRouter, Depends
@@ -18,6 +23,7 @@ from app.auth.dependencies import get_current_user  # noqa: F401 — via authori
 from app.database import get_db
 from app.mcp.client.responses import oauth_required_response
 from app.redis_client import get_redis
+from app.threads.dependencies import authorize_thread_read
 from app.threads.schemas import ThreadResponse
 
 
@@ -66,7 +72,7 @@ async def post_command(
 async def stream_events(
     thread_id: str,
     body: EventStreamBody,
-    _: ThreadResponse = Depends(authorize_thread),
+    _: ThreadResponse = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
     db: AsyncSession = Depends(get_db),  # dependency-cached: same session auth used
 ):
@@ -84,7 +90,7 @@ async def stream_events(
 async def get_history(
     thread_id: str,
     body: HistoryBody,
-    _: ThreadResponse = Depends(authorize_thread),
+    _: ThreadResponse = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
 ) -> list[dict]:
     """Checkpoint history (LangGraph `client.threads.getHistory` shape).
@@ -99,7 +105,7 @@ async def get_history(
 @router.get("/state")
 async def get_state(
     thread_id: str,
-    _: ThreadResponse = Depends(authorize_thread),
+    _: ThreadResponse = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
 ) -> dict:
     """LangGraph-shaped state snapshot (`values` / `next` / `tasks`) for
@@ -112,7 +118,7 @@ async def get_state(
 async def get_message(
     thread_id: str,
     message_id: str,
-    _: ThreadResponse = Depends(authorize_thread),
+    _: ThreadResponse = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
 ) -> dict:
     """One message, whole. `/state` and `/history` ship tool results cut at

--- a/backend/app/agents/protocol/router.py
+++ b/backend/app/agents/protocol/router.py
@@ -24,6 +24,7 @@ from app.database import get_db
 from app.mcp.client.responses import oauth_required_response
 from app.redis_client import get_redis
 from app.threads.dependencies import authorize_thread_read
+from app.threads.models import ThreadDB
 from app.threads.schemas import ThreadResponse
 
 
@@ -72,7 +73,7 @@ async def post_command(
 async def stream_events(
     thread_id: str,
     body: EventStreamBody,
-    _: ThreadResponse = Depends(authorize_thread_read),
+    _: ThreadDB = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
     db: AsyncSession = Depends(get_db),  # dependency-cached: same session auth used
 ):
@@ -90,7 +91,7 @@ async def stream_events(
 async def get_history(
     thread_id: str,
     body: HistoryBody,
-    _: ThreadResponse = Depends(authorize_thread_read),
+    _: ThreadDB = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
 ) -> list[dict]:
     """Checkpoint history (LangGraph `client.threads.getHistory` shape).
@@ -105,7 +106,7 @@ async def get_history(
 @router.get("/state")
 async def get_state(
     thread_id: str,
-    _: ThreadResponse = Depends(authorize_thread_read),
+    _: ThreadDB = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
 ) -> dict:
     """LangGraph-shaped state snapshot (`values` / `next` / `tasks`) for
@@ -118,7 +119,7 @@ async def get_state(
 async def get_message(
     thread_id: str,
     message_id: str,
-    _: ThreadResponse = Depends(authorize_thread_read),
+    _: ThreadDB = Depends(authorize_thread_read),
     service: ProtocolService = Depends(get_protocol_service),
 ) -> dict:
     """One message, whole. `/state` and `/history` ship tool results cut at

--- a/backend/app/agents/protocol/service.py
+++ b/backend/app/agents/protocol/service.py
@@ -23,22 +23,25 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import BaseMessage, ToolMessage
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from langgraph.types import Overwrite
 from redis.asyncio import Redis
 
 from app.agents.checkpoints import get_checkpoint_state
 from app.agents.hitl import InterruptScope, load_interrupt_scopes
 from app.agents.protocol.events import terminal_lifecycle
 from app.agents.protocol.filter import StreamFilter
-from app.agents.protocol.messages import serialize_message
+from app.agents.protocol.messages import serialize_message, serialize_message_preview
+from app.agents.protocol.repository import CheckpointWriteRepository
 from app.agents.protocol.schemas import EventStreamBody, ProtocolCommand
 from app.agents.protocol.wire import decode_event, frame, seq_for_entry
 from app.agents.runs.events import RunEventStream
 from app.agents.runs.models import RunDB
 from app.agents.runs.service import RunService
 from app.agents.runs.state import is_terminal
-from app.database import get_checkpointer
-from app.exceptions import DomainValidationError
+from app.database import AsyncSessionLocal, get_checkpointer
+from app.exceptions import DomainValidationError, NotFoundError
 from app.redis_client import get_redis
 
 
@@ -267,7 +270,7 @@ class ProtocolService:
         async with get_checkpointer() as checkpointer:
             state = await get_checkpoint_state(checkpointer, thread_id)
             values: dict[str, Any] = {
-                "messages": [serialize_message(m) for m in state.messages]
+                "messages": [serialize_message_preview(m) for m in state.messages]
             }
             if state.todos:
                 values["todos"] = state.todos
@@ -321,7 +324,9 @@ class ProtocolService:
             return []
         return [
             {
-                "values": {"messages": [serialize_message(m) for m in messages]},
+                "values": {
+                    "messages": [serialize_message_preview(m) for m in messages]
+                },
                 "next": [],
                 "tasks": [],
                 "metadata": {},
@@ -330,6 +335,32 @@ class ProtocolService:
                 "parent_checkpoint": None,
             }
         ]
+
+    # --- single message ---------------------------------------------------------
+
+    async def message(self, thread_id: str, message_id: str) -> dict:
+        """One message of the thread, whole — the other half of the bounded
+        snapshot (`serialize_message_preview`).
+
+        Read from `checkpoint_writes`, where each row is one task's output, so
+        the cost is the writes scanned until the id matches (newest first),
+        never the materialised conversation. The write scan covers every
+        namespace, so a subagent's tool result resolves without knowing its
+        `tools:<task id>`. Threads whose writes are gone fall back to the
+        root state.
+        """
+        async with AsyncSessionLocal() as db:
+            writes = CheckpointWriteRepository(db).iter_message_writes(thread_id)
+            async for type_tag, blob in writes:
+                for m in _messages_in_write(_SERDE.loads_typed((type_tag, blob))):
+                    if getattr(m, "id", None) == message_id:
+                        return serialize_message(m)
+        async with get_checkpointer() as checkpointer:
+            state = await get_checkpoint_state(checkpointer, thread_id)
+        for m in state.messages:
+            if getattr(m, "id", None) == message_id:
+                return serialize_message(m)
+        raise NotFoundError("Message not found")
 
 
 _TOOLS_NS_PREFIX = "tools:"
@@ -353,6 +384,21 @@ def _hydration_namespace(scope: InterruptScope) -> list[str]:
         if isinstance(call_id, str) and call_id:
             return [f"{_TOOLS_NS_PREFIX}{call_id}"]
     return scope.namespace_path
+
+
+_SERDE = JsonPlusSerializer()
+
+
+def _messages_in_write(value: Any) -> list:
+    """The messages a `messages`-channel write carries: a list, one message,
+    or either wrapped in deepagents' `Overwrite` reducer."""
+    if isinstance(value, Overwrite):
+        value = value.value
+    if isinstance(value, BaseMessage):
+        return [value]
+    if isinstance(value, list):
+        return [m for m in value if isinstance(m, BaseMessage)]
+    return []
 
 
 _NS_SEP = "|"

--- a/backend/app/agents/protocol/service.py
+++ b/backend/app/agents/protocol/service.py
@@ -346,8 +346,13 @@ class ProtocolService:
         the cost is the writes scanned until the id matches (newest first),
         never the materialised conversation. The write scan covers every
         namespace, so a subagent's tool result resolves without knowing its
-        `tools:<task id>`. Threads whose writes are gone fall back to the
-        root state.
+        `tools:<task id>`.
+
+        Fallback, for threads whose writes are gone (pruned, or written before
+        the writes table existed): the materialised *root* state. A subagent
+        message without its writes is therefore a 404 — reading every
+        namespace's state to find one message would cost what the writes scan
+        exists to avoid, and the writes outlive the log in practice.
         """
         async with AsyncSessionLocal() as db:
             writes = CheckpointWriteRepository(db).iter_message_writes(thread_id)

--- a/backend/app/agents/toolset.py
+++ b/backend/app/agents/toolset.py
@@ -16,7 +16,7 @@ from app.agents.models import AgentMCPServerBase
 from app.mcp.client.connectivity import CredentialCache
 from app.mcp.client.exceptions import as_oauth_required
 from app.mcp.client.factory import MCPClientConfigFactory
-from app.mcp.client.tools import inject_ui_metadata_into_tool
+from app.mcp.client.tools import bound_tool_artifact
 from app.mcp.servers.models import MCPServerDB
 from app.mcp.servers.repository import MCPServerRepository
 
@@ -561,8 +561,7 @@ class Toolset:
                         prepared.server_id_by_name,
                     )
                     toolset = cls(tools=agent_tools)
-                    if prepared.apply_ui:
-                        toolset.apply_ui_metadata()
+                    toolset.bound_artifacts(ui=prepared.apply_ui)
                     yield toolset
                 finally:
                     await supervisor.close()
@@ -577,12 +576,12 @@ class Toolset:
                 raise oauth from exc
             raise
 
-    def apply_ui_metadata(self) -> None:
-        """Inject UI metadata into tool coroutines.
-
-        Call for parent agent toolsets only. Subagents don't stream UI metadata
-        to the frontend, so skip this for subagent toolsets.
+    def bound_artifacts(self, *, ui: bool) -> None:
+        """Apply the per-tool artifact policy (`app/mcp/client/tools.py`) to
+        every tool: app tools keep and stamp their structured content, the rest
+        lose it. `ui` is True for the parent agent only — subagents never
+        stream widgets to the frontend, so their app tools are bounded like any
+        other.
         """
         for t in self.tools:
-            if t.ui_metadata:
-                inject_ui_metadata_into_tool(t.tool, t.ui_metadata)
+            bound_tool_artifact(t.tool, t.ui_metadata if ui else None)

--- a/backend/app/mcp/client/tools.py
+++ b/backend/app/mcp/client/tools.py
@@ -1,43 +1,65 @@
+"""Per-tool policy for MCP results, at the seam where they become ToolMessages.
+
+langchain-mcp-adapters wraps every MCP tool with
+``response_format="content_and_artifact"``: the text/image blocks become the
+model-visible ``content`` and the server's ``structuredContent`` becomes
+``ToolMessage.artifact`` — whole, uncapped. The model never sees the artifact,
+but the checkpointer, the run event log, Langfuse and the thread snapshot all
+serialise it, and nothing that manages context size (deepagents' eviction,
+summarisation) looks at it, because it costs no tokens. A Google Drive
+``download_file_content`` puts the file's base64 there: 8 MB per call that rode
+along in every checkpoint of the thread — 96% of one production thread's state.
+
+Two policies, chosen per tool when the toolset is built:
+
+- **MCP-app tools** (a ``resourceUri`` on the tool definition): the widget
+  iframe consumes ``structuredContent``, so the artifact is kept whole and
+  stamped with the app resource URI and server id — how the client recognises
+  an app result on hydration, since LangGraph persists the ToolMessage as is.
+- **Every other tool**: ``structured_content`` is dropped. No client code reads
+  it and the model never had it.
+"""
+
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import Tool
 
 
-def inject_ui_metadata_into_tool(tool: Tool, ui_metadata: dict) -> None:
-    """Wrap a tool's coroutine in-place to persist MCP app UI metadata in ToolMessage artifacts.
+_STRUCTURED_CONTENT_KEYS = ("structured_content", "structuredContent")
 
-    When a tool with a UI widget executes, this injects mcp_app_resource_uri and
-    mcp_server_id into the returned ToolMessage.artifact dict. Because LangGraph
-    persists ToolMessage objects in its checkpoint, this data is available when
-    loading thread history, allowing widgets to be re-rendered on page refresh.
-    """
-    resource_uri = ui_metadata.get("mcp_app_resource_uri")
-    server_id = ui_metadata.get("mcp_server_id")
-    if not resource_uri or not server_id:
-        return
+
+def bound_tool_artifact(tool: Tool, ui_metadata: dict | None) -> None:
+    """Wrap a tool's coroutine in place so every result's artifact follows the
+    policy above: stamped and kept whole for an app tool (`ui_metadata` carries
+    `mcp_app_resource_uri` + `mcp_server_id`), stripped of structured content
+    for any other."""
+    resource_uri = (ui_metadata or {}).get("mcp_app_resource_uri")
+    server_id = (ui_metadata or {}).get("mcp_server_id")
+    is_app_tool = bool(resource_uri and server_id)
 
     original_coroutine = tool.coroutine
+    if original_coroutine is None:
+        return
 
-    async def augmented_coroutine(*args, **kwargs):
+    def rewrite(artifact):
+        if is_app_tool:
+            stamped = dict(artifact) if isinstance(artifact, dict) else {}
+            stamped["mcp_app_resource_uri"] = resource_uri
+            stamped["mcp_server_id"] = server_id
+            return stamped
+        if isinstance(artifact, dict):
+            trimmed = {
+                k: v for k, v in artifact.items() if k not in _STRUCTURED_CONTENT_KEYS
+            }
+            return trimmed or None
+        return artifact
+
+    async def bounded_coroutine(*args, **kwargs):
         result = await original_coroutine(*args, **kwargs)
-        # langchain-mcp-adapters uses response_format="content_and_artifact" so the
-        # coroutine returns a (content, artifact) tuple. BaseTool.arun() then builds
-        # the ToolMessage from this tuple — meaning we must inject metadata HERE,
-        # before BaseTool.arun() assembles the ToolMessage.
         if isinstance(result, tuple) and len(result) == 2:
             content, artifact = result
-            if isinstance(artifact, dict):
-                artifact["mcp_app_resource_uri"] = resource_uri
-                artifact["mcp_server_id"] = server_id
-            else:
-                artifact = {
-                    "mcp_app_resource_uri": resource_uri,
-                    "mcp_server_id": server_id,
-                }
-            result = (content, artifact)
-        elif isinstance(result, ToolMessage) and isinstance(result.artifact, dict):
-            # Fallback for tools that return ToolMessage directly
-            result.artifact["mcp_app_resource_uri"] = resource_uri
-            result.artifact["mcp_server_id"] = server_id
+            return content, rewrite(artifact)
+        if isinstance(result, ToolMessage):
+            result.artifact = rewrite(result.artifact)
         return result
 
-    tool.coroutine = augmented_coroutine
+    tool.coroutine = bounded_coroutine

--- a/backend/app/threads/dependencies.py
+++ b/backend/app/threads/dependencies.py
@@ -14,13 +14,14 @@ from fastapi import Depends
 from app.agents.core.service import AgentService, get_agent_service
 from app.agents.models import EffectivePermission
 from app.auth.dependencies import get_current_user
-from app.threads.schemas import ThreadResponse, ViewerRole
+from app.threads.models import ThreadDB
+from app.threads.schemas import ViewerRole
 from app.threads.service import ThreadService, get_thread_service
 from app.users.models import UserDB
 
 
 async def resolve_viewer_role(
-    thread: ThreadResponse,
+    thread: ThreadDB,
     current_user: UserDB,
     agent_service: AgentService,
 ) -> ViewerRole | None:
@@ -47,7 +48,7 @@ async def authorize_thread_read(
     current_user: UserDB = Depends(get_current_user),
     service: ThreadService = Depends(get_thread_service),
     agent_service: AgentService = Depends(get_agent_service),
-) -> ThreadResponse:
+) -> ThreadDB:
     """Load the thread for a read: its owner, or an admin of its agent
     (404 if missing, 403 otherwise)."""
     thread = await service.get(thread_id)

--- a/backend/app/threads/dependencies.py
+++ b/backend/app/threads/dependencies.py
@@ -1,0 +1,55 @@
+"""Thread-level read authorization, shared by the thread and protocol routers.
+
+Two audiences can open a thread: its owner, and an admin of its agent
+(workspace admin, or agent owner/admin), who gets a read-only view. The thread
+router resolved that for `GET /threads/{id}`; the protocol endpoints the chat
+page hydrates from (`/state`, `/history`, `/messages/{id}`, `/stream/events`)
+must accept the same audience, or an admin sees the header and an empty
+conversation. Commands stay owner-only (`authorize_thread` in
+`app/agents/runs/router.py`).
+"""
+
+from fastapi import Depends
+
+from app.agents.core.service import AgentService, get_agent_service
+from app.agents.models import EffectivePermission
+from app.auth.dependencies import get_current_user
+from app.threads.schemas import ThreadResponse, ViewerRole
+from app.threads.service import ThreadService, get_thread_service
+from app.users.models import UserDB
+
+
+async def resolve_viewer_role(
+    thread: ThreadResponse,
+    current_user: UserDB,
+    agent_service: AgentService,
+) -> ViewerRole | None:
+    """Return the viewer's role on this thread, or raise 403.
+
+    - Owner of the thread → ``None`` (full access).
+    - Workspace admin or per-agent owner/admin → ``"admin"`` (read-only).
+    - Anyone else → ``PermissionDeniedError``.
+    """
+    if thread.user_id == current_user.id:
+        return None
+    await agent_service.require_permission(
+        thread.agent_id,
+        at_least=EffectivePermission.admin,
+        action="view this thread",
+        user_id=current_user.id,
+        user_role=current_user.role,
+    )
+    return "admin"
+
+
+async def authorize_thread_read(
+    thread_id: str,
+    current_user: UserDB = Depends(get_current_user),
+    service: ThreadService = Depends(get_thread_service),
+    agent_service: AgentService = Depends(get_agent_service),
+) -> ThreadResponse:
+    """Load the thread for a read: its owner, or an admin of its agent
+    (404 if missing, 403 otherwise)."""
+    thread = await service.get(thread_id)
+    await resolve_viewer_role(thread, current_user, agent_service)
+    return thread

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -3,14 +3,10 @@ import logging
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agents.checkpoints import get_checkpoint_state
 from app.agents.core.service import AgentService, get_agent_service
-from app.agents.hitl import pending_interrupt
 from app.agents.models import EffectivePermission
-from app.agents.protocol.messages import serialize_message
-from app.agents.structured_output import is_structured_output_artifact
 from app.auth.dependencies import detect_auth_method, get_current_user
-from app.database import get_checkpointer, get_db
+from app.database import get_db
 from app.exceptions import PermissionDeniedError
 from app.pagination import Page, PageParams
 from app.threads.models import ThreadDB, ThreadSource
@@ -54,46 +50,18 @@ async def read_thread(
     service: ThreadService = Depends(get_thread_service),
     agent_service: AgentService = Depends(get_agent_service),
 ) -> dict:
+    """Thread metadata (`thread`, with its agent) and the caller's viewer role.
+
+    The conversation is not here. The client hydrates it from the protocol
+    snapshot (`GET /threads/{id}/state`), and this endpoint used to ship the
+    same messages a second time — for a heavy thread, 16 MB twice per page
+    load — so it no longer opens the checkpoint at all. Interrupt state comes
+    from the snapshot's `next` / `tasks`.
+    """
     thread = await service.get(thread_id)
     viewer_role = await _resolve_viewer_role(thread, current_user, agent_service)
     thread_read = await service.get_with_agent(thread_id)
-
-    async with get_checkpointer() as checkpointer:
-        state = await get_checkpoint_state(checkpointer, thread_id)
-
-    if state.saved is None:
-        return {
-            "values": {"messages": []},
-            "thread": thread_read,
-            "interrupted": False,
-            "viewer_role": viewer_role,
-        }
-
-    # Formatting-turn artifacts (raw-JSON message or synthetic tool-call
-    # pair) are chat-history noise: the parsed object is exposed under
-    # values["structured_response"] instead.
-    lc_messages = [m for m in state.messages if not is_structured_output_artifact(m)]
-    values: dict = {
-        "messages": [serialize_message(m) for m in lc_messages],
-    }
-    if state.todos:
-        values["todos"] = state.todos
-    if state.structured_response is not None:
-        values["structured_response"] = state.structured_response
-
-    interrupt = pending_interrupt(state)
-
-    return {
-        "values": values,
-        "thread": thread_read,
-        "interrupted": interrupt is not None,
-        "interrupt_value": interrupt.value if interrupt else None,
-        # The stable id of the pending interrupt (recomputed from the
-        # checkpoint). Clients echo it back when resuming so a stale
-        # approval is a 409, not a resume of whatever pends now.
-        "interrupt_id": interrupt.id if interrupt else None,
-        "viewer_role": viewer_role,
-    }
+    return {"thread": thread_read, "viewer_role": viewer_role}
 
 
 @router.get("/")

--- a/backend/app/threads/router.py
+++ b/backend/app/threads/router.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter, Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents.core.service import AgentService, get_agent_service
-from app.agents.models import EffectivePermission
 from app.auth.dependencies import detect_auth_method, get_current_user
 from app.database import get_db
 from app.exceptions import PermissionDeniedError
 from app.pagination import Page, PageParams
-from app.threads.models import ThreadDB, ThreadSource
-from app.threads.schemas import ThreadCreate, ThreadPatch, ThreadResponse, ViewerRole
+from app.threads.dependencies import resolve_viewer_role
+from app.threads.models import ThreadSource
+from app.threads.schemas import ThreadCreate, ThreadPatch, ThreadResponse
 from app.threads.service import ThreadService, get_thread_service
 from app.users.models import UserDB
 
@@ -18,29 +18,6 @@ from app.users.models import UserDB
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/threads", tags=["threads"])
-
-
-async def _resolve_viewer_role(
-    thread: ThreadDB,
-    current_user: UserDB,
-    agent_service: AgentService,
-) -> ViewerRole | None:
-    """Return the viewer's role on this thread, or raise 403.
-
-    - Owner of the thread → ``None`` (full access).
-    - Workspace admin or per-agent owner/admin → ``"admin"`` (read-only).
-    - Anyone else → ``PermissionDeniedError``.
-    """
-    if thread.user_id == current_user.id:
-        return None
-    await agent_service.require_permission(
-        thread.agent_id,
-        at_least=EffectivePermission.admin,
-        action="view this thread",
-        user_id=current_user.id,
-        user_role=current_user.role,
-    )
-    return "admin"
 
 
 @router.get("/{thread_id}")
@@ -59,7 +36,7 @@ async def read_thread(
     from the snapshot's `next` / `tasks`.
     """
     thread = await service.get(thread_id)
-    viewer_role = await _resolve_viewer_role(thread, current_user, agent_service)
+    viewer_role = await resolve_viewer_role(thread, current_user, agent_service)
     thread_read = await service.get_with_agent(thread_id)
     return {"thread": thread_read, "viewer_role": viewer_role}
 

--- a/backend/tests/agents/protocol/test_messages.py
+++ b/backend/tests/agents/protocol/test_messages.py
@@ -1,0 +1,64 @@
+"""`serialize_message_preview` — the size-bounded projection a thread snapshot
+(`GET /state`, `/history`, `GET /threads/{id}`) ships instead of whole tool
+results. The whole result is served by `GET /threads/{id}/messages/{id}`."""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from app.agents.protocol.messages import (
+    TOOL_PREVIEW_CHARS,
+    serialize_message,
+    serialize_message_preview,
+)
+
+
+def _tool(content, artifact=None, **kw) -> ToolMessage:
+    return ToolMessage(
+        content=content, tool_call_id="call_1", id="m1", artifact=artifact, **kw
+    )
+
+
+def test_a_long_tool_result_is_cut_and_marked():
+    body = "x" * (TOOL_PREVIEW_CHARS + 500)
+    d = serialize_message_preview(_tool(body))
+    assert d["content"] == "x" * TOOL_PREVIEW_CHARS
+    assert d["additional_kwargs"]["truncated"] == {"chars": TOOL_PREVIEW_CHARS + 500}
+
+
+def test_a_short_tool_result_is_untouched():
+    msg = _tool("short", additional_kwargs={"keep": 1})
+    assert serialize_message_preview(msg) == serialize_message(msg)
+
+
+def test_block_content_is_previewed_as_text():
+    """MCP tools return `[{"type": "text", "text": …}]`; the preview is the
+    text itself (the client renders a string preview verbatim)."""
+    big = "y" * (TOOL_PREVIEW_CHARS * 2)
+    d = serialize_message_preview(_tool([{"type": "text", "text": big}]))
+    assert d["content"] == "y" * TOOL_PREVIEW_CHARS
+    assert d["additional_kwargs"]["truncated"]["chars"] == len(big)
+
+
+def test_the_limit_is_a_parameter():
+    d = serialize_message_preview(_tool("abcdef"), limit=3)
+    assert d["content"] == "abc"
+    assert d["additional_kwargs"]["truncated"] == {"chars": 6}
+
+
+def test_a_copy_artifact_is_dropped_but_an_app_artifact_is_kept():
+    copy = serialize_message_preview(
+        _tool("ok", artifact={"structured_content": {"a": 1}})
+    )
+    assert "artifact" not in copy
+    app_artifact = {
+        "mcp_app_resource_uri": "ui://app/main",
+        "mcp_server_id": "s1",
+        "structuredContent": {"rows": [1, 2, 3]},
+    }
+    app = serialize_message_preview(_tool("ok", artifact=app_artifact))
+    assert app["artifact"] == app_artifact
+
+
+def test_non_tool_messages_are_serialized_whole():
+    long = "z" * (TOOL_PREVIEW_CHARS * 3)
+    for msg in (HumanMessage(content=long, id="h"), AIMessage(content=long, id="a")):
+        assert serialize_message_preview(msg) == serialize_message(msg)

--- a/backend/tests/agents/protocol/test_messages.py
+++ b/backend/tests/agents/protocol/test_messages.py
@@ -58,6 +58,11 @@ def test_a_copy_artifact_is_dropped_but_an_app_artifact_is_kept():
     assert app["artifact"] == app_artifact
 
 
+def test_a_non_dict_artifact_is_dropped_too():
+    d = serialize_message_preview(_tool("ok", artifact=["raw", "blocks"]))
+    assert "artifact" not in d
+
+
 def test_non_tool_messages_are_serialized_whole():
     long = "z" * (TOOL_PREVIEW_CHARS * 3)
     for msg in (HumanMessage(content=long, id="h"), AIMessage(content=long, id="a")):

--- a/backend/tests/agents/protocol/test_router.py
+++ b/backend/tests/agents/protocol/test_router.py
@@ -1,0 +1,91 @@
+"""Protocol endpoint authorization: reads serve the owner and an admin of the
+agent (the audience `GET /threads/{id}` serves, so an admin's read-only view
+hydrates); commands stay owner-only."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.agents.protocol.router import get_protocol_service
+from app.exceptions import PermissionDeniedError
+from app.main import app
+from app.threads.models import ThreadDB
+
+
+_SNAPSHOT = {"values": {"messages": []}, "next": [], "tasks": []}
+
+
+class _Protocol:
+    async def thread_state(self, thread_id):
+        return _SNAPSHOT
+
+    async def message(self, thread_id, message_id):
+        return {"id": message_id, "type": "tool", "content": "whole"}
+
+
+@pytest.fixture
+def protocol_stub():
+    app.dependency_overrides[get_protocol_service] = lambda: _Protocol()
+    yield
+    app.dependency_overrides.pop(get_protocol_service, None)
+
+
+def _someone_elses_thread(mock_db) -> str:
+    thread_id = str(uuid4())
+    thread = ThreadDB(
+        id=thread_id,
+        user_id=uuid4(),
+        agent_id=uuid4(),
+        first_message_content="Someone else's thread",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = thread
+    mock_db.execute.return_value = result
+    return thread_id
+
+
+_GATE = "app.threads.dependencies.AgentService.require_permission"
+
+
+@pytest.mark.usefixtures("current_user", "protocol_stub")
+def test_an_agent_admin_can_read_another_users_state(client: TestClient, mock_db):
+    thread_id = _someone_elses_thread(mock_db)
+    with patch(_GATE, new_callable=AsyncMock) as gate:
+        response = client.get(f"/threads/{thread_id}/state")
+    assert response.status_code == 200
+    assert response.json() == _SNAPSHOT
+    gate.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("current_user", "protocol_stub")
+def test_an_agent_admin_can_read_a_message(client: TestClient, mock_db):
+    thread_id = _someone_elses_thread(mock_db)
+    with patch(_GATE, new_callable=AsyncMock):
+        response = client.get(f"/threads/{thread_id}/messages/m1")
+    assert response.status_code == 200
+    assert response.json()["content"] == "whole"
+
+
+@pytest.mark.usefixtures("current_user", "protocol_stub")
+def test_a_stranger_cannot_read_state(client: TestClient, mock_db):
+    thread_id = _someone_elses_thread(mock_db)
+    with patch(_GATE, new_callable=AsyncMock, side_effect=PermissionDeniedError("no")):
+        response = client.get(f"/threads/{thread_id}/state")
+    assert response.status_code == 403
+
+
+@pytest.mark.usefixtures("current_user", "protocol_stub")
+def test_commands_stay_owner_only_even_for_an_admin(client: TestClient, mock_db):
+    thread_id = _someone_elses_thread(mock_db)
+    with patch(_GATE, new_callable=AsyncMock) as gate:
+        response = client.post(
+            f"/threads/{thread_id}/commands",
+            json={"id": 1, "method": "run.start", "params": {}},
+        )
+    assert response.status_code == 403
+    gate.assert_not_awaited()

--- a/backend/tests/agents/protocol/test_service.py
+++ b/backend/tests/agents/protocol/test_service.py
@@ -10,7 +10,10 @@ import json
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from langgraph.types import Overwrite
 
+import app.agents.protocol.service as service_mod
 from app.agents.checkpoints import EMPTY_STATE
 from app.agents.protocol.schemas import ProtocolCommand
 from app.agents.protocol.service import ProtocolService
@@ -21,7 +24,7 @@ from app.agents.protocol.wire import (
     frame,
     seq_for_entry,
 )
-from app.exceptions import DomainValidationError
+from app.exceptions import DomainValidationError, NotFoundError
 from tests.agents.fake_checkpoints import checkpoint_state
 
 
@@ -401,3 +404,83 @@ async def test_thread_state_interrupt_carries_the_paused_agents_namespace(
     assert task["interrupts"] == [
         {"id": iid, "value": {"action_requests": []}, "namespace": expected_namespace}
     ]
+
+
+# ---------------------------------------------------------------------------
+# GET /threads/{id}/messages/{message_id} — one message, whole, off the writes
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _writes_repo(values):
+    """A `CheckpointWriteRepository` stand-in streaming real serde blobs of
+    `values` (what langgraph stores per task on the `messages` channel) and
+    counting how many the caller consumed."""
+    serde = JsonPlusSerializer()
+    consumed = []
+
+    class _Repo:
+        def __init__(self, db):
+            pass
+
+        async def iter_message_writes(self, thread_id):
+            for v in values:
+                consumed.append(v)
+                yield serde.dumps_typed(v)
+
+    return _Repo, consumed
+
+
+@pytest.mark.asyncio
+async def test_message_is_read_from_the_writes_without_the_state(monkeypatch):
+    big = ToolMessage(content="x" * 50_000, tool_call_id="c2", id="t2")
+    repo, consumed = _writes_repo(
+        [
+            [AIMessage(content="later", id="a3")],  # newest checkpoint first
+            [big],
+            Overwrite([HumanMessage(content="hi", id="h1")]),
+        ]
+    )
+    monkeypatch.setattr(service_mod, "CheckpointWriteRepository", repo)
+    monkeypatch.setattr(service_mod, "AsyncSessionLocal", lambda: _Session())
+
+    async def _never(*_a, **_k):
+        raise AssertionError("the state must not be materialised")
+
+    monkeypatch.setattr(service_mod, "get_checkpointer", _never)
+
+    d = await _service().message("t1", "t2")
+
+    assert d["id"] == "t2" and d["content"] == "x" * 50_000
+    assert len(consumed) == 2, "scanning stops at the first matching write"
+
+
+@pytest.mark.asyncio
+async def test_message_inside_an_overwrite_write_is_found(monkeypatch):
+    repo, _ = _writes_repo([Overwrite([HumanMessage(content="hi", id="h1")])])
+    monkeypatch.setattr(service_mod, "CheckpointWriteRepository", repo)
+    monkeypatch.setattr(service_mod, "AsyncSessionLocal", lambda: _Session())
+    assert (await _service().message("t1", "h1"))["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_message_falls_back_to_the_state_when_the_writes_are_gone(monkeypatch):
+    repo, _ = _writes_repo([])
+    monkeypatch.setattr(service_mod, "CheckpointWriteRepository", repo)
+    monkeypatch.setattr(service_mod, "AsyncSessionLocal", lambda: _Session())
+    checkpointer = _Checkpointer(
+        [ToolMessage(content="old", tool_call_id="c", id="t9")], {}
+    )
+    monkeypatch.setattr(
+        "app.agents.protocol.service.get_checkpointer", _checkpointer_cm(checkpointer)
+    )
+    assert (await _service().message("t1", "t9"))["content"] == "old"
+    with pytest.raises(NotFoundError):
+        await _service().message("t1", "nope")

--- a/backend/tests/agents/test_toolset.py
+++ b/backend/tests/agents/test_toolset.py
@@ -290,6 +290,41 @@ class TestBoundArtifacts:
         Toolset(tools=[AgentTool(tool=tool, ui_metadata=None)]).bound_artifacts(ui=True)
         assert tool.coroutine is not original_coro
 
+    @staticmethod
+    def _tool_returning(result) -> Tool:
+        async def coroutine(**kwargs):
+            return result
+
+        return Tool(name="t", description="", func=lambda: None, coroutine=coroutine)
+
+    @pytest.mark.asyncio
+    async def test_ui_true_stamps_app_tools_and_strips_plain_ones(self):
+        app_tool = self._tool_returning(("ok", {"structured_content": {"rows": [1]}}))
+        plain = self._tool_returning(("ok", {"structured_content": {"big": "x" * 10}}))
+        ui = {"mcp_app_resource_uri": "ui://app", "mcp_server_id": "s1"}
+        Toolset(
+            tools=[
+                AgentTool(tool=app_tool, ui_metadata=ui),
+                AgentTool(tool=plain, ui_metadata=None),
+            ]
+        ).bound_artifacts(ui=True)
+        _, app_artifact = await app_tool.coroutine()
+        _, plain_artifact = await plain.coroutine()
+        assert app_artifact == {"structured_content": {"rows": [1]}, **ui}
+        assert plain_artifact is None
+
+    @pytest.mark.asyncio
+    async def test_ui_false_strips_even_app_tools(self):
+        """Subagent toolsets never stream widgets, so their app tools are
+        bounded like any other tool."""
+        app_tool = self._tool_returning(("ok", {"structured_content": {"rows": [1]}}))
+        ui = {"mcp_app_resource_uri": "ui://app", "mcp_server_id": "s1"}
+        Toolset(tools=[AgentTool(tool=app_tool, ui_metadata=ui)]).bound_artifacts(
+            ui=False
+        )
+        _, artifact = await app_tool.coroutine()
+        assert artifact is None
+
     def test_idempotent(self):
         """Wrapping twice wraps twice, and does not crash."""
         tool = _make_tool("my_tool")

--- a/backend/tests/agents/test_toolset.py
+++ b/backend/tests/agents/test_toolset.py
@@ -1,4 +1,4 @@
-"""Unit tests for Toolset — name sanitization, tool filtering, UI metadata, apply_ui_metadata()."""
+"""Unit tests for Toolset — name sanitization, tool filtering, UI metadata, bound_artifacts()."""
 
 from uuid import uuid4
 
@@ -262,12 +262,16 @@ class TestToolsetProperties:
 
 
 # ---------------------------------------------------------------------------
-# apply_ui_metadata
+# bound_artifacts
 # ---------------------------------------------------------------------------
 
 
-class TestApplyUiMetadata:
-    def test_injects_metadata(self):
+class TestBoundArtifacts:
+    """Every tool is wrapped — app tools to stamp their UI metadata, the rest to
+    drop structured content (the runtime behaviour is covered in
+    tests/mcp/client/test_tools.py)."""
+
+    def test_wraps_app_tools(self):
         tool = _make_tool("my_tool")
         original_coro = tool.coroutine
         at = AgentTool(
@@ -277,20 +281,17 @@ class TestApplyUiMetadata:
                 "mcp_server_id": "s1",
             },
         )
-        ts = Toolset(tools=[at])
-        ts.apply_ui_metadata()
+        Toolset(tools=[at]).bound_artifacts(ui=True)
         assert tool.coroutine is not original_coro
 
-    def test_no_metadata_leaves_unwrapped(self):
+    def test_wraps_plain_tools_too(self):
         tool = _make_tool("my_tool")
         original_coro = tool.coroutine
-        at = AgentTool(tool=tool, ui_metadata=None)
-        ts = Toolset(tools=[at])
-        ts.apply_ui_metadata()
-        assert tool.coroutine is original_coro
+        Toolset(tools=[AgentTool(tool=tool, ui_metadata=None)]).bound_artifacts(ui=True)
+        assert tool.coroutine is not original_coro
 
     def test_idempotent(self):
-        """Calling apply_ui_metadata twice should wrap twice but not crash."""
+        """Wrapping twice wraps twice, and does not crash."""
         tool = _make_tool("my_tool")
         at = AgentTool(
             tool=tool,
@@ -300,9 +301,9 @@ class TestApplyUiMetadata:
             },
         )
         ts = Toolset(tools=[at])
-        ts.apply_ui_metadata()
+        ts.bound_artifacts(ui=True)
         coro_after_first = tool.coroutine
-        ts.apply_ui_metadata()
+        ts.bound_artifacts(ui=True)
         assert tool.coroutine is not coro_after_first
 
 

--- a/backend/tests/mcp/client/test_tools.py
+++ b/backend/tests/mcp/client/test_tools.py
@@ -1,0 +1,80 @@
+"""`bound_tool_artifact` — the per-tool artifact policy at the MCP seam."""
+
+import pytest
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import Tool
+
+from app.mcp.client.tools import bound_tool_artifact
+
+
+APP = {"mcp_app_resource_uri": "ui://app/main", "mcp_server_id": "s1"}
+DRIVE_ARTIFACT = {
+    "structured_content": {"content": "iVBOR" * 100_000, "mimeType": "image/png"}
+}
+
+
+def _tool(result) -> Tool:
+    async def coroutine(**kwargs):
+        return result
+
+    return Tool(name="t", description="", func=lambda **kw: None, coroutine=coroutine)
+
+
+@pytest.mark.asyncio
+async def test_a_plain_tool_loses_its_structured_content():
+    tool = _tool(("the text the model sees", DRIVE_ARTIFACT))
+    bound_tool_artifact(tool, None)
+    content, artifact = await tool.coroutine()
+    assert content == "the text the model sees"
+    assert artifact is None
+
+
+@pytest.mark.asyncio
+async def test_a_plain_tool_keeps_other_artifact_keys():
+    tool = _tool(("ok", {"structuredContent": {"big": 1}, "meta": {"page": 2}}))
+    bound_tool_artifact(tool, None)
+    _, artifact = await tool.coroutine()
+    assert artifact == {"meta": {"page": 2}}
+
+
+@pytest.mark.asyncio
+async def test_an_app_tool_keeps_structured_content_and_is_stamped():
+    tool = _tool(("ok", {"structured_content": {"rows": [1, 2]}}))
+    bound_tool_artifact(tool, APP)
+    _, artifact = await tool.coroutine()
+    assert artifact == {"structured_content": {"rows": [1, 2]}, **APP}
+
+
+@pytest.mark.asyncio
+async def test_an_app_tool_without_an_artifact_still_gets_stamped():
+    tool = _tool(("ok", None))
+    bound_tool_artifact(tool, APP)
+    _, artifact = await tool.coroutine()
+    assert artifact == APP
+
+
+@pytest.mark.asyncio
+async def test_a_tool_message_result_is_rewritten_in_place():
+    msg = ToolMessage(content="ok", tool_call_id="c1", artifact=dict(DRIVE_ARTIFACT))
+    tool = _tool(msg)
+    bound_tool_artifact(tool, None)
+    result = await tool.coroutine()
+    assert result is msg and result.artifact is None
+
+
+@pytest.mark.asyncio
+async def test_non_dict_artifacts_and_other_results_pass_through():
+    tool = _tool(("ok", ["a", "list"]))
+    bound_tool_artifact(tool, None)
+    assert await tool.coroutine() == ("ok", ["a", "list"])
+    plain = _tool("just a string")
+    bound_tool_artifact(plain, None)
+    assert await plain.coroutine() == "just a string"
+
+
+@pytest.mark.asyncio
+async def test_incomplete_ui_metadata_means_not_an_app_tool():
+    tool = _tool(("ok", DRIVE_ARTIFACT))
+    bound_tool_artifact(tool, {"mcp_app_resource_uri": "ui://x"})  # no server id
+    _, artifact = await tool.coroutine()
+    assert artifact is None

--- a/backend/tests/threads/test_threads_router.py
+++ b/backend/tests/threads/test_threads_router.py
@@ -4,12 +4,8 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
-from langchain_core.messages import AIMessage, HumanMessage
 
-from app.agents.checkpoints import EMPTY_STATE
-from app.agents.structured_output import STRUCTURED_OUTPUT_FLAG
 from app.threads.models import ThreadDB, ThreadSource
-from tests.agents.fake_checkpoints import checkpoint_state
 
 
 @pytest.fixture(autouse=True)
@@ -143,12 +139,10 @@ def test_get_threads_rejects_invalid_page_params(client: TestClient):
     assert client.get("/threads/", params={"offset": -1}).status_code == 422
 
 
-@patch("app.threads.router.get_checkpoint_state", new_callable=AsyncMock)
-@patch("app.threads.router.get_checkpointer")
-def test_get_thread(
-    mock_checkpointer, mock_state, client: TestClient, mock_db, current_user
-):
-    """Owner can read their own thread."""
+def test_get_thread(client: TestClient, mock_db, current_user):
+    """Owner can read their own thread: metadata and viewer role only — the
+    conversation is served by the protocol snapshot, not duplicated here, and
+    the checkpoint is never opened."""
     thread_id = str(uuid4())
     agent_id = uuid4()
     thread = ThreadDB(
@@ -165,66 +159,12 @@ def test_get_thread(
     mock_result.one_or_none.return_value = (thread, "Test Agent", "🤖", None, False)
     mock_db.execute.return_value = mock_result
 
-    mock_checkpointer.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
-    mock_checkpointer.return_value.__aexit__ = AsyncMock(return_value=None)
-    mock_state.return_value = EMPTY_STATE
-
     response = client.get(f"/threads/{thread_id}")
     assert response.status_code == 200
     data = response.json()
-    assert "thread" in data
     assert data["thread"]["id"] == thread_id
-    # The AI SDK `messages` projection is gone; the protocol-shaped values
-    # snapshot is the one message payload left.
-    assert "messages" not in data
-    assert data["values"] == {"messages": []}
     assert data["viewer_role"] is None
-
-
-@patch("app.threads.router.get_checkpoint_state", new_callable=AsyncMock)
-@patch("app.threads.router.get_checkpointer")
-def test_get_thread_hides_structured_output_artifacts(
-    mock_checkpointer, mock_state, client: TestClient, mock_db, current_user
-):
-    """Formatting-turn messages are filtered out of both message payloads and
-    the parsed object is exposed under values.structured_response instead."""
-    thread_id = str(uuid4())
-    thread = ThreadDB(
-        id=thread_id,
-        user_id=current_user.id,
-        agent_id=uuid4(),
-        first_message_content="Test thread",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-    )
-
-    mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = thread
-    mock_result.one_or_none.return_value = (thread, "Test Agent", "🤖", None, False)
-    mock_db.execute.return_value = mock_result
-
-    mock_checkpointer.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
-    mock_checkpointer.return_value.__aexit__ = AsyncMock(return_value=None)
-    mock_state.return_value = checkpoint_state(
-        [
-            HumanMessage("What is 2 + 2?"),
-            AIMessage("2 + 2 = 4"),
-            AIMessage(
-                '{"answer": 4}',
-                response_metadata={STRUCTURED_OUTPUT_FLAG: True},
-            ),
-        ],
-        values={"structured_response": {"answer": 4}},
-    )
-
-    response = client.get(f"/threads/{thread_id}")
-    assert response.status_code == 200
-    data = response.json()
-
-    raw_messages = data["values"]["messages"]
-    assert len(raw_messages) == 2
-    assert all('{"answer": 4}' not in str(m.get("content")) for m in raw_messages)
-    assert data["values"]["structured_response"] == {"answer": 4}
+    assert set(data) == {"thread", "viewer_role"}
 
 
 @pytest.mark.usefixtures("current_user")

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/message-helpers.ts
@@ -135,6 +135,11 @@ export type ToolCallView = {
   error: string | undefined;
   /** MCP artifact (structured content, app resource URI), when returned. */
   artifact: Record<string, unknown> | undefined;
+  /** Id of the ToolMessage holding the result — the key for fetching it whole. */
+  resultMessageId?: string;
+  /** Set when the snapshot carries only a preview of the result: the full
+   *  length in characters (backend `serialize_message_preview`). */
+  truncatedChars?: number;
 };
 
 /**
@@ -188,6 +193,9 @@ function toView(
       ? (handle.output as { content?: unknown; artifact?: unknown })
       : undefined;
   const content = result?.content ?? wrapped?.content ?? handle?.output;
+  const truncated = (
+    result?.additional_kwargs as { truncated?: { chars?: unknown } } | undefined
+  )?.truncated;
   return {
     id,
     callId: call.id || undefined,
@@ -210,6 +218,9 @@ function toView(
     artifact: (result?.artifact ?? wrapped?.artifact) as
       | Record<string, unknown>
       | undefined,
+    resultMessageId: result?.id,
+    truncatedChars:
+      typeof truncated?.chars === "number" ? truncated.chars : undefined,
   };
 }
 

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.test.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.test.tsx
@@ -1,0 +1,141 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ToolCallView } from "./message-helpers";
+import { ToolStep } from "./tool-step";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "agent-1", threadId: "thread-1" }),
+}));
+
+const fetchThreadMessage = vi.fn();
+vi.mock("@/lib/api/thread-messages", () => ({
+  fetchThreadMessage: (...args: unknown[]) => fetchThreadMessage(...args),
+}));
+
+const describeTool = () => ({
+  serverName: "Code execution",
+  toolName: "grep",
+  icon: undefined,
+});
+
+function view(overrides: Partial<ToolCallView>): ToolCallView {
+  return {
+    id: "call_1",
+    callId: "call_1",
+    name: "grep",
+    args: { pattern: "statRow" },
+    messageId: "ai_1",
+    status: "finished",
+    output: "line 1\nline 2",
+    error: undefined,
+    artifact: undefined,
+    ...overrides,
+  };
+}
+
+/** Steps are collapsed by default; their content mounts on expand. */
+function expand() {
+  fireEvent.click(screen.getByText("Grep"));
+}
+
+beforeEach(() => {
+  fetchThreadMessage.mockReset();
+});
+
+describe("ToolStep result loading", () => {
+  it("renders a whole result with no load affordance and no fetch", () => {
+    render(<ToolStep tc={view({})} state="done" describe={describeTool} />);
+    expand();
+    expect(screen.getByText(/line 1/)).toBeInTheDocument();
+    expect(screen.queryByText("Load full output")).toBeNull();
+    expect(fetchThreadMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch a truncated result until the step is expanded", () => {
+    fetchThreadMessage.mockResolvedValue({
+      id: "tool_1",
+      type: "tool",
+      content: "whole",
+    });
+    render(
+      <ToolStep
+        tc={view({
+          output: "part",
+          resultMessageId: "tool_1",
+          truncatedChars: 34_000,
+        })}
+        state="done"
+        describe={describeTool}
+      />,
+    );
+    expect(fetchThreadMessage).not.toHaveBeenCalled();
+  });
+
+  it("fetches the whole result on expand and swaps it in", async () => {
+    fetchThreadMessage.mockResolvedValue({
+      id: "tool_1",
+      type: "tool",
+      content: "the whole output, every line of it",
+    });
+    render(
+      <ToolStep
+        tc={view({
+          output: "the whole out",
+          resultMessageId: "tool_1",
+          truncatedChars: 34_000,
+        })}
+        state="done"
+        describe={describeTool}
+      />,
+    );
+    expand();
+    expect(
+      screen.getByText(/Loading the full output \(34 K chars\)/),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText("the whole output, every line of it"),
+      ).toBeInTheDocument();
+    });
+    expect(fetchThreadMessage).toHaveBeenCalledWith("thread-1", "tool_1");
+    expect(screen.queryByText(/Showing the first/)).toBeNull();
+  });
+
+  it("keeps the preview, shows the error and offers a retry when the load fails", async () => {
+    fetchThreadMessage
+      .mockRejectedValueOnce(new Error("Could not load the tool output (502)."))
+      .mockResolvedValueOnce({
+        id: "tool_2",
+        type: "tool",
+        content: "recovered",
+      });
+    render(
+      <ToolStep
+        tc={view({
+          output: "partial",
+          resultMessageId: "tool_2",
+          truncatedChars: 20_000,
+        })}
+        state="done"
+        describe={describeTool}
+      />,
+    );
+    expand();
+    await waitFor(() => {
+      expect(
+        screen.getByText("Could not load the tool output (502)."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("partial")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Showing the first 7 chars of 20 K chars/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Retry"));
+    await waitFor(() => {
+      expect(screen.getByText("recovered")).toBeInTheDocument();
+    });
+    expect(fetchThreadMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.test.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.test.tsx
@@ -72,6 +72,22 @@ describe("ToolStep result loading", () => {
     expect(fetchThreadMessage).not.toHaveBeenCalled();
   });
 
+  it("shows the truncation note without fetching when the message has no id", () => {
+    render(
+      <ToolStep
+        tc={view({ output: "part", truncatedChars: 34_000 })}
+        state="done"
+        describe={describeTool}
+      />,
+    );
+    expand();
+    expect(
+      screen.getByText(/Showing the first 4 chars of 34 K chars/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Retry")).toBeNull();
+    expect(fetchThreadMessage).not.toHaveBeenCalled();
+  });
+
   it("fetches the whole result on expand and swaps it in", async () => {
     fetchThreadMessage.mockResolvedValue({
       id: "tool_1",

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.tsx
@@ -123,7 +123,7 @@ export const ToolStep = memo(function ToolStep({
           ) : (
             tc.output !== undefined && (
               <StepSection label="RESULT">
-                <ToolResult tc={tc} />
+                <ToolResult key={tc.resultMessageId ?? tc.id} tc={tc} />
               </StepSection>
             )
           )}
@@ -159,8 +159,10 @@ export const ToolStep = memo(function ToolStep({
  * nobody looked at.
  */
 const ToolResult = ({ tc }: { tc: ToolCallView }) => {
+  // Keyed by the result message in `ToolStep`, so a different result mounts a
+  // fresh instance: no load state leaks from one message to the next.
   const params = useParams<{ threadId?: string }>();
-  const threadId = params?.threadId;
+  const threadId = params.threadId;
   const [full, setFull] = useState<{ forMessage: string; output: unknown } | null>(
     null,
   );
@@ -169,16 +171,18 @@ const ToolResult = ({ tc }: { tc: ToolCallView }) => {
 
   const loaded =
     full != null && full.forMessage === tc.resultMessageId ? full.output : undefined;
-  const truncated =
-    loaded === undefined && tc.truncatedChars != null && tc.resultMessageId != null;
-  // Loading is implied: a truncated result with no error yet is being fetched.
-  const loading = truncated && loadError == null;
+  const truncated = loaded === undefined && tc.truncatedChars != null;
+  // A result without a persisted message id (or outside a thread route) can
+  // only show its preview; the note still says so.
+  const canLoad = truncated && tc.resultMessageId != null && threadId != null;
+  // Loading is implied: a loadable result with no error yet is being fetched.
+  const loading = canLoad && loadError == null;
 
   useEffect(() => {
-    if (!truncated || !threadId || !tc.resultMessageId || loadError != null) return;
-    const messageId = tc.resultMessageId;
+    if (!canLoad || loadError != null) return;
+    const messageId = tc.resultMessageId as string;
     let cancelled = false;
-    fetchThreadMessage(threadId, messageId)
+    fetchThreadMessage(threadId as string, messageId)
       .then((message) => {
         if (cancelled) return;
         const content = message.content;
@@ -196,7 +200,7 @@ const ToolResult = ({ tc }: { tc: ToolCallView }) => {
     return () => {
       cancelled = true;
     };
-  }, [truncated, threadId, tc.resultMessageId, loadError, attempt]);
+  }, [canLoad, threadId, tc.resultMessageId, loadError, attempt]);
 
   return (
     <>
@@ -217,16 +221,18 @@ const ToolResult = ({ tc }: { tc: ToolCallView }) => {
                 {formatChars(tc.truncatedChars ?? 0)}.
               </span>
               {loadError && <span className="text-destructive">{loadError}</span>}
-              <button
-                type="button"
-                onClick={() => {
-                  setLoadError(null);
-                  setAttempt((n) => n + 1);
-                }}
-                className="cursor-pointer font-semibold text-petrol underline-offset-2 hover:underline"
-              >
-                Retry
-              </button>
+              {canLoad && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLoadError(null);
+                    setAttempt((n) => n + 1);
+                  }}
+                  className="cursor-pointer font-semibold text-petrol underline-offset-2 hover:underline"
+                >
+                  Retry
+                </button>
+              )}
             </>
           )}
         </div>

--- a/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.tsx
+++ b/web/src/app/(protected)/agents/[id]/chat/[threadId]/tool-step.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { memo, useMemo } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
 import { BanIcon, Loader2, XCircleIcon } from "lucide-react";
+import { parseToolPayload } from "@langchain/langgraph-sdk/stream";
 import {
   ChainStep,
   ChainStepIcon,
@@ -14,6 +16,7 @@ import {
   summarizeToolArgs,
 } from "@/components/ai-elements/chain-of-thought";
 import { cn } from "@/lib/utils";
+import { fetchThreadMessage } from "@/lib/api/thread-messages";
 import type { HitlDecision } from "@/hooks/use-hitl-approvals";
 import {
   type ToolCallView,
@@ -120,7 +123,7 @@ export const ToolStep = memo(function ToolStep({
           ) : (
             tc.output !== undefined && (
               <StepSection label="RESULT">
-                <StepCode value={tc.output} />
+                <ToolResult tc={tc} />
               </StepSection>
             )
           )}
@@ -147,6 +150,97 @@ export const ToolStep = memo(function ToolStep({
     </ChainStep>
   );
 });
+
+/**
+ * A step's result. The thread snapshot carries at most a preview of a large
+ * result (`tc.truncatedChars`); the rest is fetched when the step is expanded
+ * — `ChainStep` mounts its content only while open, so mounting *is* the
+ * expand — and a page load never parses or lays out megabytes of tool output
+ * nobody looked at.
+ */
+const ToolResult = ({ tc }: { tc: ToolCallView }) => {
+  const params = useParams<{ threadId?: string }>();
+  const threadId = params?.threadId;
+  const [full, setFull] = useState<{ forMessage: string; output: unknown } | null>(
+    null,
+  );
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  const loaded =
+    full != null && full.forMessage === tc.resultMessageId ? full.output : undefined;
+  const truncated =
+    loaded === undefined && tc.truncatedChars != null && tc.resultMessageId != null;
+  // Loading is implied: a truncated result with no error yet is being fetched.
+  const loading = truncated && loadError == null;
+
+  useEffect(() => {
+    if (!truncated || !threadId || !tc.resultMessageId || loadError != null) return;
+    const messageId = tc.resultMessageId;
+    let cancelled = false;
+    fetchThreadMessage(threadId, messageId)
+      .then((message) => {
+        if (cancelled) return;
+        const content = message.content;
+        setFull({
+          forMessage: messageId,
+          output: typeof content === "string" ? parseToolPayload(content) : content,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setLoadError(
+          err instanceof Error ? err.message : "Could not load the tool output.",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [truncated, threadId, tc.resultMessageId, loadError, attempt]);
+
+  return (
+    <>
+      <StepCode value={loaded ?? tc.output} />
+      {truncated && (
+        <div className="flex items-center gap-2 pt-1 text-[11.5px] text-meta dark:text-panel-dim">
+          {loading ? (
+            <>
+              <Loader2 className="size-3 animate-spin" />
+              <span>
+                Loading the full output ({formatChars(tc.truncatedChars ?? 0)})…
+              </span>
+            </>
+          ) : (
+            <>
+              <span>
+                Showing the first {formatChars(String(tc.output ?? "").length)} of{" "}
+                {formatChars(tc.truncatedChars ?? 0)}.
+              </span>
+              {loadError && <span className="text-destructive">{loadError}</span>}
+              <button
+                type="button"
+                onClick={() => {
+                  setLoadError(null);
+                  setAttempt((n) => n + 1);
+                }}
+                className="cursor-pointer font-semibold text-petrol underline-offset-2 hover:underline"
+              >
+                Retry
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+const formatChars = (n: number): string =>
+  n >= 1_000_000
+    ? `${(n / 1_000_000).toFixed(1)} M chars`
+    : n >= 1_000
+      ? `${Math.round(n / 1_000)} K chars`
+      : `${n} chars`;
 
 const ApprovalButton = ({
   approval,

--- a/web/src/lib/api/thread-messages.ts
+++ b/web/src/lib/api/thread-messages.ts
@@ -17,8 +17,14 @@ export async function fetchThreadMessage(
   threadId: string,
   messageId: string,
 ): Promise<ThreadMessage> {
-  const url = `/api/backend/threads/${encodeURIComponent(threadId)}/messages/${encodeURIComponent(messageId)}`;
-  const response = await fetch(url, { credentials: "include" });
+  const path = `/api/backend/threads/${encodeURIComponent(threadId)}/messages/${encodeURIComponent(messageId)}`;
+  // Origin-pinned by construction: a fixed same-origin path whose two
+  // segments are URL-encoded ids, so it cannot reach another host. The taint
+  // scanner cannot see that sanitizer.
+  // nosemgrep
+  const response = await fetch(new URL(path, window.location.origin), {
+    credentials: "include",
+  });
   if (!response.ok) {
     throw new Error(`Could not load the tool output (${response.status}).`);
   }

--- a/web/src/lib/api/thread-messages.ts
+++ b/web/src/lib/api/thread-messages.ts
@@ -1,0 +1,26 @@
+/**
+ * One message of a thread, whole (`GET /threads/{id}/messages/{id}`).
+ *
+ * Thread snapshots (`/state`, `/history`) ship tool results cut at the
+ * backend's preview limit; this fetches the rest when a step asks for it.
+ * Raw `fetch`, not the axios client: the body is protocol-shaped (snake_case,
+ * arbitrary tool payloads) and must not be camelized.
+ */
+export type ThreadMessage = {
+  id: string | null;
+  type: string;
+  content: unknown;
+  artifact?: unknown;
+};
+
+export async function fetchThreadMessage(
+  threadId: string,
+  messageId: string,
+): Promise<ThreadMessage> {
+  const url = `/api/backend/threads/${encodeURIComponent(threadId)}/messages/${encodeURIComponent(messageId)}`;
+  const response = await fetch(url, { credentials: "include" });
+  if (!response.ok) {
+    throw new Error(`Could not load the tool output (${response.status}).`);
+  }
+  return (await response.json()) as ThreadMessage;
+}


### PR DESCRIPTION
## Why

Opening a heavy thread took 40–49 s: the page downloaded the whole conversation **twice** (`GET /state` and the legacy `GET /threads/{id}`), 21 MB each through the web tier. Decoding the production checkpoints showed **96% of that state is `artifact.structured_content`** — four Google Drive `download_file_content` results holding 1.9–8 MB of base64 each. The model never sees the artifact (deepagents' eviction had already moved the *content* to the sandbox), but the checkpointer serialised it on every superstep, Langfuse received it in every tool span (the `413 Request Entity Too Large` export failures), and both snapshot endpoints shipped it to the browser.

## What

**Backend**
- `app/mcp/client/tools.py` — `bound_tool_artifact`, applied to **every** toolset (parent and subagents): MCP-app tools (a `resourceUri` on the tool) keep their structured content and get the UI stamp; every other tool loses `structured_content`. No client code reads it and the model never had it.
- `serialize_message_preview` — `GET /state` and `POST /history` ship tool results cut at 16 000 chars (`additional_kwargs.truncated = {chars}`) and omit non-app artifacts.
- `GET /threads/{id}/messages/{message_id}` — one message whole, streamed off `checkpoint_writes` newest-first (each row is one task's write) so the thread is never materialised; falls back to the root state, 404 otherwise.
- `GET /threads/{id}` — metadata only (`thread`, `viewer_role`); it no longer opens the checkpoint.
- The protocol reads (`/state`, `/history`, `/messages/{id}`, `/stream/events`) now accept the thread's owner **and** an admin of its agent (`authorize_thread_read`, shared `resolve_viewer_role` in `app/threads/dependencies.py`) — the audience the thread read already served, so an admin's read-only view hydrates. `/commands` stays owner-only.

**Web**
- `ToolStep` shows the preview and fetches the whole result **when the step is expanded** (`ChainStep` mounts content only while open). Spinner while loading, Retry on failure. Live runs unchanged: results still stream whole.

## Measured

On production checkpoints (`compare` script, best of 3; state = latest `messages` blob; `/state` = JSON the browser receives):

| Thread | msgs | State today | After artifact cap | `/state` today | `/state` after |
| --- | --- | --- | --- | --- | --- |
| bilan `f223b508` | 150 | 21.5 MB | **0.81 MB** | 21.6 MB | **0.67 MB** |
| slides `fdc83c24` | 198 | 16.2 MB | **0.72 MB** | 16.2 MB | **0.53 MB** |
| notion `d42fb3bb` | 80 | 21.4 MB | **0.34 MB** | 21.4 MB | **0.31 MB** |
| `a844196a` | 90 | 1.7 MB | 1.3 MB | 1.8 MB | **0.82 MB** |
| `b525411b` | 71 | 2.4 MB | 2.4 MB | 2.4 MB | **0.47 MB** |

The last two are genuine tool text / base64 images in `content`, governed by the eviction threshold, not the artifact. Local: build+encode+gzip of the 2.36 MB thread 75 → 48 ms; on-demand fetch of its largest result 36 ms, 3 MB peak. Per-step checkpoint serialisation on the bilan thread drops from 21.5 MB to 0.8 MB.

## Breaking

- `GET /threads/{id}` no longer returns `values`, `interrupted`, `interrupt_value`, `interrupt_id`. The web app only read `thread` and `viewer_role`; interrupt state and messages come from `GET /threads/{id}/state` (`next` / `tasks` / `values`).
- Non-app MCP tools no longer carry `structured_content` in their ToolMessage artifact (nothing consumed it).

## Tests

- backend: 1075 passed (`test_messages.py`, `test_tools.py`, `protocol/test_router.py` new; `test_service.py`, `test_toolset.py`, `test_threads_router.py` updated)
- web: 62 passed (`tool-step.test.tsx` new), `tsc`, strict pre-commit eslint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
